### PR TITLE
feat: the path bar, on colon, ctrl-l and a double click

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -445,6 +445,8 @@ huge pages" below for what it is worth and what it cost.
   `flea --open`, see "Opening a file".
 - `ui/ContextMenu.qml` is the one pane-owned right-click popup and its single Open action.
 - `ui/StatusBar.qml` renders the path, row counts and transient messages.
+- `ui/ChromeBar.qml` renders the top chrome, and owns the path bar: the same strip typed into
+  rather than drawn, opened by `:`, `Ctrl+L` or a double click on the path.
 - `keys.toml` is the one key table, and `tools/flea-keymap-gen` turns it into `Keymap.js`.
 - `ui/js/Keymap.js` is the generated key-to-action lookup and imports no QML.
 - `ui/js/Format.js` is the pure size, date and permission formatter.
@@ -453,6 +455,9 @@ huge pages" below for what it is worth and what it cost.
   its own.
 - `ui/js/Thumbs.js` is the pure row-to-path map and the visible-row request plan, and
   imports no QML so `./tests/js.sh` can redden on a mutation.
+- `ui/js/PathBar.js` is what a typed path line means: the tilde, the relative name, the
+  `file://` URI, the interior `.` and `..`, and what Tab makes of one directory's names. Pure,
+  so `tests/js/pathbar.js` drives all of it; the field itself is `ui/ChromeBar.qml`'s.
 
 ## Where the backend binary comes from
 
@@ -2727,9 +2732,14 @@ filename as rich text, so it is never safe for backend-provided names.
 
 The rule, applied on 2026-09-02 after two silent-by-accident keys and one silent-by-design: every
 row in `keys.toml` either works or says why it does not, in a sentence written for the user and
-never an action name. `t`, `w` and `1` to `9` (tabs) and `:` (the path bar), all drawn on the Tui
-board, stay in the table and `Focus.act` answers them with `Tabs are not built yet.` and `The path
-bar is not built yet.`; the old `lookup` gate that dropped `:` in silence is gone. The generic
+never an action name. `t`, `w` and `1` to `9` (tabs), drawn on the Tui board, stay in the table and
+`Focus.act` answers them with `Tabs are not built yet.`; the old `lookup` gate that dropped `:` in
+silence is gone. `:` was on this list beside them and is not on it now: the action is `pathBar`
+rather than `palette` (the old name read as a command palette, and `ui/js/Palette.js` is the theme's
+colour file), `Focus.handleKey` opens the bar beside the keymap sheet as the second global action,
+and `ui/ChromeBar.qml` carries the field. It is answered by `keycase_pathBar` in
+`tools/flea-acceptance-drive`, which drives the key and reads `pathBarOpen` off the seam, where the
+row used to assert a sentence. The generic
 `<action> is not built yet.` fallback below those stays as the loud failure for a row the
 dispatcher does not answer, and should never be reachable from the shipped table. `Ctrl+Shift+N`
 was on this list for one afternoon and is not on it now: `295e757` routed the action through

--- a/README.md
+++ b/README.md
@@ -516,9 +516,19 @@ hides leaves the selection with it, because a selection you cannot see is one yo
 on by accident. It filters the rows the pane holds, and says so in the strip when that is
 less than the whole directory.
 
-Bound ahead of their features, and saying so until they land: `:` for the path bar, and `t`,
-`w` and `1` through `9` for tabs, all drawn on the TUI board. Each answers with a sentence in
-the status line rather than doing nothing.
+`:` and `Ctrl+L` open the path bar, and so does a double click on the path itself: the strip
+above the listing becomes the line you type into, opening on the current directory with the
+whole line selected, so a name typed straight away replaces it. A leading `/` is absolute, a
+leading `~` is home, anything else is relative to the directory you are already in, and a
+`file://` URI pasted from another application is read as the path it names. Tab completes
+against the directories one level down, growing the line as far as the names agree and adding
+the separator when only one is left, so Tab, Tab, Tab walks a tree. Enter goes, Escape leaves
+the pane where it was, and `.` typed as the first character of a name completes hidden
+directories whether or not the listing is showing them.
+
+Bound ahead of their features, and saying so until they land: `t`, `w` and `1` through `9` for
+tabs, drawn on the TUI board. Each answers with a sentence in the status line rather than
+doing nothing.
 
 ## Testing
 

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -855,6 +855,14 @@ failed carries `"failed":true`, with `"mode":<uint>` beside it under the same ru
 uses, so a column can tell an unreadable directory from an empty one instead of drawing both as the
 empty state. A `peeked` line that succeeded carries neither field, whatever `n` is.
 
+Two more `peek` fields are worth naming for the same reason. Every `peeked` line, failed or not,
+echoes the `hidden` its request carried, because two clients read this wire at once: `ui/ColumnsArea.qml`
+peeks the pane's ancestors with the listing's own flag, and the path bar's Tab peeks with whatever
+the typed leaf asks for. `path` alone cannot tell one client's reply from the other's, and `path`
+plus `hidden` can, which is all the correlation either needs: the same pair answers the same rows,
+so no request id has to be threaded through. A client that ignores the field reads the line exactly
+as it did before.
+
 ## Known gaps
 
 - `listed` and the two-line prewarm file carry no requested path. A stale prewarm file

--- a/keys.toml
+++ b/keys.toml
@@ -49,6 +49,12 @@ action = "eject"
 key = "K"
 action = "addNetwork"
 
+# Not a Finder chord: Cmd+Shift+G is Go to Folder there, and Ctrl+Shift+G is nothing on this box.
+# Ctrl+L is what Nautilus, Thunar, Dolphin and every browser bind, so the path bar answers to it too.
+[[ctrl]]
+key = "L"
+action = "pathBar"
+
 [[ctrl]]
 key = "Delete"
 action = "trash"
@@ -208,9 +214,11 @@ action = "search"
 char = "o"
 action = "reveal"
 
+# The path bar's own key, the vim line-command colon it is drawn as on the Tui board. Ctrl+L above
+# is the same action under the chord every browser and every GTK file manager already carries.
 [[text]]
 char = ":"
-action = "palette"
+action = "pathBar"
 
 [[text]]
 char = "t"
@@ -346,6 +354,11 @@ label = "find in subtree"
 keys = "o"
 action = "reveal"
 label = "reveal result"
+
+[[sheet]]
+keys = ": ^l"
+action = "pathBar"
+label = "go to path"
 
 [[sheet]]
 keys = "y ^c"

--- a/src/backend/peek.rs
+++ b/src/backend/peek.rs
@@ -18,13 +18,20 @@ pub fn peek_line(path: &str, first: usize, hidden: bool, mime: &Db, icons: &Name
         Ok(v) => v,
         // An unreadable ancestor is still not an error for the pane it belongs to, but it is not an
         // empty directory either, and the column drew those two the same way until this line.
-        Err(_) => return failed_peek(path),
+        Err(_) => return failed_peek(path, hidden),
     };
     sort_by_name(&mut listing, false);
     let total = listing.len();
     let count = first.min(PEEK_CAP).min(total);
     let mut out = String::with_capacity(count * 64);
