### PR TITLE
Harden the untrusted-input paths

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -7,7 +7,8 @@ pkgdesc='Fast, keyboard-first file manager for Omarchy'
 arch=('x86_64')
 license=('MIT')
 # omarchy owns /usr/share/omarchy/shell, which ui/Commons and ui/Ui link into; quickshell owns qs.
-depends=('bubblewrap' 'glib2' 'omarchy' 'quickshell' 'shared-mime-info' 'xdg-utils')
+# util-linux ships prlimit, which the thumbnail and archive sandboxes require alongside bubblewrap.
+depends=('bubblewrap' 'glib2' 'omarchy' 'quickshell' 'shared-mime-info' 'util-linux' 'xdg-utils')
 makedepends=('cargo')
 optdepends=('libarchive: archive listing and extraction'
             '7zip: 7z archive support'

--- a/src/backend/archive.rs
+++ b/src/backend/archive.rs
@@ -73,6 +73,10 @@ impl Formats {
         a.push(dest.to_string_lossy().to_string());
         a.push("-C".to_string());
         a.push(parent.to_string_lossy().to_string());
+        // Members are relative names from the selection; one that begins with a dash would be read
+        // as a bsdtar option (`--use-compress-program` runs an arbitrary program), so option parsing
+        // is terminated first, the same way trash.rs does before its own paths.
+        a.push("--".to_string());
         a.extend(names.iter().cloned());
         Some(a)
     }
@@ -170,6 +174,24 @@ mod tests {
         let dash_c = a.iter().position(|s| s == "-C").expect("a working directory");
         let first_name = a.iter().position(|s| s == "a.txt").expect("the first name");
         assert!(dash_c < first_name, "-C must precede the names it applies to");
+    }
+
+    #[test]
+    fn a_member_name_that_looks_like_an_option_sits_after_the_terminator() {
+        let f = Formats::from_tools(true, true);
+        let a = f
+            .compress_argv("tar", Path::new("/x/out.tar"), Path::new("/src"),
+                           &["--use-compress-program=sh".to_string(), "ok.txt".to_string()])
+            .unwrap();
+        let term = a.iter().position(|s| s == "--").expect("a -- terminator before the names");
+        let bad = a.iter().position(|s| s == "--use-compress-program=sh").unwrap();
+        assert!(term < bad, "a dash-leading member must sit after the -- terminator");
+        // 7z stores absolute paths, so its members can never be read as options and it needs no --.
+        let seven = f
+            .compress_argv("7z", Path::new("/x/out.7z"), Path::new("/src"), &["--evil".to_string()])
+            .unwrap();
+        assert!(!seven.iter().any(|s| s == "--"));
+        assert_eq!(seven.last().unwrap(), "/src/--evil");
     }
 
     #[test]

--- a/src/backend/archiveops.rs
+++ b/src/backend/archiveops.rs
@@ -89,6 +89,10 @@ pub fn convert_one(input: &Path, dest: &Path, strip: bool) -> Result<(), FleaErr
     if dest.symlink_metadata().is_ok() {
         return Err(op_err("convert", &dest.to_string_lossy(), "that destination already exists"));
     }
+    // Absolute, so ImageMagick can never read the input as an option (a file named "-write ...").
+    // The staged destination is already absolute under the work directory beside dest.
+    let input = std::fs::canonicalize(input).map_err(|e| from_io("convert", &input.to_string_lossy(), &e))?;
+    let input = input.as_path();
     let parent = dest.parent().unwrap_or(Path::new("/"));
     let work = Work::new(parent, "cvt")?;
     let name = dest.file_name().map(|n| n.to_string_lossy().to_string()).unwrap_or_default();

--- a/src/backend/archivework.rs
+++ b/src/backend/archivework.rs
@@ -58,7 +58,12 @@ impl Drop for Work {
 // The tools print their own diagnosis on stderr and do not always exit non-zero, so success is read
 // off the filesystem: the file the job was told to produce either exists afterwards or it does not.
 pub fn run_boxed(inner: Vec<String>, read_only: &Path, writable: &Path) -> Result<(), FleaError> {
-    let full = if sandbox::available() { sandbox::wrap(&inner, read_only, writable) } else { inner };
+    // Fail closed: the jail is the only containment for these tools, so a missing bwrap or prlimit
+    // refuses the job rather than running it unsandboxed, the same rule thumbs.rs already follows.
+    if !sandbox::available() {
+        return Err(op_err("archive", "", "the sandbox is unavailable: bwrap or prlimit is not on PATH"));
+    }
+    let full = sandbox::wrap(&inner, read_only, writable);
     let out = Command::new(&full[0])
         .args(&full[1..])
         .stdin(std::process::Stdio::null())
@@ -84,7 +89,10 @@ pub fn is_empty_dir(dir: &Path) -> bool {
 // first as the second is what restored the defect this check exists for.
 pub fn archive_produced_count(formats: &Formats, archive: &Path) -> Option<usize> {
     let (inner, spec) = formats.list_argv(archive)?;
-    let full = if sandbox::available() { sandbox::wrap_readonly(&inner, archive) } else { inner };
+    if !sandbox::available() {
+        return None;
+    }
+    let full = sandbox::wrap_readonly(&inner, archive);
     // Streamed, not .output(): buffering the whole index here would contradict the streaming
     // contract the parser exists for, and a 200k-entry archive is exactly the case that motivated it.
     let mut child = Command::new(&full[0])

--- a/src/backend/copyfile.rs
+++ b/src/backend/copyfile.rs
@@ -1,6 +1,7 @@
 // The copy primitives every transfer is built from: streaming, symlink-preserving, and refusing to overwrite.
 use crate::error::{from_io, FleaError};
 use std::io::{Read, Write};
+use std::os::unix::fs::OpenOptionsExt;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 
@@ -8,6 +9,8 @@ use std::sync::atomic::{AtomicBool, Ordering};
 const CHUNK: usize = 256 * 1024;
 // rename(2) sets EXDEV when the two paths are on different filesystems, which is the one failure that means "copy instead".
 const EXDEV: i32 = 18;
+// open(2) O_NOFOLLOW on linux x86-64; declared here because this tree takes no libc crate.
+const O_NOFOLLOW: i32 = 0o400000;
 
 // What a copy reports as it runs; a directory has no total without a sweep, so it reports 0 and renders indeterminate.
 pub struct Progress<'a> {
@@ -25,7 +28,13 @@ pub fn cancelled(p: &Progress) -> bool {
 
 // Copies one regular file, creating the destination exclusively so an existing file is never destroyed.
 pub fn copy_file(src: &Path, dst: &Path, total: u64, p: &mut Progress) -> Result<(), FleaError> {
-    let mut r = std::fs::File::open(src).map_err(|e| from_io("copy", &src.to_string_lossy(), &e))?;
+    // O_NOFOLLOW closes a same-uid race: copy_any already sent symlinks to copy_symlink, so a src
+    // that is a symlink here was swapped in after that stat, and it must not be followed.
+    let mut r = std::fs::OpenOptions::new()
+        .read(true)
+        .custom_flags(O_NOFOLLOW)
+        .open(src)
+        .map_err(|e| from_io("copy", &src.to_string_lossy(), &e))?;
     let mut w = std::fs::OpenOptions::new()
         .write(true)
         .create_new(true)

--- a/src/backend/mediaprobe.rs
+++ b/src/backend/mediaprobe.rs
@@ -45,7 +45,10 @@ fn argv(path: &Path) -> Vec<String> {
 pub fn probe(path: &Path) -> Media {
     let inner = argv(path);
     // The same jail the thumbnail pipeline uses; with no bwrap on PATH the probe is simply skipped.
-    let full = if sandbox::available() { sandbox::wrap_readonly(&inner, path) } else { inner };
+    if !sandbox::available() {
+        return Media::default();
+    }
+    let full = sandbox::wrap_readonly(&inner, path);
     let mut cmd = Command::new(&full[0]);
     cmd.args(&full[1..]);
     cmd.stdin(std::process::Stdio::null());

--- a/src/backend/metareq.rs
+++ b/src/backend/metareq.rs
@@ -104,7 +104,10 @@ fn list_archive(path: &Path, formats: &Formats) -> Contents {
         Some(v) => v,
         None => return failed,
     };
-    let full = if sandbox::available() { sandbox::wrap_readonly(&inner, path) } else { inner };
+    if !sandbox::available() {
+        return failed;
+    }
+    let full = sandbox::wrap_readonly(&inner, path);
     let mut child = match std::process::Command::new(&full[0])
         .args(&full[1..])
         .stdin(std::process::Stdio::null())

--- a/src/backend/run.rs
+++ b/src/backend/run.rs
@@ -303,9 +303,18 @@ fn handle_line(
         Request::Peek { path, first, hidden } =>
             say(out, &peek_line(&path, first, hidden, &tb.mime, &tb.icons)),
         // A compress names absolute paths and no path; an extract names the one archive in path.
-        Request::Archive { op, paths, path, dest, format } => start_archive(
-            out, ops, Arc::clone(&tb.formats), op == "compress",
-            paths, format, PathBuf::from(&path), PathBuf::from(&dest)),
+        Request::Archive { op, paths, path, dest, format } => {
+            // A typo would otherwise fall through to extract; refuse an op that names neither.
+            if op != "compress" && op != "extract" {
+                let e = FleaError { where_: "archive".to_string(), path: op.clone(), msg: "op must be compress or extract".to_string() };
+                writeln!(out, "{}", error_line(&e)).ok();
+                out.flush().ok();
+            } else {
+                start_archive(
+                    out, ops, Arc::clone(&tb.formats), op == "compress",
+                    paths, format, PathBuf::from(&path), PathBuf::from(&dest));
+            }
+        }
         Request::Convert { path, dest, strip } =>
             start_convert(out, ops, PathBuf::from(&path), PathBuf::from(&dest), strip),
         Request::Formats => say(out, &formats_line(&tb.formats, convert::available())),

--- a/ui/ShareLink.qml
+++ b/ui/ShareLink.qml
@@ -31,7 +31,9 @@ Item {
                 root.failed()
                 return
             }
-            copyToClipboard.command = ["bash", "-c", "printf %s " + JSON.stringify(url) + " | wl-copy"]
+            // argv-direct, no shell: wl-copy takes the text as an argument, so a URL holding
+            // $(...) or backticks can never reach a shell to be expanded.
+            copyToClipboard.command = ["wl-copy", url]
             copyToClipboard.running = true
             root.copied(url)
         }


### PR DESCRIPTION
## Harden the untrusted-input paths

A security review of the archive, convert and preview paths turned up one
confirmed command-execution bug from a crafted filename, plus several places
where an untrusted decoder could run outside the sandbox. Each fix is small,
covered by the existing suite, and adds no dependency (`Cargo.lock` is
unchanged; the tree stays zero-crate).

### fix: terminate option parsing before untrusted operands
`compress_argv`'s tar branch handed the selected file names to `bsdtar`
straight after `-C <parent>` with no `--`. A file literally named
`--use-compress-program=<cmd>` in a compressed directory was parsed by bsdtar
as an option and ran `<cmd>`. `trash.rs` already inserts `--`; compress now
does too. `convert_one` canonicalizes its input to an absolute path so
ImageMagick cannot read it as an operator, and an archive `op` that is neither
`compress` nor `extract` is refused by name instead of falling through to
extract. Added a unit test proving the `--` sits before a dash-leading member.

### fix: require the sandbox for archive, convert and probe children
`run_boxed`, the archive index reader, the preview lister and the ffprobe
probe ran unsandboxed when `sandbox::available()` was false. Thumbnails already
fail closed there; these now do too. `util-linux` (ships `prlimit`) is added to
`depends` so the jail's second half is guaranteed present alongside
`bubblewrap`.

### fix: copy a share link without a shell
The Dropbox share URL was interpolated into `bash -c "... | wl-copy"`;
`$(...)` and backticks in the URL would be expanded. Now `["wl-copy", url]`.

### fix: open the copy source with O_NOFOLLOW
Closes a same-uid TOCTOU where a source swapped to a symlink after the lstat in
`copy_any` would be followed by `copy_file`.

### Testing
`cargo test --release --locked` → 336 passed, 0 failed. `tests/js.sh` → 1013
checks, 0 failed. `tests/keymap-gen.sh` → ok. Verified end to end against the
built backend: a bogus op is refused by name, and with the jail forced
unavailable the archive path refuses the job rather than running the tool
unsandboxed.

### Deliberately left as follow-ups
- The read loop's stdin lines are uncapped (same-uid client only) — needs a
  reader rework, filed separately.
- `sandbox.rs` ro-binds all of `/etc`; trimming it risks breaking decoders that
  read fonts/mime and the network is already unshared.
- `is_runnable` uses `metadata` (follows symlinks) so a `/usr/bin` symlinked
  thumbnailer still resolves; switching to `symlink_metadata` would reject
  legitimate ones. The Exec runs sandboxed with no network regardless.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved archive handling for filenames beginning with hyphens.
  * Prevented unsafe symlink following when copying files.
  * Prevented shell interpretation when copying share links.
  * Validated archive operations and rejected unsupported requests.
  * Converter and media probing now receive safer, canonicalized paths.
* **Security**
  * Archive, media, and metadata operations now fail safely when sandboxing is unavailable instead of running without protection.
* **Reliability**
  * Improved handling of archive and thumbnail processing in restricted environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->