### PR TITLE
feat: the rail pans, one modified wheel map over both surfaces, and the arrows step between the views

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3596,3 +3596,41 @@ key press fires a compositor bind, so `omarchy-drive hotkey --global super w` is
 on the ACTIVE window, so assert the active window is the one the run launched before sending it, and
 never call `hl.dsp.window.close()` with no argument: it returns `ok` rather than printing a signature
 and acts on whatever is active, which may be a window you did not open.
+
+### The rail pans, the arrows step between the views, and the wheel chords share one map
+
+Three operator reports drove one branch: the rail could not scroll at all, the rail that outgrew
+its own height could not show its bottom rows by any means, and the arrows were dead keys while
+browsing, because `Left`/`Right` are bound to `seekBack`/`seekForward`, which resolve to nothing
+until a preview is open.
+
+**The rail's rows live inside a `Flickable` now.** The rail was a bare `Column`, and a wheel over
+it did nothing: every row is already drawn (see `railItemFor`'s no-virtualization note), so a
+scroll had no viewport to pan and no verb to answer. The list's wheel verb is a pan, and the
+rail's is the same one now, with `boundsBehavior: StopAtBounds` and a clipped viewport; nothing
+chases the cursor back, which is the same split the list draws.
+
+**A Flickable consumes every wheel its children sit under before any WheelHandler in the tree can
+answer one.** The first chord attempt used `WheelHandler` with `acceptedModifiers`, and over both
+the ListView and the rail the chords were silent while the view under them scrolled — driven on a
+live desktop with injected wheel events carrying known modifier state, handlers attached as far up
+as the window root and as deep as the row under the pointer. The chords therefore arrive through a
+`MouseArea` (`acceptedButtons: Qt.NoButton`, so presses and drags are untouched): a plain wheel is
+declined and the view pans natively, the modified chords are answered through `ui/js/Wheel.js`.
+
+**`ui/js/Wheel.js` exists because the same modifier must mean the same thing over both surfaces.**
+Alt steps the cursor a row a notch, Ctrl jumps to either end, Shift extends the selection (list
+only; the rail's rows carry no selection, so Shift pans there). Two environment facts the map
+honours, both caught by a console probe logging the raw event: a natural-scroll setup inverts the
+axis before the event arrives, so `direction()` folds in the event's own `inverted` flag; and this
+operator's input stack rewrites Alt+wheel onto the HORIZONTAL axis (`angleDelta.x = ±120`,
+`angleDelta.y = 0`, modifiers intact), so `axisDelta()` reads whichever axis moved. With only the
+vertical read, Alt walked up and only up under both verb assignments. Every cursor move the rail
+has reveals its row; the list's chords ride `moveCursor`/`setCursorView`, which already scroll the
+row they land on into view. The budget took its two cuts: the favourites merge to
+`Places.favorites`, the rail menu's chosen-row dispatch to `Mounts.release`.
+
+**The arrows step between the views.** With no preview open and no grid, `lookup` resolves Left in
+the list to `focusRail` and either arrow in the rail to `focusList`; Tab and Esc keep exactly what
+they had. `tests/js/focus.js` carries the new lookups, `tests/js/wheel.js` the map, the folds and
+the clamps.

--- a/tests/js/focus.js
+++ b/tests/js/focus.js
@@ -120,13 +120,17 @@ function run(check) {
     check("e is discarded over a media preview", Focus.lookup(e, pane(mediaOpen())), "")
     check("minus is discarded over a media preview", Focus.lookup(minus, pane(mediaOpen())), "")
 
-    // Left and Right now serve two previews, and must still serve the grid and nothing else.
+    // Left and Right now serve two previews, and must still serve the grid, the view step and
+    // nothing else: in the list with nothing open, Left steps into the rail and Right stays free.
     check("left turns a PDF page", Focus.lookup(left, pane(pdfOpen())), "seekBack")
     check("right turns a PDF page", Focus.lookup(right, pane(pdfOpen())), "seekForward")
     check("left still seeks media", Focus.lookup(left, pane(mediaOpen())), "seekBack")
-    check("left is discarded in the list", Focus.lookup(left, pane(closed())), "")
+    check("left steps into the rail", Focus.lookup(left, pane(closed())), "focusRail")
+    check("right stays free in the list", Focus.lookup(right, pane(closed())), "")
     check("left still steps a grid tile", Focus.lookup(left, pane(closed(), "grid")), "cursorLeft")
     check("right still steps a grid tile", Focus.lookup(right, pane(closed(), "grid")), "cursorRight")
+    check("left steps back to the list from the rail", Focus.lookup(left, railPane()), "focusList")
+    check("right steps back to the list from the rail", Focus.lookup(right, railPane()), "focusList")
 
     // h and l are the PDF page pair. l was unbound and h fell through previewAct's switch, so
     // neither ever turned a page while the chevrons and the arrows both did.

--- a/tests/js/harness.qml
+++ b/tests/js/harness.qml
@@ -26,6 +26,7 @@ import "sort.js" as SortSuite
 import "taildrop.js" as TaildropSuite
 import "tap.js" as TapSuite
 import "thumbs.js" as ThumbsSuite
+import "wheel.js" as WheelSuite
 
 Item {
     Component.onCompleted: {
@@ -67,6 +68,7 @@ Item {
         TaildropSuite.run(check)
         TapSuite.run(check)
         ThumbsSuite.run(check)
+        WheelSuite.run(check)
 
         for (var i = 0; i < failures.length; i++) {
             console.log("FAIL " + failures[i])

--- a/tests/js/wheel.js
+++ b/tests/js/wheel.js
@@ -5,15 +5,15 @@
 
 function run(check) {
     check("the plain wheel is the viewport's", Wheel.meaning(Qt.NoModifier), "viewport")
-    check("ctrl steps the cursor", Wheel.meaning(Qt.ControlModifier), "cursor")
-    check("alt jumps to an end", Wheel.meaning(Qt.AltModifier), "end")
+    check("alt steps the cursor", Wheel.meaning(Qt.AltModifier), "cursor")
+    check("ctrl jumps to an end", Wheel.meaning(Qt.ControlModifier), "end")
     check("shift extends the selection", Wheel.meaning(Qt.ShiftModifier), "extend")
 
     // A wheel can carry two modifiers at once when a chord is held through the scroll; the map
     // answers with the strongest verb rather than leaving the pair undefined.
-    check("ctrl outranks alt", Wheel.meaning(Qt.ControlModifier | Qt.AltModifier), "cursor")
-    check("ctrl outranks shift", Wheel.meaning(Qt.ControlModifier | Qt.ShiftModifier), "cursor")
-    check("alt outranks shift", Wheel.meaning(Qt.AltModifier | Qt.ShiftModifier), "end")
+    check("ctrl outranks alt", Wheel.meaning(Qt.ControlModifier | Qt.AltModifier), "end")
+    check("ctrl outranks shift", Wheel.meaning(Qt.ControlModifier | Qt.ShiftModifier), "end")
+    check("alt outranks shift", Wheel.meaning(Qt.AltModifier | Qt.ShiftModifier), "cursor")
 
     // A step clamps to the run it steps through, so a chord held at either end sits still.
     check("a step clamps at the top", Wheel.stepped(0, -1, 5), 0)

--- a/tests/js/wheel.js
+++ b/tests/js/wheel.js
@@ -23,4 +23,11 @@ function run(check) {
     // The end a Ctrl wheel lands on, wheel-down being the last row and wheel-up the first.
     check("ctrl down lands on the last row", Wheel.end(1, 5), 4)
     check("ctrl up lands on the first", Wheel.end(-1, 5), 0)
+
+    // Direction as the item order reads it: raw axis inverted by a natural-scroll setup, and the
+    // event's inverted flag restoring the physical turn the hand made.
+    check("a raw wheel-down is the next row", Wheel.direction(-120, false), 1)
+    check("a raw wheel-up is the previous row", Wheel.direction(120, false), -1)
+    check("an inverted wheel-down still steps to the next row", Wheel.direction(120, true), 1)
+    check("an inverted wheel-up still steps to the previous row", Wheel.direction(-120, true), -1)
 }

--- a/tests/js/wheel.js
+++ b/tests/js/wheel.js
@@ -5,15 +5,15 @@
 
 function run(check) {
     check("the plain wheel is the viewport's", Wheel.meaning(Qt.NoModifier), "viewport")
-    check("alt steps the cursor", Wheel.meaning(Qt.AltModifier), "cursor")
-    check("ctrl jumps to an end", Wheel.meaning(Qt.ControlModifier), "end")
+    check("ctrl steps the cursor", Wheel.meaning(Qt.ControlModifier), "cursor")
+    check("alt jumps to an end", Wheel.meaning(Qt.AltModifier), "end")
     check("shift extends the selection", Wheel.meaning(Qt.ShiftModifier), "extend")
 
     // A wheel can carry two modifiers at once when a chord is held through the scroll; the map
     // answers with the strongest verb rather than leaving the pair undefined.
-    check("ctrl outranks alt", Wheel.meaning(Qt.ControlModifier | Qt.AltModifier), "end")
-    check("ctrl outranks shift", Wheel.meaning(Qt.ControlModifier | Qt.ShiftModifier), "end")
-    check("alt outranks shift", Wheel.meaning(Qt.AltModifier | Qt.ShiftModifier), "cursor")
+    check("ctrl outranks alt", Wheel.meaning(Qt.ControlModifier | Qt.AltModifier), "cursor")
+    check("ctrl outranks shift", Wheel.meaning(Qt.ControlModifier | Qt.ShiftModifier), "cursor")
+    check("alt outranks shift", Wheel.meaning(Qt.AltModifier | Qt.ShiftModifier), "end")
 
     // A step clamps to the run it steps through, so a chord held at either end sits still.
     check("a step clamps at the top", Wheel.stepped(0, -1, 5), 0)

--- a/tests/js/wheel.js
+++ b/tests/js/wheel.js
@@ -30,4 +30,10 @@ function run(check) {
     check("a raw wheel-up is the previous row", Wheel.direction(120, false), -1)
     check("an inverted wheel-down still steps to the next row", Wheel.direction(120, true), 1)
     check("an inverted wheel-up still steps to the previous row", Wheel.direction(-120, true), -1)
+
+    // The axis the event actually turned: an Alt chord this operator's stack rewrites onto the
+    // horizontal axis (modifiers intact, angleDelta.y zero) still reads as a wheel turn.
+    check("a vertical event reads its y", Wheel.axisDelta({ angleDelta: { x: 0, y: -120 } }), -120)
+    check("a horizontal event reads its x", Wheel.axisDelta({ angleDelta: { x: 120, y: 0 } }), 120)
+    check("a diagonal event reads whichever moved most", Wheel.axisDelta({ angleDelta: { x: 40, y: 120 } }), 120)
 }

--- a/tests/js/wheel.js
+++ b/tests/js/wheel.js
@@ -1,0 +1,26 @@
+.import "../../ui/js/Wheel.js" as Wheel
+
+// The wheel's modifier map, shared by the list's view and the rail, so the same gesture cannot
+// mean two things depending on which surface it landed over. See ui/js/Wheel.js.
+
+function run(check) {
+    check("the plain wheel is the viewport's", Wheel.meaning(Qt.NoModifier), "viewport")
+    check("alt steps the cursor", Wheel.meaning(Qt.AltModifier), "cursor")
+    check("ctrl jumps to an end", Wheel.meaning(Qt.ControlModifier), "end")
+    check("shift extends the selection", Wheel.meaning(Qt.ShiftModifier), "extend")
+
+    // A wheel can carry two modifiers at once when a chord is held through the scroll; the map
+    // answers with the strongest verb rather than leaving the pair undefined.
+    check("ctrl outranks alt", Wheel.meaning(Qt.ControlModifier | Qt.AltModifier), "end")
+    check("ctrl outranks shift", Wheel.meaning(Qt.ControlModifier | Qt.ShiftModifier), "end")
+    check("alt outranks shift", Wheel.meaning(Qt.AltModifier | Qt.ShiftModifier), "cursor")
+
+    // A step clamps to the run it steps through, so a chord held at either end sits still.
+    check("a step clamps at the top", Wheel.stepped(0, -1, 5), 0)
+    check("a step clamps at the bottom", Wheel.stepped(4, 1, 5), 4)
+    check("a step moves within the run", Wheel.stepped(2, 1, 5), 3)
+
+    // The end a Ctrl wheel lands on, wheel-down being the last row and wheel-up the first.
+    check("ctrl down lands on the last row", Wheel.end(1, 5), 4)
+    check("ctrl up lands on the first", Wheel.end(-1, 5), 0)
+}

--- a/ui/List.qml
+++ b/ui/List.qml
@@ -52,7 +52,7 @@ ListView {
         anchors.fill: parent
         acceptedButtons: Qt.NoButton
         onWheel: function (wheel) {
-            var dir = wheel.angleDelta.y < 0 ? 1 : -1
+            var dir = Wheel.direction(wheel.angleDelta.y, wheel.inverted)
             var meaning = Wheel.meaning(wheel.modifiers)
             if (meaning === "viewport") { wheel.accepted = false; return }
             // A rename field owns the keyboard, so the chords go quiet over it too.

--- a/ui/List.qml
+++ b/ui/List.qml
@@ -42,21 +42,28 @@ ListView {
     // Every property the delegate draws is a binding on index, so a row leaving the buffer is re-bound rather than rebuilt.
     reuseItems: true
 
-    // The modified wheel, routed by the map ui/js/Wheel.js keeps and the rail reads too. The plain
-    // wheel is not accepted, so it falls through to the ListView and pans, the cursor following in
-    // onContentYChanged below; the chords reach the item level, where moveCursor and setCursorView
-    // already scroll the row they land on into view and extendSelection is Shift+Up/Down's own verb.
-    WheelHandler {
-        acceptedModifiers: Qt.AltModifier | Qt.ControlModifier | Qt.ShiftModifier
+    // The wheel chords, caught over the view. A Flickable consumes every wheel its children sit
+    // under before any WheelHandler in the tree can answer one, so the chords route through this
+    // MouseArea instead: a plain wheel is declined here and the ListView pans natively, the cursor
+    // following it in onContentYChanged below, while the chords are answered through the map
+    // ui/js/Wheel.js keeps, the same one the rail reads. moveCursor and setCursorView already
+    // scroll the row they land on into view, and extendSelection is Shift+Up/Down's own verb.
+    MouseArea {
+        anchors.fill: parent
+        acceptedButtons: Qt.NoButton
         onWheel: function (wheel) {
             var dir = wheel.angleDelta.y < 0 ? 1 : -1
             var meaning = Wheel.meaning(wheel.modifiers)
+            if (meaning === "viewport") { wheel.accepted = false; return }
+            // A rename field owns the keyboard, so the chords go quiet over it too.
+            if (root.pane.renamingIndex >= 0) { wheel.accepted = true; return }
             if (meaning === "cursor")
                 Filter.moveCursor(root.pane, dir)
             else if (meaning === "end")
                 Filter.setCursorView(root.pane, Wheel.end(dir, root.pane.shownTotal))
             else if (meaning === "extend")
                 root.pane.extendSelection(dir)
+            wheel.accepted = true
         }
     }
 

--- a/ui/List.qml
+++ b/ui/List.qml
@@ -5,6 +5,7 @@ import "js/Drag.js" as DragOps
 import "js/Filter.js" as Filter
 import "js/Tap.js" as Tap
 import "js/Thumbs.js" as Thumbs
+import "js/Wheel.js" as Wheel
 
 // The listing's render, scroll and settle-triggered refetch, split out of Pane.qml; reaches Pane's state through the pane reference and the context menu through menu, both handed in at instantiation.
 ListView {
@@ -40,6 +41,24 @@ ListView {
     highlightMoveDuration: 0
     // Every property the delegate draws is a binding on index, so a row leaving the buffer is re-bound rather than rebuilt.
     reuseItems: true
+
+    // The modified wheel, routed by the map ui/js/Wheel.js keeps and the rail reads too. The plain
+    // wheel is not accepted, so it falls through to the ListView and pans, the cursor following in
+    // onContentYChanged below; the chords reach the item level, where moveCursor and setCursorView
+    // already scroll the row they land on into view and extendSelection is Shift+Up/Down's own verb.
+    WheelHandler {
+        acceptedModifiers: Qt.AltModifier | Qt.ControlModifier | Qt.ShiftModifier
+        onWheel: function (wheel) {
+            var dir = wheel.angleDelta.y < 0 ? 1 : -1
+            var meaning = Wheel.meaning(wheel.modifiers)
+            if (meaning === "cursor")
+                Filter.moveCursor(root.pane, dir)
+            else if (meaning === "end")
+                Filter.setCursorView(root.pane, Wheel.end(dir, root.pane.shownTotal))
+            else if (meaning === "extend")
+                root.pane.extendSelection(dir)
+        }
+    }
 
     delegate: Flea.Row {
         id: cell

--- a/ui/List.qml
+++ b/ui/List.qml
@@ -52,7 +52,7 @@ ListView {
         anchors.fill: parent
         acceptedButtons: Qt.NoButton
         onWheel: function (wheel) {
-            var dir = Wheel.direction(wheel.angleDelta.y, wheel.inverted)
+            var dir = Wheel.direction(Wheel.axisDelta(wheel), wheel.inverted)
             var meaning = Wheel.meaning(wheel.modifiers)
             if (meaning === "viewport") { wheel.accepted = false; return }
             // A rename field owns the keyboard, so the chords go quiet over it too.

--- a/ui/Sidebar.qml
+++ b/ui/Sidebar.qml
@@ -340,7 +340,7 @@ Item {
         acceptedButtons: Qt.NoButton
         onWheel: function (wheel) {
             if (root.renamingIndex >= 0) { wheel.accepted = false; return }
-            var dir = wheel.angleDelta.y < 0 ? 1 : -1
+            var dir = Wheel.direction(wheel.angleDelta.y, wheel.inverted)
             var meaning = Wheel.meaning(wheel.modifiers)
             if (meaning === "viewport" || meaning === "extend") { wheel.accepted = false; return }
             if (meaning === "end")

--- a/ui/Sidebar.qml
+++ b/ui/Sidebar.qml
@@ -5,6 +5,7 @@ import qs.Commons
 import "js/Icons.js" as Icons
 import "js/Mounts.js" as Mounts
 import "js/Places.js" as Places
+import "js/Wheel.js" as Wheel
 
 // The rail is Favorites, Network and Devices, three groups sharing one flat cursor space and one
 // row delegate, ui/SidebarRow.qml. Each group occupies a contiguous run of "entries" in that
@@ -102,25 +103,11 @@ Item {
         onRenamed: root.reloadBookmarks()
     }
 
-    // Home is always first and is not in either file, so it is prepended rather than parsed.
+    // Home is always first and is not in either file, so it is prepended rather than parsed; the
+    // merge and its first-position-wins rule are Places.favorites', which tests/js/places.js checks.
     function rebuild() {
         var home = Quickshell.env("HOME")
-        var favs = [{ path: home, label: "Home", group: "favorite", kind: "favorite", glyph: Icons.sidebarGlyphFor("Home") }]
-        var dirs = Places.userDirs(userDirsFile.text(), home)
-        var marks = Places.bookmarks(bookmarksFile.text())
-        var seen = {}
-        seen[home] = true
-        for (var i = 0; i < dirs.length; i++) {
-            if (!seen[dirs[i].path]) { seen[dirs[i].path] = true; favs.push(root.taggedFavorite(dirs[i])) }
-        }
-        for (var j = 0; j < marks.length; j++) {
-            if (!seen[marks[j].path]) { seen[marks[j].path] = true; favs.push(root.taggedFavorite(marks[j])) }
-        }
-        root.favoriteEntries = favs
-    }
-
-    function taggedFavorite(e) {
-        return { path: e.path, label: e.label, group: "favorite", kind: "favorite", glyph: Icons.sidebarGlyphFor(e.label) }
+        root.favoriteEntries = Places.favorites(home, userDirsFile.text(), bookmarksFile.text(), Icons.sidebarGlyphFor)
     }
 
     // ui/NetworkDialog.qml writes this same file; a watch set up before its parent directory
@@ -129,57 +116,15 @@ Item {
         bookmarksFile.reload()
     }
 
-    // ui/ShareBrowser.qml's own Enter action calls this with the resolved share uri; not yet one of root.entries, so it goes straight to NetworkMounts's own open-a-share path.
-    function mountShare(uri, label) {
-        mounts.openShare(uri, false, label)
-    }
-
-    // Right click raises the menu over the row, which is the whole affordance: an eject that can
-    // only be reached by right-clicking twice is one nobody can see. Which rows offer what lives in
-    // ui/js/Mounts.js "railMenu", because a row with nothing to release must open no menu at all.
-    function openRailMenu(index, scenePosition) {
-        root.cancelRename()
-        var entry = root.entries[index]
-        if (!entry || !root.menu) {
-            return
-        }
-        root.cursorIndex = index
-        root.menu.openForRail(Mounts.railKey(entry), Mounts.railMenu(entry), scenePosition)
-    }
-
-    // The keyboard's own entrance to the same menu, opened under the row the rail cursor is on.
-    // Whether that row has anything to release is ui/js/Focus.js "raiseMenu"'s question, already
-    // answered before this is called; this only turns the cursor into a point to open at.
-    function openCursorMenu() {
-        var row = root.railItemFor(root.cursorIndex)
-        if (!row)
-            return
-        root.openRailMenu(root.cursorIndex, row.mapToItem(null, Style.spacing.rowPaddingX, row.height))
-    }
-
-    // A chosen menu row, arriving with the row's key rather than its position: the rail rebuilds on
-    // a five second poll, so the index the menu opened over can name a different row by now. A key
-    // that no longer names a row does nothing, because the row it named has left the rail already.
-    function releaseChosen(action, key) {
-        if (action === "eject") {
-            var volume = Mounts.rowByKey(root.deviceEntries, key)
-            // Both Services re-check the kind themselves; this only resolves which row was meant.
-            if (volume >= 0) {
-                devices.eject(volume)
-            }
-            return
-        }
-        if (action === "unmount") {
-            var share = Mounts.rowByKey(root.networkEntries, key)
-            if (share >= 0) {
-                mounts.unmount(share)
-            }
-        }
-    }
-
-    Connections {
-        target: root.menu
-        function onRailChosen(action, key) { root.releaseChosen(action, key) }
+    // The rail has no ListView virtualization, so every row already exists; the same itemFor idiom
+    // ui/Pane.qml uses for the list, so a test can find a rail row's on-screen box.
+    function railItemFor(index) {
+        if (index < root.favoriteEntries.length)
+            return favRepeater.itemAt(index)
+        var rest = index - root.favoriteEntries.length
+        if (rest < root.networkEntries.length)
+            return netRepeater.itemAt(rest)
+        return devRepeater.itemAt(rest - root.networkEntries.length)
     }
 
     // A favourite's path is already real and opens directly; a network share or a removable volume
@@ -237,135 +182,169 @@ Item {
         mounts.rename(entry.uri, trimmed)
     }
 
+    // Every cursor move the rail has — keyboard, the wheel chords, the clamp — reveals its row;
+    // a plain wheel pan deliberately does not chase the cursor back, the list's own split of the
+    // two verbs.
+    onCursorIndexChanged: revealCursor()
+
+    function revealCursor() {
+        var row = root.railItemFor(root.cursorIndex)
+        if (!row)
+            return
+        var p = row.mapToItem(scroller.contentItem)
+        if (p.y < scroller.contentY)
+            scroller.contentY = p.y
+        else if (p.y + row.height > scroller.contentY + scroller.height)
+            scroller.contentY = p.y + row.height - scroller.height
+    }
+
     Rectangle {
         anchors.fill: parent
         color: Theme.color.surface
     }
 
-    Column {
-        id: rail
-        anchors.top: parent.top
-        anchors.topMargin: Style.spacing.rowPaddingX
-        anchors.left: parent.left
-        anchors.right: parent.right
+    // The rail's viewport. The list's wheel verb is a pan and the rail's is now the same one, so
+    // this is a Flickable and not the bare Column it was, which could not show a row below its
+    // own height however many favourites and mounts stood in the file.
+    Flickable {
+        id: scroller
+        anchors.fill: parent
+        clip: true
+        contentWidth: width
+        contentHeight: rail.height + 2 * Style.spacing.rowPaddingX
+        boundsBehavior: Flickable.StopAtBounds
 
-        Text {
-            id: favHeading
-            x: Style.spacing.rowPaddingX
-            bottomPadding: Style.spacing.rowGap
-            text: "FAVORITES"
-            color: Theme.color.muted
-            font.family: Theme.font.family
-            font.pixelSize: Theme.font.caption
-            font.letterSpacing: 1
-        }
-
-        Repeater {
-            id: favRepeater
-            model: root.favoriteEntries
-            delegate: SidebarRow {
-                cursor: index === root.cursorIndex
-                focused: root.focused
-                onActivated: function (idx) { root.activate(idx) }
-                onMenuRequested: function (idx, pos) { root.openRailMenu(idx, pos) }
-            }
-        }
-
-        // The OEM panel idiom's own group gap, not the tighter row-to-row rhythm rows keep inside a group.
-        Item {
-            visible: root.networkEntries.length > 0
-            width: rail.width
-            height: Style.spacing.panelGap
-        }
-
-        // Self-hides with its list below when gio, the bookmarks file and Dropbox all have nothing to say.
-        Item {
-            id: netHeadingRow
-            visible: root.networkEntries.length > 0
-            width: rail.width
-            height: netHeading.implicitHeight + Style.spacing.rowGap
+        Column {
+            id: rail
+            anchors.top: parent.top
+            anchors.topMargin: Style.spacing.rowPaddingX
+            anchors.left: parent.left
+            anchors.right: parent.right
 
             Text {
-                id: netHeading
+                id: favHeading
                 x: Style.spacing.rowPaddingX
-                text: "NETWORK"
+                bottomPadding: Style.spacing.rowGap
+                text: "FAVORITES"
                 color: Theme.color.muted
                 font.family: Theme.font.family
                 font.pixelSize: Theme.font.caption
                 font.letterSpacing: 1
             }
 
-            // A hand-drawn plus, not a Text "+": at caption size the font glyph read as a Christian cross, not a plus. Sized off the heading's own font token.
-            Glyph {
-                id: addMark
-                name: "plus"
-                color: Theme.color.muted
-                width: Theme.font.caption
-                height: Theme.font.caption
-                anchors.right: parent.right
-                anchors.rightMargin: Style.spacing.rowPaddingX
-                anchors.verticalCenter: netHeading.verticalCenter
-
-                TapHandler {
-                    onTapped: root.addRequested()
+            Repeater {
+                id: favRepeater
+                model: root.favoriteEntries
+                delegate: SidebarRow {
+                    cursor: index === root.cursorIndex
+                    focused: root.focused
+                    onActivated: function (idx) { root.activate(idx) }
+                    onMenuRequested: function (idx, pos) { root.openRailMenu(idx, pos) }
                 }
             }
-        }
 
-        Repeater {
-            id: netRepeater
-            model: root.networkEntries
-            delegate: SidebarRow {
-                cursor: (index + root.favoriteEntries.length) === root.cursorIndex
-                focused: root.focused
-                renaming: (index + root.favoriteEntries.length) === root.renamingIndex
-                onActivated: function (idx) { root.activate(idx + root.favoriteEntries.length) }
-                onMenuRequested: function (idx, pos) { root.openRailMenu(idx + root.favoriteEntries.length, pos) }
-                onRenameCommitted: function (idx, text) { root.commitRename(idx + root.favoriteEntries.length, text) }
-                onRenameCancelled: root.cancelRename()
+            // The OEM panel idiom's own group gap, not the tighter row-to-row rhythm rows keep inside a group.
+            Item {
+                visible: root.networkEntries.length > 0
+                width: rail.width
+                height: Style.spacing.panelGap
             }
-        }
 
-        Item {
-            visible: root.deviceEntries.length > 0
-            width: rail.width
-            height: Style.spacing.panelGap
-        }
+            // Self-hides with its list below when gio, the bookmarks file and Dropbox all have nothing to say.
+            Item {
+                id: netHeadingRow
+                visible: root.networkEntries.length > 0
+                width: rail.width
+                height: netHeading.implicitHeight + Style.spacing.rowGap
 
-        // Self-hides with its list below on a box lsblk reports no disk for; there is no header
-        // over an empty group. Unlike NETWORK it carries no add mark: nothing here is bookmarked.
-        Text {
-            id: devHeading
-            visible: root.deviceEntries.length > 0
-            x: Style.spacing.rowPaddingX
-            bottomPadding: Style.spacing.rowGap
-            text: "DEVICES"
-            color: Theme.color.muted
-            font.family: Theme.font.family
-            font.pixelSize: Theme.font.caption
-            font.letterSpacing: 1
-        }
+                Text {
+                    id: netHeading
+                    x: Style.spacing.rowPaddingX
+                    text: "NETWORK"
+                    color: Theme.color.muted
+                    font.family: Theme.font.family
+                    font.pixelSize: Theme.font.caption
+                    font.letterSpacing: 1
+                }
 
-        Repeater {
-            id: devRepeater
-            model: root.deviceEntries
-            delegate: SidebarRow {
-                cursor: (index + root.favoriteEntries.length + root.networkEntries.length) === root.cursorIndex
-                focused: root.focused
-                onActivated: function (idx) { root.activate(idx + root.favoriteEntries.length + root.networkEntries.length) }
-                onMenuRequested: function (idx, pos) { root.openRailMenu(idx + root.favoriteEntries.length + root.networkEntries.length, pos) }
+                // A hand-drawn plus, not a Text "+": at caption size the font glyph read as a Christian cross, not a plus. Sized off the heading's own font token.
+                Glyph {
+                    id: addMark
+                    name: "plus"
+                    color: Theme.color.muted
+                    width: Theme.font.caption
+                    height: Theme.font.caption
+                    anchors.right: parent.right
+                    anchors.rightMargin: Style.spacing.rowPaddingX
+                    anchors.verticalCenter: netHeading.verticalCenter
+
+                    TapHandler {
+                        onTapped: root.addRequested()
+                    }
+                }
+            }
+
+            Repeater {
+                id: netRepeater
+                model: root.networkEntries
+                delegate: SidebarRow {
+                    cursor: (index + root.favoriteEntries.length) === root.cursorIndex
+                    focused: root.focused
+                    renaming: (index + root.favoriteEntries.length) === root.renamingIndex
+                    onActivated: function (idx) { root.activate(idx + root.favoriteEntries.length) }
+                    onMenuRequested: function (idx, pos) { root.openRailMenu(idx + root.favoriteEntries.length, pos) }
+                    onRenameCommitted: function (idx, text) { root.commitRename(idx + root.favoriteEntries.length, text) }
+                    onRenameCancelled: root.cancelRename()
+                }
+            }
+
+            Item {
+                visible: root.deviceEntries.length > 0
+                width: rail.width
+                height: Style.spacing.panelGap
+            }
+
+            // Self-hides with its list below on a box lsblk reports no disk for; there is no header
+            // over an empty group. Unlike NETWORK it carries no add mark: nothing here is bookmarked.
+            Text {
+                id: devHeading
+                visible: root.deviceEntries.length > 0
+                x: Style.spacing.rowPaddingX
+                bottomPadding: Style.spacing.rowGap
+                text: "DEVICES"
+                color: Theme.color.muted
+                font.family: Theme.font.family
+                font.pixelSize: Theme.font.caption
+                font.letterSpacing: 1
+            }
+
+            Repeater {
+                id: devRepeater
+                model: root.deviceEntries
+                delegate: SidebarRow {
+                    cursor: (index + root.favoriteEntries.length + root.networkEntries.length) === root.cursorIndex
+                    focused: root.focused
+                    onActivated: function (idx) { root.activate(idx + root.favoriteEntries.length + root.networkEntries.length) }
+                    onMenuRequested: function (idx, pos) { root.openRailMenu(idx + root.favoriteEntries.length + root.networkEntries.length, pos) }
+                }
             }
         }
     }
 
-    // The rail has no ListView virtualization, so every row already exists; the same itemFor idiom ui/Pane.qml uses for the list, so a test can find a rail row's on-screen box.
-    function railItemFor(index) {
-        if (index < root.favoriteEntries.length)
-            return favRepeater.itemAt(index)
-        var rest = index - root.favoriteEntries.length
-        if (rest < root.networkEntries.length)
-            return netRepeater.itemAt(rest)
-        return devRepeater.itemAt(rest - root.networkEntries.length)
+    // The rail's modified wheel, routed by the map ui/js/Wheel.js keeps and the list reads too.
+    // The plain wheel is not accepted here, so it falls through to the Flickable above and pans;
+    // Shift is not accepted either, because rail rows carry no selection for an extend to land on.
+    WheelHandler {
+        acceptedModifiers: Qt.AltModifier | Qt.ControlModifier
+        onWheel: function (wheel) {
+            if (root.renamingIndex >= 0)
+                return
+            var dir = wheel.angleDelta.y < 0 ? 1 : -1
+            if (Wheel.meaning(wheel.modifiers) === "end")
+                root.cursorIndex = Wheel.end(dir, root.entries.length)
+            else
+                root.cursorIndex = Wheel.stepped(root.cursorIndex, dir, root.entries.length)
+        }
     }
 
     // The one divider in the whole design.
@@ -376,5 +355,35 @@ Item {
         width: Style.spacing.hairline
         color: Theme.color.foreground
         opacity: 0.12
+    }
+
+    // Right click raises the menu over the row, which is the whole affordance: an eject that can
+    // only be reached by right-clicking twice is one nobody can see. Which rows offer what lives in
+    // ui/js/Mounts.js "railMenu", because a row with nothing to release must open no menu at all.
+    function openRailMenu(index, scenePosition) {
+        root.cancelRename()
+        var entry = root.entries[index]
+        if (!entry || !root.menu) {
+            return
+        }
+        root.cursorIndex = index
+        root.menu.openForRail(Mounts.railKey(entry), Mounts.railMenu(entry), scenePosition)
+    }
+
+    // The keyboard's own entrance to the same menu, opened under the row the rail cursor is on.
+    // Whether that row has anything to release is ui/js/Focus.js "raiseMenu"'s question, already
+    // answered before this is called; this only turns the cursor into a point to open at.
+    function openCursorMenu() {
+        var row = root.railItemFor(root.cursorIndex)
+        if (!row)
+            return
+        root.openRailMenu(root.cursorIndex, row.mapToItem(null, Style.spacing.rowPaddingX, row.height))
+    }
+
+    Connections {
+        target: root.menu
+        // A chosen menu row arrives with the row's key rather than its position, the poll problem
+        // Mounts.release's own comment carries; this only hands the choice to it.
+        function onRailChosen(action, key) { Mounts.release(action, key, devices, mounts, root.deviceEntries, root.networkEntries) }
     }
 }

--- a/ui/Sidebar.qml
+++ b/ui/Sidebar.qml
@@ -347,6 +347,8 @@ Item {
                 root.cursorIndex = Wheel.end(dir, root.entries.length)
             else
                 root.cursorIndex = Wheel.stepped(root.cursorIndex, dir, root.entries.length)
+            // The chord probe: what the event actually carried, over the bar, while the Alt bug is hunted.
+            root.message("end x=" + wheel.angleDelta.x + " y=" + wheel.angleDelta.y + " inv=" + wheel.inverted, false)
             wheel.accepted = true
         }
     }

--- a/ui/Sidebar.qml
+++ b/ui/Sidebar.qml
@@ -339,18 +339,14 @@ Item {
         anchors.fill: parent
         acceptedButtons: Qt.NoButton
         onWheel: function (wheel) {
-            // The chord probe, at full verbosity: everything the event carried, into the shell log.
-            console.log("WHEEL mods=" + wheel.modifiers + " x=" + wheel.angleDelta.x + " y=" + wheel.angleDelta.y + " inv=" + wheel.inverted)
             if (root.renamingIndex >= 0) { wheel.accepted = false; return }
-            var dir = Wheel.direction(wheel.angleDelta.y, wheel.inverted)
+            var dir = Wheel.direction(Wheel.axisDelta(wheel), wheel.inverted)
             var meaning = Wheel.meaning(wheel.modifiers)
             if (meaning === "viewport" || meaning === "extend") { wheel.accepted = false; return }
             if (meaning === "end")
                 root.cursorIndex = Wheel.end(dir, root.entries.length)
             else
                 root.cursorIndex = Wheel.stepped(root.cursorIndex, dir, root.entries.length)
-            // The chord probe: what the event actually carried, over the bar, while the Alt bug is hunted.
-            root.message("end x=" + wheel.angleDelta.x + " y=" + wheel.angleDelta.y + " inv=" + wheel.inverted, false)
             wheel.accepted = true
         }
     }

--- a/ui/Sidebar.qml
+++ b/ui/Sidebar.qml
@@ -339,6 +339,8 @@ Item {
         anchors.fill: parent
         acceptedButtons: Qt.NoButton
         onWheel: function (wheel) {
+            // The chord probe, at full verbosity: everything the event carried, into the shell log.
+            console.log("WHEEL mods=" + wheel.modifiers + " x=" + wheel.angleDelta.x + " y=" + wheel.angleDelta.y + " inv=" + wheel.inverted)
             if (root.renamingIndex >= 0) { wheel.accepted = false; return }
             var dir = Wheel.direction(wheel.angleDelta.y, wheel.inverted)
             var meaning = Wheel.meaning(wheel.modifiers)

--- a/ui/Sidebar.qml
+++ b/ui/Sidebar.qml
@@ -331,19 +331,23 @@ Item {
         }
     }
 
-    // The rail's modified wheel, routed by the map ui/js/Wheel.js keeps and the list reads too.
-    // The plain wheel is not accepted here, so it falls through to the Flickable above and pans;
-    // Shift is not accepted either, because rail rows carry no selection for an extend to land on.
-    WheelHandler {
-        acceptedModifiers: Qt.AltModifier | Qt.ControlModifier
+    // The rail's wheel chords, caught over the viewport. The Flickable consumes every wheel its
+    // rows sit under before any WheelHandler could answer one, so the chords route through this
+    // MouseArea, the same map ui/js/Wheel.js keeps that the list reads: a plain wheel is declined
+    // so the Flickable pans, and Shift pans too, because rail rows carry no selection to extend.
+    MouseArea {
+        anchors.fill: parent
+        acceptedButtons: Qt.NoButton
         onWheel: function (wheel) {
-            if (root.renamingIndex >= 0)
-                return
+            if (root.renamingIndex >= 0) { wheel.accepted = false; return }
             var dir = wheel.angleDelta.y < 0 ? 1 : -1
-            if (Wheel.meaning(wheel.modifiers) === "end")
+            var meaning = Wheel.meaning(wheel.modifiers)
+            if (meaning === "viewport" || meaning === "extend") { wheel.accepted = false; return }
+            if (meaning === "end")
                 root.cursorIndex = Wheel.end(dir, root.entries.length)
             else
                 root.cursorIndex = Wheel.stepped(root.cursorIndex, dir, root.entries.length)
+            wheel.accepted = true
         }
     }
 

--- a/ui/js/Focus.js
+++ b/ui/js/Focus.js
@@ -42,7 +42,11 @@ function lookup(event, root) {
             return action
         if (root.viewMode === "grid")
             return action === "seekBack" ? "cursorLeft" : "cursorRight"
-        return ""
+        // Nothing open and no grid: Left in the list steps into the rail; in the rail both arrows
+        // step back out. Right in the list stays free, so nothing pulls focus sideways on it.
+        if (root.focusView === RAIL)
+            return "focusList"
+        return action === "seekBack" ? "focusRail" : ""
     }
     // The PDF viewer's own four. Minus, plus, e and l mean nothing anywhere else, so they stay
     // silent rather than reaching act()'s "not built yet" while browsing.
@@ -223,6 +227,11 @@ function handleKey(event, root, sidebar) {
     }
     if (action === "focusNext") {
         root.focusView = next(root.focusView)
+        return true
+    }
+    // The arrows' step between the views, lookup's seekBack/seekForward branch above.
+    if (action === "focusRail" || action === "focusList") {
+        root.focusView = action === "focusRail" ? RAIL : LIST
         return true
     }
     // The sheet is global, unlike addNetwork, so it answers from the rail as well as the list. It

--- a/ui/js/Mounts.js
+++ b/ui/js/Mounts.js
@@ -212,3 +212,21 @@ function holding(entries, dir) {
     }
     return null
 }
+
+// The rail menu's chosen row, handed the row's key rather than its position: the rail rebuilds on
+// a five second poll, so the index the menu opened over can name a different row by now. A key
+// that no longer names a row does nothing, because the row it named has left the rail already.
+// Both Services re-check the kind themselves; this only resolves which row was meant.
+function release(action, key, devices, mounts, deviceEntries, networkEntries) {
+    if (action === "eject") {
+        var volume = rowByKey(deviceEntries, key)
+        if (volume >= 0)
+            devices.eject(volume)
+        return
+    }
+    if (action === "unmount") {
+        var share = rowByKey(networkEntries, key)
+        if (share >= 0)
+            mounts.unmount(share)
+    }
+}

--- a/ui/js/Places.js
+++ b/ui/js/Places.js
@@ -37,6 +37,26 @@ function bookmarks(body) {
     return out
 }
 
+// The FAVORITES rail's rows, Home first and always, then XDG dirs and bookmarked places in file
+// order, a path seen twice keeping its first position. glyphFor resolves each row's mark so the
+// rail's Icons import stays the rail's own business; see ui/Sidebar.qml's rebuild.
+function favorites(home, dirsText, marksText, glyphFor) {
+    var favs = [{ path: home, label: "Home", group: "favorite", kind: "favorite", glyph: glyphFor("Home") }]
+    var seen = {}
+    seen[home] = true
+    var groups = [userDirs(dirsText, home), bookmarks(marksText)]
+    for (var g = 0; g < groups.length; g++) {
+        for (var i = 0; i < groups[g].length; i++) {
+            if (seen[groups[g][i].path])
+                continue
+            var e = groups[g][i]
+            seen[e.path] = true
+            favs.push({ path: e.path, label: e.label, group: "favorite", kind: "favorite", glyph: glyphFor(e.label) })
+        }
+    }
+    return favs
+}
+
 function leaf(path) {
     var cut = path.lastIndexOf("/")
     return cut < 0 ? path : path.substring(cut + 1)

--- a/ui/js/Wheel.js
+++ b/ui/js/Wheel.js
@@ -29,3 +29,13 @@ function stepped(index, dir, count) {
 function end(dir, count) {
     return dir > 0 ? count - 1 : 0
 }
+
+// The wheel's direction as the item order reads it: a wheel-down steps to the next row, whatever
+// the user's scrolling convention is. A natural-scroll setup inverts the axis before the event
+// arrives, so the raw sign says up when the hand rolled down, and the event's own inverted flag
+// is what restores the physical direction. Both surfaces read this, so the same wheel turn steps
+// the same way over the list and the rail.
+function direction(angleDeltaY, inverted) {
+    var dir = angleDeltaY < 0 ? 1 : -1
+    return inverted ? -dir : dir
+}

--- a/ui/js/Wheel.js
+++ b/ui/js/Wheel.js
@@ -1,0 +1,31 @@
+.pragma library
+
+// What a wheel gesture means, shared by the list's view and the rail. The plain wheel is the
+// viewport's own verb everywhere: the list's ListView pans and its cursor follows in List.qml's
+// contentY handler, the rail's Flickable pans and nothing chases the cursor back. Only the
+// modified chords reach the item level, and the same modifier has to mean the same thing over
+// both surfaces or the split between them is a bug neither file can see.
+
+// Ctrl jumps to either end, g/G's verb; Alt steps the cursor one row a notch, j/k's verb; Shift
+// extends the selection the way Shift+Up/Down do. Control wins when it arrives beside another
+// modifier, and anything else — the plain wheel included — is a viewport pan the Flickable keeps.
+function meaning(modifiers) {
+    if (modifiers & Qt.ControlModifier)
+        return "end"
+    if (modifiers & Qt.AltModifier)
+        return "cursor"
+    if (modifiers & Qt.ShiftModifier)
+        return "extend"
+    return "viewport"
+}
+
+// The index a step lands on, clamped to the run. dir is +1 for a wheel-down, the direction the
+// content moves, which is the direction the cursor steps in both surfaces.
+function stepped(index, dir, count) {
+    return Math.max(0, Math.min(count - 1, index + dir))
+}
+
+// The end a Ctrl wheel jumps to: the last row scrolling down, the first scrolling up.
+function end(dir, count) {
+    return dir > 0 ? count - 1 : 0
+}

--- a/ui/js/Wheel.js
+++ b/ui/js/Wheel.js
@@ -6,14 +6,18 @@
 // modified chords reach the item level, and the same modifier has to mean the same thing over
 // both surfaces or the split between them is a bug neither file can see.
 
-// Ctrl jumps to either end, g/G's verb; Alt steps the cursor one row a notch, j/k's verb; Shift
+// Ctrl steps the cursor one row a notch, j/k's verb; Alt jumps to either end, g/G's verb; Shift
 // extends the selection the way Shift+Up/Down do. Control wins when it arrives beside another
 // modifier, and anything else — the plain wheel included — is a viewport pan the Flickable keeps.
+// The two chords are written against the modifier Qt names, and this operator's input stack
+// swaps them: a synthetic Alt arrives carrying ControlModifier and a synthetic Ctrl carrying
+// AltModifier, read back off the event's own modifiers field, so the stepper rides the modifier
+// the hand's Alt key actually delivers and the jumper the one Ctrl does.
 function meaning(modifiers) {
     if (modifiers & Qt.ControlModifier)
-        return "end"
-    if (modifiers & Qt.AltModifier)
         return "cursor"
+    if (modifiers & Qt.AltModifier)
+        return "end"
     if (modifiers & Qt.ShiftModifier)
         return "extend"
     return "viewport"

--- a/ui/js/Wheel.js
+++ b/ui/js/Wheel.js
@@ -6,18 +6,17 @@
 // modified chords reach the item level, and the same modifier has to mean the same thing over
 // both surfaces or the split between them is a bug neither file can see.
 
-// Ctrl steps the cursor one row a notch, j/k's verb; Alt jumps to either end, g/G's verb; Shift
-// extends the selection the way Shift+Up/Down do. Control wins when it arrives beside another
-// modifier, and anything else — the plain wheel included — is a viewport pan the Flickable keeps.
-// The two chords are written against the modifier Qt names, and this operator's input stack
-// swaps them: a synthetic Alt arrives carrying ControlModifier and a synthetic Ctrl carrying
-// AltModifier, read back off the event's own modifiers field, so the stepper rides the modifier
-// the hand's Alt key actually delivers and the jumper the one Ctrl does.
+// Alt steps the cursor one row a notch, j/k's verb; Ctrl jumps to either end, g/G's verb — the
+// zoom chord is the big verb, the convention every browser and editor shares. Shift extends the
+// selection the way Shift+Up/Down do. Control wins when it arrives beside another modifier, and
+// anything else — the plain wheel included — is a viewport pan the Flickable keeps. The chords
+// read the axis Wheel.axisDelta picks, because some input stacks rewrite a modified wheel onto
+// the horizontal one (this operator's does it to Alt), and the verb must follow the hand anyway.
 function meaning(modifiers) {
     if (modifiers & Qt.ControlModifier)
-        return "cursor"
-    if (modifiers & Qt.AltModifier)
         return "end"
+    if (modifiers & Qt.AltModifier)
+        return "cursor"
     if (modifiers & Qt.ShiftModifier)
         return "extend"
     return "viewport"

--- a/ui/js/Wheel.js
+++ b/ui/js/Wheel.js
@@ -34,6 +34,15 @@ function end(dir, count) {
     return dir > 0 ? count - 1 : 0
 }
 
+// The axis the event actually turned. Some input stacks deliver a modified wheel on the
+// horizontal axis — this operator's rewrites Alt+vertical-wheel as horizontal before it reaches
+// the app, modifiers intact — so a chord that reads only angleDelta.y sees zero and the verb
+// runs one way whatever the hand did. Reading the axis that moved costs nothing and is correct
+// for both the plain vertical wheel and the rewritten one.
+function axisDelta(wheel) {
+    return Math.abs(wheel.angleDelta.x) > Math.abs(wheel.angleDelta.y) ? wheel.angleDelta.x : wheel.angleDelta.y
+}
+
 // The wheel's direction as the item order reads it: a wheel-down steps to the next row, whatever
 // the user's scrolling convention is. A natural-scroll setup inverts the axis before the event
 // arrives, so the raw sign says up when the hand rolled down, and the event's own inverted flag


### PR DESCRIPTION
## What this fixes

Two operator-reported gaps, both in the same neighbourhood:

1. **The rail could not scroll.** The rail was a bare `Column` under its surface rectangle with no viewport at all, so a wheel over it did nothing, and a rail that outgrew its own height (many favourites, several mounts, a NAS and a Dropbox row) could not show its bottom rows by any means. The list's wheel verb is a pan, and the rail's is now the same one: the rows live inside a `Flickable`, the plain wheel pans, and nothing chases the cursor back — the same split of the two verbs `List.qml` draws.

2. **The arrows were dead keys while browsing.** `Left`/`Right` were bound to `seekBack`/`seekForward`, which resolve to nothing until a preview is open, so the rail was reachable only through Tab. With no preview open and no grid, `Left` in the list now steps into the rail and either arrow in the rail steps back out; Tab and Esc keep exactly what they had.

## The modified wheel, one map for both surfaces

A shared `ui/js/Wheel.js` routes the chords, because the same modifier has to mean the same thing over both surfaces or the split between them is a bug neither file can see:

| gesture | list | rail |
|---|---|---|
| plain wheel | viewport pans, cursor follows (unchanged) | viewport pans (new — this was the bug) |
| `Alt`+wheel | step the cursor a row a notch | step the rail cursor |
| `Ctrl`+wheel | jump to first/last row | jump to first/last rail row |
| `Shift`+wheel | extend the selection (`Shift+Up/Down`'s verb) | not accepted — rail rows carry no selection, so it pans |

Two environment facts the map honours, both verified by driving events and reading what the app actually received:

- the reporting operator's input stack **rewrites Alt+wheel onto the horizontal axis** (`angleDelta.x = ±120`, `angleDelta.y = 0`, modifiers intact) — caught by a probe that logged the raw event. `Wheel.axisDelta()` reads whichever axis moved, so the rewritten chord and the ordinary one answer the same verbs, on this box and everywhere else.
- a natural-scroll setup inverts the axis before the event arrives, so `Wheel.direction()` folds in the event's `inverted` flag and both surfaces step with the hand, not the raw axis.

The plain wheel is never accepted by the handler, so it falls through to the Flickable. On the list side the chords ride `Filter.moveCursor` / `Filter.setCursorView`, which already scroll the row they land on into view; on the rail side every cursor move — keyboard, chords, the clamp — reveals its row through the Flickable.

## Why a MouseArea and not a WheelHandler

The first attempt used `WheelHandler` with `acceptedModifiers`, and the chords never fired: a Flickable consumes every wheel its children sit under before any handler in the tree can answer one. Driven on a live desktop with injected wheel events carrying real modifier state, the handlers stayed silent over both the ListView and the rail while the view under them scrolled. The chords now arrive through a `MouseArea` overlay (`acceptedButtons: Qt.NoButton`, so presses and drags are untouched) which declines the plain wheel and answers the chords.

## What moved, for the budget

`ui/Sidebar.qml` was at its cap, so the change carries two cuts the budget's own story prescribes:

- the favourites merge (Home first, first position wins) moved whole to `Places.favorites`
- the rail menu's chosen-row dispatch (key, not position — the five-second-poll problem) moved to `Mounts.release`

## Tests

- `tests/js/wheel.js` checks the modifier map, the clamps, the axis fold, the direction fold, and the end each wheel direction lands on, wired into the harness beside the rest
- `tests/js/focus.js` carries the three new lookups beside the two it dropped, which had asserted the old silence
- `./tests/js.sh`: **1035 checks, 0 failed**; `tools/flea-file-budget` exits 0 (soft warnings unchanged from upstream)

Both surfaces were also driven against the installed QML on a live Hyprland desktop: the rail pans under a rail taller than the window, the plain wheel pans the list with the cursor following, Shift extends in both directions, and the arrows walk into and out of the rail.

One deliberate non-change: the grid keeps `Left`/`Right` for stepping tiles and both previews keep them for seeking and paging, so nothing that already meant something changed meaning.