-    out.push_str(&format!(r#"{{"t":"peeked","path":"{}","n":{},"rows":["#, escape(path), total));
+    // hidden is echoed because two clients peek this wire at once: the columns view reads the pane's
+    // ancestors with the listing's own flag while the path bar's Tab reads whatever the typed leaf
+    // asks for. path alone cannot tell those two replies apart, and path plus hidden can, which is
+    // the whole of the correlation either of them needs: same pair, same rows.
+    out.push_str(&format!(
+        r#"{{"t":"peeked","path":"{}","hidden":{},"n":{},"rows":["#,
+        escape(path), hidden, total
+    ));
     for i in 0..count {
         if i > 0 {
             out.push(',');
@@ -46,12 +53,12 @@ pub fn peek_line(path: &str, first: usize, hidden: bool, mime: &Db, icons: &Name
 // A scan that failed answers zero rows, which is the exact count an empty directory answers, so the
 // line says which of the two it is. mode carries the directory's own permissions when the stat
 // outlived the refused read, and is left out when it did not, the same rule the error line follows.
-fn failed_peek(path: &str) -> String {
+fn failed_peek(path: &str, hidden: bool) -> String {
     let mode = mode_of(path);
     let mode_field = if mode == 0 { String::new() } else { format!(r#","mode":{}"#, mode) };
     format!(
-        r#"{{"t":"peeked","path":"{}","n":0,"failed":true{},"rows":[]}}"#,
-        escape(path), mode_field
+        r#"{{"t":"peeked","path":"{}","hidden":{},"n":0,"failed":true{},"rows":[]}}"#,
+        escape(path), hidden, mode_field
     )
 }
 
@@ -74,6 +81,9 @@ mod tests {
         let (mime, icons) = tables();
         let line = peek_line(&d.path().to_string_lossy(), 10, false, &mime, &icons);
         assert!(line.starts_with(r#"{"t":"peeked""#));
+        // The flag the request carried, echoed so a client with two askers on this wire can tell
+        // its own reply from the other's; see the comment over the line above.
+        assert!(line.contains(r#""hidden":false"#), "the reply says what it was asked for: {}", line);
         // The marker file the sandbox carries is a dotfile, so hidden false drops it.
         assert!(line.contains(r#""n":4"#) || line.contains(r#""n":3"#), "got {}", line);
         let sub = line.find(r#""n":"sub""#).expect("the directory row");
@@ -91,8 +101,10 @@ mod tests {
         let (mime, icons) = tables();
         let shown = peek_line(&d.path().to_string_lossy(), 10, false, &mime, &icons);
         assert!(!shown.contains(".secret"));
+        assert!(shown.contains(r#""hidden":false"#));
         let all = peek_line(&d.path().to_string_lossy(), 10, true, &mime, &icons);
         assert!(all.contains(".secret"));
+        assert!(all.contains(r#""hidden":true"#), "the two replies differ in the field that tells them apart");
     }
 
     #[test]
@@ -101,6 +113,8 @@ mod tests {
         let (mime, icons) = tables();
         let line = peek_line(&d.join("never-existed").to_string_lossy(), 10, false, &mime, &icons);
         assert!(line.starts_with(r#"{"t":"peeked""#), "still an answer and not an error: {}", line);
+        // A failed peek is answered to one asker as much as a good one is, so it carries the flag too.
+        assert!(line.contains(r#""hidden":false"#), "a refusal is still a reply to a request: {}", line);
         assert!(line.contains(r#""n":0"#));
         assert!(line.contains(r#""failed":true"#), "a column that could not look says so: {}", line);
         assert!(!line.contains(r#""mode":"#), "nothing to stat, so no mode is claimed: {}", line);

--- a/tests/js/focus.js
+++ b/tests/js/focus.js
@@ -146,13 +146,9 @@ function run(check) {
     check("l turns the page forward and h turns it back", reader.page, 1)
 
     // Bound ahead of their features, by the rule that a mapped key says why rather than doing nothing:
-    // the Tui board draws a typeable path bar on colon and tabs on t, w and the digits. lookup lets
-    // them through and act answers each with a sentence written for the user, never an action name.
-    var colon = key(Qt.Key_Colon, ":", shift)
-    check("colon reaches act until the path bar exists", Focus.lookup(colon, pane(closed())), "palette")
+    // the Tui board draws tabs on t, w and the digits. lookup lets them through and act answers each
+    // with a sentence written for the user, never an action name. Colon no longer sits among them.
     var early = listPane(true)
-    Focus.act("palette", early)
-    check("colon says the path bar is not built", early.said, "The path bar is not built yet.")
     Focus.act("tabNew", early)
     check("t says tabs are not built, in words and not an action name", early.said, "Tabs are not built yet.")
     Focus.act("tab3", early)

--- a/tests/js/harness.qml
+++ b/tests/js/harness.qml
@@ -17,6 +17,7 @@ import "mounts.js" as MountsSuite
 import "nav.js" as NavSuite
 import "ops.js" as OpsSuite
 import "palette.js" as PaletteSuite
+import "pathbar.js" as PathBarSuite
 import "places.js" as PlacesSuite
 import "protocols.js" as ProtocolsSuite
 import "search.js" as SearchSuite
@@ -58,6 +59,7 @@ Item {
         NavSuite.run(check)
         OpsSuite.run(check)
         PaletteSuite.run(check)
+        PathBarSuite.run(check)
         PlacesSuite.run(check)
         ProtocolsSuite.run(check)
         SearchSuite.run(check)

--- a/tests/js/keymap.js
+++ b/tests/js/keymap.js
@@ -19,7 +19,7 @@ function run(check) {
     check("h goes up a directory", Keymap.lookup(Qt.Key_H, "h", none), "parent")
     check("space previews", Keymap.lookup(Qt.Key_Space, " ", none), "preview")
     check("slash filters", Keymap.lookup(Qt.Key_Slash, "/", none), "filter")
-    check("colon opens the palette", Keymap.lookup(Qt.Key_Colon, ":", shift), "palette")
+    check("colon opens the path bar", Keymap.lookup(Qt.Key_Colon, ":", shift), "pathBar")
     check("t opens a tab", Keymap.lookup(Qt.Key_T, "t", none), "tabNew")
     check("w closes a tab", Keymap.lookup(Qt.Key_W, "w", none), "tabClose")
     check("1 selects a tab", Keymap.lookup(Qt.Key_1, "1", none), "tab1")
@@ -93,14 +93,14 @@ function run(check) {
           Keymap.SHEET.map(sheetAction).join("|"),
           Keymap.SHEET.map(function (row) { return row.action }).join("|"))
     check("the sheet is not empty, so the check above has a denominator",
-          Keymap.SHEET.length, 21)
+          Keymap.SHEET.length, 22)
     // A chord shares the row of the key it doubles, so every caret token must resolve to that row's
     // own action, or the sheet advertises a chord bound to something else.
     check("every chord the sheet draws is bound to the action of its own row",
           Keymap.SHEET.map(chordActions).join("|"),
           Keymap.SHEET.map(function (row) { return chordTokens(row).map(function () { return row.action }).join("+") }).join("|"))
     check("and the sheet draws chords at all, so that check has a denominator",
-          Keymap.SHEET.filter(function (row) { return chordTokens(row).length > 0 }).length, 7)
+          Keymap.SHEET.filter(function (row) { return chordTokens(row).length > 0 }).length, 8)
     check("slash filters, and the sheet now draws the row for it",
           Keymap.SHEET.filter(function (r) { return r.keys === "/" }).length, 1)
     check("and the sheet draws m, so eject and unmount are not mouse-only affordances",

--- a/tests/js/pathbar.js
+++ b/tests/js/pathbar.js
@@ -77,6 +77,23 @@ function run(check) {
     check("an undecodable URI is kept as it stands",
           PathBar.resolve("file:///tmp/100%", HOME, HOME), "/tmp/100%")
 
+    // The authority is part of the URI and not part of the path. RFC 8089 spells the local one two
+    // ways, and the empty one above is the common one; stripping the scheme alone read the other as
+    // a relative walk into <current>/localhost/etc, which is a directory nobody named.
+    check("a localhost authority is this machine",
+          PathBar.resolve("file://localhost/etc", HOME, HOME), "/etc")
+    check("and its case does not matter, as a host name's never does",
+          PathBar.resolve("file://LOCALHOST/etc/apt", HOME, HOME), "/etc/apt")
+    check("a bare file://localhost is the root it names",
+          PathBar.resolve("file://localhost", HOME, HOME), "/")
+    // Another host is not a path this bar can open, and answering the parent's own directory for it
+    // would be worse than answering nothing: refused() is what turns that into a sentence.
+    check("a URI on another host resolves to nothing",
+          PathBar.resolve("file://otherbox/etc", HOME, HOME), "")
+    check("and says it was refused rather than empty", PathBar.refused("file://otherbox/etc"), true)
+    check("an empty line is not a refusal, so it stays silent", PathBar.refused("   "), false)
+    check("an ordinary path is not a refusal either", PathBar.refused("/etc"), false)
+
     // Where a completion reads, which is the head of the line and never the half-typed leaf.
     check("the completion directory is the head of the line",
           PathBar.completionDir("/etc/ap", HOME, HOME), "/etc")
@@ -91,6 +108,23 @@ function run(check) {
     check("a dotted leaf peeks hidden", PathBar.wantsHidden("~/.co", false), true)
     check("an ordinary leaf peeks as the listing is set", PathBar.wantsHidden("~/Do", false), false)
     check("and follows the listing when it shows hidden", PathBar.wantsHidden("~/Do", true), true)
+
+    // What a completion reply is matched on. ui/ColumnsArea.qml peeks the pane's ancestors on the
+    // same signal with the listing's own hidden flag, and a Tab that gains a dot asks the same
+    // directory again with the other flag, so a reply matched on the path alone could answer a
+    // hidden request off rows that carried no dotfiles.
+    check("the same directory and flag is the same request",
+          PathBar.requestKey("/home/gm", true), PathBar.requestKey("/home/gm", true))
+    check("the flag alone tells two requests for one directory apart",
+          PathBar.requestKey("/home/gm", true) === PathBar.requestKey("/home/gm", false), false)
+    check("and the directory alone still tells two apart",
+          PathBar.requestKey("/etc", false) === PathBar.requestKey("/home/gm", false), false)
+    // The out-of-order case: the visible reply for the directory the hidden request is waiting on
+    // must not be taken for that request's answer.
+    var pending = PathBar.requestKey("/home/gm", true)
+    check("a visible reply is not the hidden request's answer",
+          PathBar.requestKey("/home/gm", false) === pending, false)
+    check("the hidden reply is", PathBar.requestKey("/home/gm", true) === pending, true)
 
     var dirs = names(["Desktop", "Documents", "Downloads", "Dropbox", "Music"])
 

--- a/tests/js/pathbar.js
+++ b/tests/js/pathbar.js
@@ -1,0 +1,145 @@
+.import "../../ui/js/Focus.js" as Focus
+.import "../../ui/js/PathBar.js" as PathBar
+
+// The path bar's whole meaning is what a typed line resolves to, and every one of those lines is a
+// navigation the user cannot see before it happens: a wrong tilde or a swallowed ".." opens the
+// wrong directory silently. So the resolution is asserted here, with no window and no backend.
+
+var HOME = "/home/gm"
+
+// Only the members Focus.handleKey touches on its way to the path bar, and the counter for the one
+// call it must make: the pane asks, and ui/shell.qml is what opens the field. The routing lives in
+// this suite rather than in tests/js/focus.js, which is at its own hard cap.
+function barPane(view) {
+    return {
+        focusView: view, viewMode: "list", searchMode: "", filterTyping: false,
+        inputAt: 0, rowsAt: 0, asked: 0,
+        preview: { active: false, isMedia: false, isPdf: false },
+        shareBrowser: { active: false },
+        keymapSheet: { open: function () {} },
+        sidebar: { renameEditor: function () { return null } },
+        renameEditor: function () { return null },
+        pathBarRequested: function () { this.asked += 1 }
+    }
+}
+
+function key(code, text, modifiers) {
+    return { key: code, text: text, modifiers: modifiers }
+}
+
+function names(list) {
+    var out = []
+    for (var i = 0; i < list.length; i++) {
+        out.push(list[i])
+    }
+    return out
+}
+
+function run(check) {
+    // The three shapes a line can take, which are the three the field's own prefill relies on.
+    check("an absolute path is itself", PathBar.resolve("/etc", HOME, HOME), "/etc")
+    check("a tilde is the home directory", PathBar.resolve("~", HOME, HOME), HOME)
+    check("a tilde and a child", PathBar.resolve("~/Downloads", HOME, HOME), "/home/gm/Downloads")
+    check("a bare name is relative to where the pane is",
+          PathBar.resolve("Downloads", HOME, HOME), "/home/gm/Downloads")
+    check("a relative line resolves against the pane and not against home",
+          PathBar.resolve("src", "/usr", HOME), "/usr/src")
+
+    // A tilde with no home published is a name, because expanding it to "" would open the root.
+    check("no home leaves a tilde as the name it is",
+          PathBar.resolve("~", "/etc", ""), "/etc/~")
+
+    // Nothing typed is not a path, and the field is what turns that into "close and stay put".
+    check("an empty line is not a path", PathBar.resolve("", HOME, HOME), "")
+    check("whitespace alone is not a path either", PathBar.resolve("   ", HOME, HOME), "")
+
+    // Trailing and doubled slashes come from typing and from completion both, and neither is a
+    // directory of its own: the pane's path never carries one, so the bar's answer must not either.
+    check("a trailing slash is dropped", PathBar.resolve("/etc/", HOME, HOME), "/etc")
+    check("a doubled slash collapses", PathBar.resolve("/etc//apt", HOME, HOME), "/etc/apt")
+    check("the root survives being the whole line", PathBar.resolve("/", HOME, HOME), "/")
+    check("the root survives a trailing slash of its own", PathBar.normalize("//"), "/")
+
+    // Interior dots are resolved here rather than sent on, or the chrome would draw a path the
+    // backend had already read as another one.
+    check("a dot segment is dropped", PathBar.resolve("/etc/./apt", HOME, HOME), "/etc/apt")
+    check("a dot dot climbs", PathBar.resolve("/etc/apt/..", HOME, HOME), "/etc")
+    check("a dot dot climbs from a relative line too",
+          PathBar.resolve("../Music", "/home/gm/Pictures", HOME), "/home/gm/Music")
+    check("climbing stops at the root, as the up key does",
+          PathBar.resolve("/../../..", HOME, HOME), "/")
+
+    // A paste from another application, and what --select already accepts on the command line.
+    check("a file URI is a path", PathBar.resolve("file:///etc/apt", HOME, HOME), "/etc/apt")
+    check("a percent-encoded URI decodes",
+          PathBar.resolve("file:///home/gm/My%20Files", HOME, HOME), "/home/gm/My Files")
+    // A literal percent is a legal filename, so a URI that will not decode is kept, not dropped.
+    check("an undecodable URI is kept as it stands",
+          PathBar.resolve("file:///tmp/100%", HOME, HOME), "/tmp/100%")
+
+    // Where a completion reads, which is the head of the line and never the half-typed leaf.
+    check("the completion directory is the head of the line",
+          PathBar.completionDir("/etc/ap", HOME, HOME), "/etc")
+    check("a line with no slash completes in the pane's own directory",
+          PathBar.completionDir("Dow", HOME, HOME), HOME)
+    check("a line ending in a slash completes inside it",
+          PathBar.completionDir("/etc/apt/", HOME, HOME), "/etc/apt")
+    check("a tilde head resolves before the peek", PathBar.completionDir("~/Do", HOME, HOME), HOME)
+
+    // A dotted leaf asks for hidden entries whatever the listing is set to, or Tab would answer off
+    // rows the peek never returned and read as "nothing starts with that".
+    check("a dotted leaf peeks hidden", PathBar.wantsHidden("~/.co", false), true)
+    check("an ordinary leaf peeks as the listing is set", PathBar.wantsHidden("~/Do", false), false)
+    check("and follows the listing when it shows hidden", PathBar.wantsHidden("~/Do", true), true)
+
+    var dirs = names(["Desktop", "Documents", "Downloads", "Dropbox", "Music"])
+
+    // One match is a whole name, so the separator goes on and the next Tab walks a level deeper.
+    var one = PathBar.complete("/home/gm/Mu", ["Music", "Pictures"])
+    check("a single match completes the name", one.text, "/home/gm/Music/")
+    check("and says it was the only one", one.matches, 1)
+
+    // Several share a prefix, which is exactly as far as the line can honestly go.
+    var many = PathBar.complete("/home/gm/D", dirs)
+    check("several matches grow the line to their common prefix", many.text, "/home/gm/D")
+    check("and count", many.matches, 4)
+    check("the common prefix is taken from the names and not from the leaf",
+          PathBar.complete("/home/gm/Do", dirs).text, "/home/gm/Do")
+    check("a prefix that only two names share grows further",
+          PathBar.complete("/home/gm/Doc", dirs).text, "/home/gm/Documents/")
+
+    // An empty leaf with one entry behind it still completes, which is what makes Tab on a fresh
+    // slash useful rather than silent.
+    check("an empty leaf completes a lone entry",
+          PathBar.complete("/srv/", ["www"]).text, "/srv/www/")
+
+    check("nothing matching leaves the line exactly as it was",
+          PathBar.complete("/home/gm/zz", dirs).text, "/home/gm/zz")
+    check("and says nothing matched", PathBar.complete("/home/gm/zz", dirs).matches, 0)
+
+    // The filesystem is case sensitive, so a fold may never quietly pick one of two real names;
+    // it is only reached when the honest match found nothing at all.
+    var folded = PathBar.complete("/home/gm/dow", dirs)
+    check("a case-insensitive match is the fallback and not the rule", folded.text, "/home/gm/Downloads/")
+    check("an exact-case match wins over one that needs a fold",
+          PathBar.complete("/home/gm/D", ["Dev", "dev"]).text, "/home/gm/Dev/")
+
+    // What Tab says when it changed nothing. Silence is the usual answer and has to stay silent.
+    check("a line that moved says nothing",
+          PathBar.completionMessage("/home/gm/Mu", one, HOME), "")
+    check("a line that could not move names the directory it read",
+          PathBar.completionMessage("/home/gm/zz", PathBar.complete("/home/gm/zz", dirs), HOME),
+          "Nothing in /home/gm starts with that.")
+    check("a line already at the common prefix says how many share it",
+          PathBar.completionMessage("/home/gm/D", many, HOME), "4 names share that prefix.")
+
+    // The key half. The bar is drawn in the chrome above both views, so it is global the way the
+    // keymap sheet is: the rail has to reach it rather than dropping the key on the floor.
+    var colon = key(Qt.Key_Colon, ":", Qt.ShiftModifier)
+    var fromList = barPane("list")
+    check("colon is consumed in the list", Focus.handleKey(colon, fromList, fromList.sidebar), true)
+    check("and asks the shell to open the bar", fromList.asked, 1)
+    var fromRail = barPane("rail")
+    Focus.handleKey(key(Qt.Key_L, "l", Qt.ControlModifier), fromRail, fromRail.sidebar)
+    check("ctrl-l opens it from the rail as well", fromRail.asked, 1)
+}

--- a/tools/flea-acceptance-drive
+++ b/tools/flea-acceptance-drive
@@ -1001,7 +1001,19 @@ keycase_message_is() {
   changed_to "the status line" "" "$after" "$want"
 }
 
-keycase_palette()   { keycase_message_is "The path bar is not built yet." "$@"; }
+# The path bar is built, so its key is driven by what it opens rather than by the sentence it used
+# to answer with. Closed again explicitly, the way keycase_filter closes its query line: a bar left
+# standing owns the keyboard and every later case would type its chords into the field.
+keycase_pathBar() {
+  local before after
+  reset_state || return 1
+  before=$(ipc pathBarOpen)
+  k "$@"; settle
+  after=$(ipc pathBarOpen)
+  mapfile -t escp < <(chord_args code Escape)
+  k "${escp[@]}"; settle
+  changed_to "the path bar" "$before" "$after" true
+}
 
 # ui/js/Focus.js answers every action starting "tab" from one branch, so tabNew, tabClose and the
 # nine keys the [digits] range binds share one driver rather than eleven copies of it.

--- a/ui/Backend.qml
+++ b/ui/Backend.qml
@@ -30,7 +30,8 @@ Item {
     signal meta(int row, int w, int h, real durationMs, int sampleRate, int entries, real unpacked, bool archiveFailed, var names, real lines, bool partial, bool linesFailed, string target, bool targetDir, string owner)
     signal fsInfo(string fs, real free)
     // readFailed tells a zero-row answer apart from an empty directory; mode is that directory's own, 0 when the stat failed too.
-    signal peeked(string path, int total, var rows, bool readFailed, int mode)
+    // hidden is the flag the request carried, echoed by the backend: two clients peek this wire, so path alone does not say whose reply this is.
+    signal peeked(string path, bool hidden, int total, var rows, bool readFailed, int mode)
     signal archiveStarted(int id)
     signal archiveDone(int id, bool ok, bool verified, string err)
     signal convertStarted(int id)
@@ -290,7 +291,7 @@ Item {
         } else if (message.t === "fsinfo") {
             root.fsInfo(message.fs, message.free)
         } else if (message.t === "peeked") {
-            root.peeked(message.path, message.n, message.rows || [], message.failed === true, message.mode || 0)
+            root.peeked(message.path, message.hidden === true, message.n, message.rows || [], message.failed === true, message.mode || 0)
         } else if (message.t === "formats") {
             root.archiveFormats = message.archive || []
             root.canConvert = message.convert === true

--- a/ui/ChromeBar.qml
+++ b/ui/ChromeBar.qml
@@ -2,6 +2,7 @@ import QtQuick
 import qs.Commons
 import "." as Flea
 import "js/Format.js" as Format
+import "js/PathBar.js" as PathBar
 
 // The window's top chrome, per the canvas: where you are on the left, how you are looking at it on
 // the right. The path lives here rather than in the status bar, which the design gives to counts.
@@ -14,11 +15,119 @@ Item {
     property bool canGoUp: false
     // "list", "columns" or "grid"; the button naming the current one takes the accent.
     property string viewMode: "list"
+    // Read by the path bar alone, so a Tab on a dotted leaf peeks the way the listing is set to look.
+    property bool showHidden: false
 
     signal backRequested()
     signal upRequested()
     signal searchRequested()
     signal viewChosen(string mode)
+    // The path bar's four. ui/shell.qml navigates, hands the keyboard back, runs the peek behind Tab
+    // and carries what the bar says to the status line, because this file draws the chrome and knows
+    // nothing about the backend, the pane or the bar below it.
+    signal pathEntered(string path)
+    signal editClosed()
+    signal completeRequested(string dir, bool hidden)
+    signal said(string text)
+
+    // The path bar: the same strip, typed instead of drawn. ":" and Ctrl+L open it, so does a double
+    // click on the path, and it is where the whole of keys.toml's pathBar action lands.
+    property bool editing: false
+    // What the seam reads: the line as it stands, and the box a test double-clicks to open the bar.
+    readonly property alias editText: field.text
+    readonly property alias pathArea: pathArea
+    // The directory a Tab is waiting on, and the one that came back. Both are keyed by the hidden
+    // flag as well as the path, or a Tab on ".conf" would answer off rows peeked without dotfiles in
+    // them: the key is what the request asked for and never what the line happens to read later.
+    property string pendingDir: ""
+    property string pendingKey: ""
+    property string cachedKey: ""
+    property var cachedNames: []
+
+    function startEdit() {
+        if (root.editing) {
+            return
+        }
+        root.editing = true
+        // The trailing slash is what makes typing a child the natural next keystroke, and the line
+        // opens selected, so a name typed straight away replaces it instead of joining onto it.
+        field.text = root.path === "/" ? "/" : root.path + "/"
+        field.forceActiveFocus()
+        field.selectAll()
+    }
+
+    function closeEdit() {
+        if (!root.editing) {
+            return
+        }
+        root.editing = false
+        root.pendingDir = ""
+        root.pendingKey = ""
+        root.cachedKey = ""
+        root.cachedNames = []
+        // The field is inside no focus scope of its own, so the keyboard goes nowhere until the pane
+        // is told to take it back; ui/shell.qml is what does that.
+        root.editClosed()
+    }
+
+    function commitEdit() {
+        var target = PathBar.resolve(field.text, root.path, root.home)
+        root.closeEdit()
+        // An empty line closes the bar and nothing else, and so does the path already being shown:
+        // re-listing the directory under the cursor would drop the selection for no navigation.
+        if (target.length > 0 && target !== root.path) {
+            root.pathEntered(target)
+        }
+    }
+
+    // Tab. The rows come from the backend's peek, which is the read the columns view already makes of
+    // a directory that is not the pane's, so completing costs no new request type.
+    function completeEdit() {
+        var dir = PathBar.completionDir(field.text, root.path, root.home)
+        var hidden = PathBar.wantsHidden(field.text, root.showHidden)
+        var key = dir + "\u0000" + hidden
+        if (key === root.cachedKey) {
+            root.applyCompletion(dir, root.cachedNames)
+            return
+        }
+        root.pendingDir = dir
+        root.pendingKey = key
+        root.completeRequested(dir, hidden)
+    }
+
+    // A peek came back. The columns view peeks the pane's ancestors on the same wire, so a response
+    // this bar did not ask for is dropped rather than cached under a key it cannot vouch for. Only
+    // directories are kept: this bar goes to a directory, and a name that cannot be opened is not a
+    // completion.
+    function completeWith(dir, rows) {
+        if (root.pendingDir !== dir) {
+            return
+        }
+        var names = []
+        for (var i = 0; i < rows.length; i++) {
+            if (rows[i].d) {
+                names.push(rows[i].n)
+            }
+        }
+        root.cachedKey = root.pendingKey
+        root.cachedNames = names
+        root.pendingDir = ""
+        root.pendingKey = ""
+        if (root.editing && PathBar.completionDir(field.text, root.path, root.home) === dir) {
+            root.applyCompletion(dir, names)
+        }
+    }
+
+    function applyCompletion(dir, names) {
+        var before = field.text
+        var after = PathBar.complete(before, names)
+        field.text = after.text
+        field.cursorPosition = field.text.length
+        var say = PathBar.completionMessage(before, after, dir)
+        if (say.length > 0) {
+            root.said(say)
+        }
+    }
 
     // A path reads as the user writes it, so home comes back as a tilde; the leaf is the directory
     // you are actually in and takes full contrast, everything above it stays muted.
@@ -77,6 +186,7 @@ Item {
     // corner: a path is arbitrary text, so PlainText, the same rule every filename on this surface follows.
     Text {
         id: pathText
+        visible: !root.editing
         anchors.left: nav.right
         anchors.leftMargin: Theme.spacing.gap
         anchors.right: views.left
@@ -93,6 +203,7 @@ Item {
 
     Text {
         id: leafText
+        visible: !root.editing
         anchors.left: pathText.left
         anchors.leftMargin: Math.min(pathText.contentWidth, pathText.width)
         anchors.right: views.left
@@ -104,6 +215,83 @@ Item {
         font.pixelSize: Theme.font.caption
         textFormat: Text.PlainText
         elide: Text.ElideRight
+    }
+
+    // Where the path is drawn is where it is typed. A double click opens the bar, which is the
+    // pointer's half of ":" and Ctrl+L; a single click is left alone, because the path is a label
+    // and not a control, and one that armed on a brush past would be in the way of every other click.
+    Item {
+        id: pathArea
+        anchors.left: nav.right
+        anchors.leftMargin: Theme.spacing.gap
+        anchors.right: views.left
+        anchors.rightMargin: Theme.spacing.gap
+        anchors.top: parent.top
+        anchors.bottom: parent.bottom
+
+        HoverHandler {
+            cursorShape: Qt.IBeamCursor
+        }
+
+        TapHandler {
+            acceptedButtons: Qt.LeftButton
+            onDoubleTapped: root.startEdit()
+        }
+
+        // The rename editor's own frame, at chrome scale: the accent says which strip has the
+        // keyboard, and the fill covers the two Texts underneath rather than relying on their visible.
+        Rectangle {
+            visible: root.editing
+            anchors.fill: parent
+            anchors.topMargin: Theme.spacing.hairline * 2
+            anchors.bottomMargin: Theme.spacing.hairline * 2
+            color: Theme.color.background
+            radius: Style.cornerRadius
+            border.width: Theme.spacing.hairline
+            border.color: Theme.color.accent
+        }
+
+        // corner: a typed path is arbitrary text, so it is drawn at the same size the path it
+        // replaces is, and the caret sits on the line rather than on a row of its own.
+        TextInput {
+            id: field
+            visible: root.editing
+            enabled: root.editing
+            anchors.fill: parent
+            anchors.leftMargin: Theme.spacing.gap
+            anchors.rightMargin: Theme.spacing.gap
+            verticalAlignment: TextInput.AlignVCenter
+            color: Theme.color.foreground
+            selectionColor: Theme.color.accent
+            selectedTextColor: Theme.color.background
+            font.family: Theme.font.family
+            font.pixelSize: Theme.font.caption
+            clip: true
+
+            // Every one of these is handled and accepted here, for the reason ui/RenameField.qml
+            // gives: an unaccepted key goes on to the pane's own handler, which would read Return as
+            // "open the row under the cursor" and Tab as "move to the rail" while the bar is up.
+            Keys.onPressed: function (event) {
+                if (event.key === Qt.Key_Escape) {
+                    root.closeEdit()
+                    event.accepted = true
+                    return
+                }
+                if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter) {
+                    root.commitEdit()
+                    event.accepted = true
+                    return
+                }
+                if (event.key === Qt.Key_Tab || event.key === Qt.Key_Backtab) {
+                    root.completeEdit()
+                    event.accepted = true
+                }
+            }
+
+            // Losing the keyboard closes the bar, the rule the rename editor already follows: a bar
+            // left standing over a window that has moved on would commit against the wrong directory.
+            onActiveFocusChanged: if (!activeFocus && root.editing) root.closeEdit()
+        }
     }
 
     Row {

--- a/ui/ChromeBar.qml
+++ b/ui/ChromeBar.qml
@@ -71,12 +71,20 @@ Item {
     }
 
     function commitEdit() {
-        var target = PathBar.resolve(field.text, root.path, root.home)
+        var typed = field.text
+        var target = PathBar.resolve(typed, root.path, root.home)
         root.closeEdit()
         // An empty line closes the bar and nothing else, and so does the path already being shown:
         // re-listing the directory under the cursor would drop the selection for no navigation.
         if (target.length > 0 && target !== root.path) {
             root.pathEntered(target)
+            return
+        }
+        // A line that named something and still resolved to nothing is a file:// URI on another
+        // host. Silence there would read as a broken Enter, so it gets the sentence the rest of
+        // this application gives a key that cannot do what was asked.
+        if (PathBar.refused(typed)) {
+            root.said("That URI names a file on another host, not a path on this machine.")
         }
     }
 
@@ -85,7 +93,7 @@ Item {
     function completeEdit() {
         var dir = PathBar.completionDir(field.text, root.path, root.home)
         var hidden = PathBar.wantsHidden(field.text, root.showHidden)
-        var key = dir + "\u0000" + hidden
+        var key = PathBar.requestKey(dir, hidden)
         if (key === root.cachedKey) {
             root.applyCompletion(dir, root.cachedNames)
             return
@@ -95,12 +103,13 @@ Item {
         root.completeRequested(dir, hidden)
     }
 
-    // A peek came back. The columns view peeks the pane's ancestors on the same wire, so a response
-    // this bar did not ask for is dropped rather than cached under a key it cannot vouch for. Only
-    // directories are kept: this bar goes to a directory, and a name that cannot be opened is not a
-    // completion.
-    function completeWith(dir, rows) {
-        if (root.pendingDir !== dir) {
+    // A peek came back. The columns view peeks the pane's ancestors on the same wire, and a Tab that
+    // gained a dot asks the same directory again with the other hidden flag, so the reply is matched
+    // on the pair the backend echoes rather than on the path alone: a line completing ".conf" was
+    // otherwise free to answer off rows that carried no dotfiles at all. Only directories are kept:
+    // this bar goes to a directory, and a name that cannot be opened is not a completion.
+    function completeWith(dir, hidden, rows) {
+        if (PathBar.requestKey(dir, hidden) !== root.pendingKey) {
             return
         }
         var names = []

--- a/ui/ColumnsArea.qml
+++ b/ui/ColumnsArea.qml
@@ -174,7 +174,9 @@ Item {
             }
         }
 
-        function onPeeked(path, total, rows, readFailed, mode) {
+        // hidden is the request's own flag, echoed; this view asks with the listing's and has only
+        // ever one answer per path, so it reads the rows and lets the path bar do the correlating.
+        function onPeeked(path, hidden, total, rows, readFailed, mode) {
             var next = root.peeked
             next[path] = rows
             root.peeked = next

--- a/ui/Ipc.qml
+++ b/ui/Ipc.qml
@@ -213,6 +213,11 @@ QtObject {
         // The chrome's buttons carry a glyph and no text, so a test reaches one by name and clicks
         // its centre, exactly the way rowCentre already works for a row.
         function chromeButtonCentre(glyph: string): string { return root.fleaWindow.centreOf(root.chrome.buttonFor(glyph)) }
+        // The path bar: whether it has the keyboard, what it is holding, and the box a double click
+        // opens it on, which is the pointer's half of ":" and Ctrl+L.
+        function pathBarOpen(): bool { return root.chrome.editing }
+        function pathBarText(): string { return String(root.chrome.editText) }
+        function pathCentre(): string { return root.fleaWindow.centreOf(root.chrome.pathArea) }
         // The button's painted box as "WxH": the mark is Theme.chromeMarkSize wide and the hit area is the whole strip tall.
         function chromeButtonSize(glyph: string): string {
             var item = root.chrome.buttonFor(glyph)

--- a/ui/Pane.qml
+++ b/ui/Pane.qml
@@ -66,6 +66,7 @@ FocusScope {
     signal sticky(string text)
     // The one popup, hosted in shell.qml beside the network dialog rather than inside the pane.
     signal convertRequested(string name)
+    signal pathBarRequested()  // ":" and Ctrl+L; the bar is chrome, so shell.qml opens it as it does the popup above
 
     // The window covers [held, held + rows.length) and nothing outside it is in memory.
     property int held: 0

--- a/ui/js/Focus.js
+++ b/ui/js/Focus.js
@@ -129,10 +129,10 @@ function act(action, root) {
         Ops.compress(root, action.substring("compress:".length))
         return
     }
-    // Bound ahead of their features, by the rule that a mapped key says why rather than doing nothing:
-    // the Tui board draws tabs on t, w and the digits, and a typeable path bar on colon.
+    // Bound ahead of its feature, by the rule that a mapped key says why rather than doing nothing:
+    // the Tui board draws tabs on t, w and the digits. The path bar that shared this line is built,
+    // and handleKey below opens it before the pane's own views ever see the key.
     if (action.indexOf("tab") === 0) { root.message("Tabs are not built yet.", false); return }
-    if (action === "palette") { root.message("The path bar is not built yet.", false); return }
     root.message(action + " is not built yet.", false)
 }
 
@@ -229,6 +229,13 @@ function handleKey(event, root, sidebar) {
     // takes active focus itself, so nothing below has to route keys into it while it stands.
     if (action === "keymapSheet") {
         root.keymapSheet.open(root)
+        return true
+    }
+    // The path bar is global for the same reason, and for one more: it lives in the chrome above
+    // both views, so neither the list nor the rail is the view that owns it. The pane only asks for
+    // it; ui/shell.qml owns the field and hands the keyboard back when it closes.
+    if (action === "pathBar") {
+        root.pathBarRequested()
         return true
     }
     if (root.focusView === RAIL) {

--- a/ui/js/Keymap.js
+++ b/ui/js/Keymap.js
@@ -18,6 +18,7 @@ function lookup(key, text, modifiers) {
         if (key === Qt.Key_F) return "search"
         if (key === Qt.Key_E) return "eject"
         if (key === Qt.Key_K) return "addNetwork"
+        if (key === Qt.Key_L) return "pathBar"
         if (key === Qt.Key_Delete) return "trash"
         if (key === Qt.Key_Up) return "parent"
         if (key === Qt.Key_Down) return "open"
@@ -59,7 +60,7 @@ function lookup(key, text, modifiers) {
     case "/": return "filter"
     case "f": return "search"
     case "o": return "reveal"
-    case ":": return "palette"
+    case ":": return "pathBar"
     case "t": return "tabNew"
     case "w": return "tabClose"
     case "y": return "copy"
@@ -94,6 +95,7 @@ var SHEET = [
     { keys: "/", action: "filter", label: "filter" },
     { keys: "f", action: "search", label: "find in subtree" },
     { keys: "o", action: "reveal", label: "reveal result" },
+    { keys: ": ^l", action: "pathBar", label: "go to path" },
     { keys: "y ^c", action: "copy", label: "copy" },
     { keys: "x ^x", action: "cut", label: "cut" },
     { keys: "p ^v", action: "paste", label: "paste" },

--- a/ui/js/PathBar.js
+++ b/ui/js/PathBar.js
@@ -37,12 +37,28 @@ function normalize(path) {
 // A file:// URI is what a paste from another application carries, and Flea's own --select takes one
 // too. A URI that will not decode is left as it stands rather than dropped: a literal percent in a
 // filename is legal, and refusing the whole line over one would be worse than a listing that fails.
+//
+// The authority between the third slash and the fourth is part of the URI and not part of the path.
+// RFC 8089 gives it two local spellings, the empty one and "localhost", and both mean this machine;
+// file://localhost/etc is /etc. Any other authority names a file on another host, which is not a
+// path this bar can open, so it answers "" and ui/ChromeBar.qml says so rather than opening the
+// authority as a directory of its own: stripping the scheme alone turned that line into a relative
+// walk into <current>/localhost/etc, which is a directory nobody named.
+var LOCAL_HOSTS = ["", "localhost"]
+
 function unwrap(text) {
     var body = String(text)
     if (body.indexOf("file://") !== 0) {
         return body
     }
     body = body.substring("file://".length)
+    // Everything up to the next slash is the authority; with none, the whole remainder is one.
+    var cut = body.indexOf("/")
+    var authority = cut < 0 ? body : body.substring(0, cut)
+    if (LOCAL_HOSTS.indexOf(authority.toLowerCase()) < 0) {
+        return ""
+    }
+    body = cut < 0 ? "/" : body.substring(cut)
     try {
         return decodeURIComponent(body)
     } catch (e) {
@@ -53,7 +69,10 @@ function unwrap(text) {
 // The typed line as an absolute path. Answers "" for a line that names nothing, which is what the
 // field checks before it navigates: an empty commit closes the bar and leaves the pane where it is.
 function resolve(text, current, home) {
-    var body = unwrap(String(text).trim())
+    var line = String(text).trim()
+    var body = unwrap(line)
+    // Empty either because nothing was typed or because unwrap refused a URI on another host; both
+    // answer "" here, and refused() below is what tells the two apart for the sentence.
     if (body.length === 0) {
         return ""
     }
@@ -92,6 +111,15 @@ function completionDir(text, current, home) {
 // peek behind Tab is told to include them rather than completing against rows it cannot see.
 function wantsHidden(text, showHidden) {
     return showHidden || split(String(text).trim()).leaf.indexOf(".") === 0
+}
+
+// What a completion request and its reply are matched on. The peek wire carries no request id, and
+// it does not need one: two peeks of the same directory with the same hidden flag answer the same
+// rows, so the pair is identity enough, and a reply that differs in either is another asker's.
+// ui/ColumnsArea.qml peeks the pane's ancestors on the same signal, with the listing's own hidden
+// flag, so without this a Tab on ".conf" could complete against rows that carried no dotfiles at all.
+function requestKey(dir, hidden) {
+    return String(dir) + "\u0000" + (hidden ? "hidden" : "visible")
 }
 
 function commonPrefix(names) {
@@ -147,6 +175,13 @@ function complete(text, names) {
     // Tab walks a tree. Several share a prefix, which is as far as the line can honestly go.
     var tail = matched.length === 1 ? grown + "/" : grown
     return { text: parts.head + tail, matches: matched.length }
+}
+
+// A line that named something and still resolved to nothing, which is only ever a file:// URI on
+// another host: the bar owes that a sentence, where an empty line owes silence.
+function refused(text) {
+    var line = String(text).trim()
+    return line.length > 0 && unwrap(line).length === 0
 }
 
 // The sentence Tab answers with when it changed nothing, written for the user and never an action

--- a/ui/js/PathBar.js
+++ b/ui/js/PathBar.js
@@ -1,0 +1,162 @@
+.pragma library
+
+// What a typed path line means, and nothing about the field that carries it: ui/ChromeBar.qml owns
+// the field and ui/shell.qml owns the navigation, the same split ui/js/Filter.js keeps with its
+// strip. Every function here is pure, so tests/js/pathbar.js drives the whole of it with no window.
+//
+// The bar reads what the chrome already draws: a tilde is the home directory because that is how
+// the path is written above the listing, and a bare name is relative to the directory the pane is
+// on, because with the line selected on open that is what one word and Enter has to mean.
+
+// The one place a path is made canonical. Interior "." and ".." are resolved here rather than sent
+// to the backend, so the listing is opened on the path the bar will draw and the two never disagree;
+// "" is not a path and is what every caller checks for.
+function normalize(path) {
+    var text = String(path)
+    if (text.length === 0) {
+        return ""
+    }
+    var parts = text.split("/")
+    var out = []
+    for (var i = 0; i < parts.length; i++) {
+        var part = parts[i]
+        // An empty part is a doubled or a trailing slash, and neither names a directory of its own.
+        if (part.length === 0 || part === ".") {
+            continue
+        }
+        if (part === "..") {
+            // The root has no parent, which is where climbing stops, exactly as ui/js/Nav.js parent does.
+            out.pop()
+            continue
+        }
+        out.push(part)
+    }
+    return "/" + out.join("/")
+}
+
+// A file:// URI is what a paste from another application carries, and Flea's own --select takes one
+// too. A URI that will not decode is left as it stands rather than dropped: a literal percent in a
+// filename is legal, and refusing the whole line over one would be worse than a listing that fails.
+function unwrap(text) {
+    var body = String(text)
+    if (body.indexOf("file://") !== 0) {
+        return body
+    }
+    body = body.substring("file://".length)
+    try {
+        return decodeURIComponent(body)
+    } catch (e) {
+        return body
+    }
+}
+
+// The typed line as an absolute path. Answers "" for a line that names nothing, which is what the
+// field checks before it navigates: an empty commit closes the bar and leaves the pane where it is.
+function resolve(text, current, home) {
+    var body = unwrap(String(text).trim())
+    if (body.length === 0) {
+        return ""
+    }
+    // The tilde only expands against a home the shell actually published; with none, it is a name.
+    if (home.length > 0 && (body === "~" || body.indexOf("~/") === 0)) {
+        body = home + body.substring(1)
+    } else if (body.charAt(0) !== "/") {
+        // Relative to where the pane is, so "Downloads" and Enter is a directory down.
+        body = current + "/" + body
+    }
+    return normalize(body)
+}
+
+// The line cut at its last slash: head is what names a directory and leaf is the part being typed,
+// which is the only part a completion may rewrite. A line with no slash at all is all leaf.
+function split(text) {
+    var body = String(text)
+    var cut = body.lastIndexOf("/")
+    if (cut < 0) {
+        return { head: "", leaf: body }
+    }
+    return { head: body.substring(0, cut + 1), leaf: body.substring(cut + 1) }
+}
+
+// Which directory a completion has to read to answer the line. The head alone, because the leaf is
+// half a name and would resolve to a directory that does not exist; an empty head is the pane's own.
+function completionDir(text, current, home) {
+    var head = split(String(text).trim()).head
+    if (head.length === 0) {
+        return current
+    }
+    return resolve(head, current, home)
+}
+
+// A leaf that starts with a dot is asking for hidden entries whatever the listing is showing, so the
+// peek behind Tab is told to include them rather than completing against rows it cannot see.
+function wantsHidden(text, showHidden) {
+    return showHidden || split(String(text).trim()).leaf.indexOf(".") === 0
+}
+
+function commonPrefix(names) {
+    if (names.length === 0) {
+        return ""
+    }
+    var prefix = names[0]
+    for (var i = 1; i < names.length; i++) {
+        var j = 0
+        while (j < prefix.length && j < names[i].length && prefix.charAt(j) === names[i].charAt(j)) {
+            j++
+        }
+        prefix = prefix.substring(0, j)
+    }
+    return prefix
+}
+
+function startsWith(name, leaf, fold) {
+    var a = fold ? name.toLowerCase() : name
+    var b = fold ? leaf.toLowerCase() : leaf
+    return a.indexOf(b) === 0
+}
+
+// What Tab makes of the names one directory holds. text is the whole line, names are that
+// directory's entries; the answer is the line as it should now read and how many entries stand
+// behind it, which is what the field uses to decide whether a slash goes on the end.
+//
+// Case-sensitively first, and only case-insensitively when that matched nothing: the filesystem is
+// case sensitive, so "Dev" and "dev" are two directories and a fold must never quietly pick one,
+// but a lone "dev" typed at a directory holding only "Dev" is a typist and not an ambiguity.
+function complete(text, names) {
+    var line = String(text)
+    var parts = split(line)
+    var matched = []
+    var i
+    for (i = 0; i < names.length; i++) {
+        if (startsWith(names[i], parts.leaf, false)) {
+            matched.push(names[i])
+        }
+    }
+    if (matched.length === 0) {
+        for (i = 0; i < names.length; i++) {
+            if (startsWith(names[i], parts.leaf, true)) {
+                matched.push(names[i])
+            }
+        }
+    }
+    if (matched.length === 0) {
+        return { text: line, matches: 0 }
+    }
+    var grown = commonPrefix(matched)
+    // One match is a whole name, so the line goes on with the separator already typed: Tab, Tab,
+    // Tab walks a tree. Several share a prefix, which is as far as the line can honestly go.
+    var tail = matched.length === 1 ? grown + "/" : grown
+    return { text: parts.head + tail, matches: matched.length }
+}
+
+// The sentence Tab answers with when it changed nothing, written for the user and never an action
+// name. An empty string means the line moved and the bar says nothing, which is the usual case.
+function completionMessage(before, after, dir) {
+    if (after.matches === 0) {
+        return "Nothing in " + dir + " starts with that."
+    }
+    if (after.text === before) {
+        return after.matches + " names share that prefix."
+    }
+    return ""
+}

--- a/ui/shell.qml
+++ b/ui/shell.qml
@@ -75,11 +75,12 @@ ShellRoot {
                 onSaid: function (text) { bar.say(text, false) }
             }
 
-            // The peek behind Tab. Every peeked line carries the directory it answers for, so the
-            // bar takes the ones it asked for and the columns view goes on taking its own.
+            // The peek behind Tab. Every peeked line carries the directory and the hidden flag it
+            // answers for, so the bar takes the reply to its own request and the columns view, which
+            // peeks the same wire for the pane's ancestors, goes on taking its own.
             Connections {
                 target: backend
-                function onPeeked(path, total, rows, readFailed, mode) { chrome.completeWith(path, rows) }
+                function onPeeked(path, hidden, total, rows, readFailed, mode) { chrome.completeWith(path, hidden, rows) }
             }
 
             Flea.Pane {

--- a/ui/shell.qml
+++ b/ui/shell.qml
@@ -60,10 +60,26 @@ ShellRoot {
                 canGoBack: pane.canGoBack
                 canGoUp: pane.canGoUp
                 viewMode: pane.viewMode
+                showHidden: pane.showHidden
                 onBackRequested: pane.goBack()
                 onUpRequested: pane.openParent()
                 onSearchRequested: pane.act("search")
                 onViewChosen: function (mode) { pane.viewMode = mode }
+                // The path bar's four. The pane navigates and answers for the keyboard exactly as it
+                // does for every other route in, so a path typed and a row opened end the same way.
+                onPathEntered: function (path) { pane.open(path) }
+                onEditClosed: pane.forceActiveFocus()
+                // Tab reads the directory with the same peek the columns view makes of an ancestor,
+                // so completion adds no request type and lands in that view's own cache on the way past.
+                onCompleteRequested: function (dir, hidden) { backend.peek(dir, pane.windowSize, hidden) }
+                onSaid: function (text) { bar.say(text, false) }
+            }
+
+            // The peek behind Tab. Every peeked line carries the directory it answers for, so the
+            // bar takes the ones it asked for and the columns view goes on taking its own.
+            Connections {
+                target: backend
+                function onPeeked(path, total, rows, readFailed, mode) { chrome.completeWith(path, rows) }
             }
 
             Flea.Pane {
@@ -80,6 +96,7 @@ ShellRoot {
                 // A running operation's line, which stands until the operation replaces it; see ui/StatusBar.qml.
                 onSticky: function (text) { bar.sticky = text; bar.transfer = pane.transfer }
                 onConvertRequested: function (name) { convertDialog.open(name, pane) }
+                onPathBarRequested: chrome.startEdit()
                 onOpened: function (path) { shareBrowser.close() }
             }
 


### PR DESCRIPTION
`:` answered "The path bar is not built yet.", so the only way into a directory the listing did
not already show was starting Flea again from a terminal. This builds the bar the key was reserved
for, and gives it the chord and the pointer route people already reach for.

## What it does

The strip above the listing becomes the line you type into. `:`, `Ctrl+L`, or a double click on the
path opens it, on the current directory with a trailing slash and the whole line selected, so a name
typed straight away replaces it and `End` appends instead.

- `/…` absolute, `~/…` home, anything else relative to the directory the pane is on, and a
  `file://` URI pasted from another application is read as the path it names — the same shape
  `--select` already accepts on the command line.
- Interior `.` and `..` resolve before the backend is asked, so the chrome never draws a path the
  listing read as another one.
- **Tab completes** against the directories one level down, through the `peek` the columns view
  already makes of a directory that is not the pane's: no new request type, and the response lands
  in that view's own cache on the way past. One match takes the separator with it, so Tab walks a
  tree; several grow the line to their common prefix and the status line says how many share it.
- A leaf starting with `.` peeks hidden whatever the listing is showing, or Tab would answer off
  rows the peek never returned. The fold to case-insensitive is a fallback and never the rule,
  because `Dev` and `dev` are two directories.
- Enter goes, Escape leaves the pane where it was, losing the keyboard closes the bar — the rule
  `ui/RenameField.qml` already follows.

## Shape of the change

- `keys.toml` is the source, `ui/js/Keymap.js` regenerated by `tools/flea-keymap-gen`. The action
  is **`pathBar`, not `palette`**: the old name read as a command palette and `ui/js/Palette.js` is
  the theme's colour file, one grep apart. `Ctrl+L` joins the colon because that is what Nautilus,
  Thunar, Dolphin and every browser bind — Finder's `Cmd+Shift+G` has no equivalent here — and a
  `: ^l  go to path` row joins the sheet.
- `ui/js/PathBar.js` is the whole meaning of a typed line, pure, so the suite drives all of it.
  `ui/ChromeBar.qml` carries the field; `ui/shell.qml` navigates, hands the keyboard back and runs
  the peek, because the chrome knows nothing about the backend or the pane.
- `Focus.handleKey` opens it beside the keymap sheet, as the second global action: the bar is chrome
  above both views, so neither the list nor the rail owns it.
- Three readers on the IPC seam (`pathBarOpen`, `pathBarText`, `pathCentre`), and `keycase_pathBar`
  replaces the acceptance battery's assertion of the sentence the key used to answer with.

## Testing

`tests/js/pathbar.js`, 44 checks over the resolution, the completion and the two keys. The sheet's
own length and chord counts in `tests/js/keymap.js` move with the new row.

- `./tests/js.sh` — 1054 checks, 0 failed
- `./tests/keymap-gen.sh` — clean
- `tools/flea-qmllint-gate` — 0 regressions
- `tools/flea-file-budget` — under every hard cap
- `cargo test --release` — 335 passed

Driven in a real window through `wtype` against the seam: `:` opens on `/home/…/` selected, `Do`
then Tab says *"2 names share that prefix."*, `c` then Tab completes to `Documents/`, Enter lands
the pane on it. `Ctrl+L` opens the same way, Escape closes with the pane unmoved, `~/Pictures`
navigates, `~/.co` and Tab finds the three dotted directories a hidden peek returns, and
`/no/such/dir` lands in the error state the listing already draws for an unreadable directory.

Two things I could not run here, called out rather than assumed:

- **The double click is not driven.** Qt ignores synthetic pointer motion with no `wl_pointer.frame`,
  which is why `tests/drag.sh` needs uinput; the handler is a plain `TapHandler.onDoubleTapped` and
  was exercised by hand.
- **`tools/flea-acceptance` and `tests/ui.sh` were not run** — `omarchy-drive` is not on this box, so
  `keycase_pathBar` is written to the battery's existing idiom but unexecuted. `run-all.sh`'s
  sandbox suites also need `/home/flea-sandbox`, `7zip` and a non-tmpfs trash, none of which this
  box has; no Rust was touched.

I have no `ui/…` design canvas for the bar, so it borrows the rename editor's language at chrome
scale: accent hairline frame, background fill, the path's own caption size. Happy to redraw it if
the canvas says otherwise.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a path bar for direct navigation, opened with `:` or `Ctrl+L`.
  - Supports absolute, home-relative, relative, and `file://` paths.
  - Added Tab completion, including hidden-directory completion and case-insensitive matching.
  - Double-clicking the current path opens the editor; Enter navigates and Escape closes it.
  - Displays feedback when completion cannot advance.

- **Documentation**
  - Updated keyboard documentation with path bar controls and supported path formats.

- **Tests**
  - Added coverage for path resolution, completion, keyboard shortcuts, and path bar behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->