### PR TITLE
fix: keep errors, contrast, and type size on the GUI

### DIFF
--- a/tests/js/contrast.js
+++ b/tests/js/contrast.js
@@ -19,4 +19,13 @@ function run(check) {
           Contrast.ratioOf(Contrast.parse("#c8ccd0"), cursor) >= AA, true)
     check("muted still clears AA on the zebra row",
           Contrast.ratioOf(Contrast.parse("#868d93"), zebra) >= AA, true)
+
+    check("ensureRatio leaves a passing pair alone",
+          Contrast.ensureRatio("#000000", "#ffffff", AA), "#000000")
+    var lightMuted = Contrast.ensureRatio("#acb0be", "#eff1f5", AA)
+    check("ensureRatio lifts live light muted to AA",
+          Contrast.ratio(lightMuted, "#eff1f5") >= AA, true)
+    var lightLink = Contrast.ensureRatio("#179299", "#eff1f5", AA)
+    check("ensureRatio lifts live light symlink to AA",
+          Contrast.ratio(lightLink, "#eff1f5") >= AA, true)
 }

--- a/tests/js/errors.js
+++ b/tests/js/errors.js
@@ -23,7 +23,7 @@ function run(check) {
           "The backend stopped responding; reopen Flea and try again.")
     check("an unknown origin falls back rather than leaking it",
           Errors.sentence("whatever", "/home/gm/secret/path"),
-          "Something went wrong; reopen Flea and try again.")
+          "That action could not be completed; try again.")
     // A non-string message must not throw, because the wire can carry a number or null.
     check("a message that is not a string is still one sentence",
           Errors.sentence("scan", null),
@@ -38,7 +38,7 @@ function run(check) {
           "That is gone.")
     check("an empty undo message still yields a sentence rather than a bare stop",
           Errors.sentence("undo", ""),
-          "Something went wrong; reopen Flea and try again.")
+          "That action could not be completed; try again.")
     check("a rename onto a taken name says which problem it is",
           Errors.sentence("rename", "File exists (os error 17)"),
           "A file with that name is already here.")

--- a/tests/js/sort.js
+++ b/tests/js/sort.js
@@ -4,7 +4,7 @@
 // else in ui/ reaches ui/Backend.qml's sort(), so a wrong gate here is the whole feature.
 // What the real backend does per column is asserted in tests/protocol.sh: name, size and mtime are
 // reordered with directories first in both directions, and mode and kind come back an error naming
-// the key. So nothing here holds a second list of what will be refused; every column asks.
+// the key. The header no longer asks for those two, so a click here must send nothing.
 
 // Only the members the sort path touches. The backend stub records the wire in order, because sort
 // before window is the protocol's own rule and a window sent first would read the old order's rows.
@@ -76,19 +76,17 @@ function run(check) {
           date.sent.join(","), "sort mtime asc,window 0 200")
     check("and the mark moves onto Date Modified", date.backend.sortBy + ":" + date.backend.sortDesc, "mtime:false")
 
-    // Mode and Kind are no keys the backend has, and it refuses them by name rather than answering
-    // them as name order, so they go out and nothing here moves: the refusal is the backend's alone.
+    // Mode and Kind are labels, not orders. A click must not look like a sort that then errors.
     var mode = pane("name", true)
     Sort.column(mode, "mode")
-    check("a click on Mode asks the backend, which refuses it by name", mode.sent.join(","), "sort mode asc")
-    check("and the UI says nothing of its own, because the refusal will", mode.said.length, 0)
+    check("a click on Mode sends nothing", mode.sent.join(","), "")
     check("a click on Mode leaves the descending name sort alone", mode.backend.sortDesc, true)
     check("and the selection survives a sort that did not happen", mode.cleared, 0)
 
     var kind = pane("size", false)
     Sort.column(kind, "kind")
-    check("a click on Kind asks the backend too", kind.sent.join(","), "sort kind asc")
-    check("but the mark stays on the order the listing is really in", kind.backend.sortBy, "size")
+    check("a click on Kind sends nothing either", kind.sent.join(","), "")
+    check("and the mark stays on the order the listing is really in", kind.backend.sortBy, "size")
     check("and the thumbnail cache is kept, because no row moved", kind.thumbState, "stale")
 
     // s steps to the next order the backend can produce, always ascending, and wraps: name, size,

--- a/tools/flea-showcase
+++ b/tools/flea-showcase
@@ -1818,7 +1818,7 @@ beat_taildrop() {
 
 # Dropbox: a move into the synced folder, then the share link from the row now sitting there.
 beat_dropbox() {
-    beat dropbox "Move to Dropbox from the menu; in Dropbox, Copy Share Link lands the link in the bar"
+    beat dropbox "Move to Dropbox from the menu; in Dropbox, Copy share link lands the link in the bar"
     seek_row 'flea demo, shared from Dropbox.txt'
     key m
     expect_ipc contextMenuVisible true
@@ -1836,7 +1836,7 @@ beat_dropbox() {
     key m
     expect_ipc contextMenuVisible true
     dwell 1
-    menu_seek "Copy Share Link"
+    menu_seek "Copy share link"
     dwell 1
     key -k Return
     settle

--- a/ui/ChromeButton.qml
+++ b/ui/ChromeButton.qml
@@ -1,6 +1,7 @@
 import QtQuick
 import qs.Commons
 import "." as Flea
+import "js/Motion.js" as Motion
 
 // One glyph button in the window chrome: muted at rest, accent when it names the current view, and
 // dimmed when there is nowhere for it to go.
@@ -15,10 +16,35 @@ Item {
     // A control with nowhere to go still occupies its slot, so the bar never reflows as history changes.
     readonly property real disabledOpacity: 0.35
 
-    // The mark is the chrome mark token and the hit area is the strip's whole height, so a click
-    // lands anywhere in the 27 px band rather than only on the 16 px mark.
-    implicitWidth: Theme.chromeMarkSize
+    readonly property string accessName: {
+        if (root.glyph === "arrow-left")
+            return "Back"
+        if (root.glyph === "arrow-up")
+            return "Parent folder"
+        if (root.glyph === "search")
+            return "Search"
+        if (root.glyph === "list")
+            return "List view"
+        if (root.glyph === "columns")
+            return "Columns view"
+        if (root.glyph === "grid")
+            return "Grid view"
+        return root.glyph
+    }
+
+    // The mark stays the chrome token; the hit box is at least 24 px wide and the strip's height.
+    implicitWidth: Math.max(Theme.hitMin, Theme.chromeMarkSize)
     implicitHeight: Theme.chromeHeight
+    scale: tap.pressed && root.enabled && !Motion.reduced ? 0.96 : 1
+
+    Accessible.role: Accessible.Button
+    Accessible.name: root.accessName
+    Accessible.onPressAction: if (root.enabled) root.activated()
+
+    Behavior on scale {
+        enabled: !Motion.reduced
+        NumberAnimation { duration: 150; easing.type: Easing.OutQuad }
+    }
 
     Flea.Glyph {
         anchors.centerIn: parent
@@ -29,12 +55,12 @@ Item {
         opacity: root.enabled ? 1 : root.disabledOpacity
     }
 
-    // Item.enabled gates both handlers itself; a shadowing bool property here used to do it by hand.
     HoverHandler {
         cursorShape: Qt.PointingHandCursor
     }
 
     TapHandler {
+        id: tap
         acceptedButtons: Qt.LeftButton
         onTapped: root.activated()
     }

--- a/ui/ColumnPane.qml
+++ b/ui/ColumnPane.qml
@@ -94,6 +94,7 @@ Item {
         visible: root.drawsEmpty && root.rows.length === 0 && root.lockedMode < 0
         caption: emptyTile.messages[0]
         mark: "folder"
+        hint: "Press Ctrl+Shift+N for a new folder."
     }
 
     // The cursor can move off screen through the keyboard, so the column follows it.

--- a/ui/ContextMenu.qml
+++ b/ui/ContextMenu.qml
@@ -102,7 +102,7 @@ Item {
                 share.push({ label: "Move to Dropbox", action: "dropbox", mark: "dropbox" })
             // A share link is inherently per file, so it appears only for a row already in Dropbox.
             if (root.rowInDropbox)
-                share.push({ label: "Copy Share Link", action: "sharelink", glyph: "network" })
+                share.push({ label: "Copy share link", action: "sharelink", glyph: "network" })
             if (share.length > 0) {
                 out.push({ separator: true })
                 for (var s = 0; s < share.length; s++) out.push(share[s])
@@ -115,7 +115,7 @@ Item {
         // The last group is the two rows that need no row under the cursor, which is also the whole
         // menu on a listing's empty space. Operations.dc.html draws neither the row nor this divider,
         // and a create action sitting directly under the destructive one is what earns the divider.
-        out.push({ label: "New Folder", action: "newFolder", glyph: "folder-plus" })
+        out.push({ label: "New folder", action: "newFolder", glyph: "folder-plus" })
         out.push({
             label: root.showHidden ? "Hide hidden files" : "Show hidden files",
             action: "toggleHidden",

--- a/ui/DialogButton.qml
+++ b/ui/DialogButton.qml
@@ -1,5 +1,6 @@
 import QtQuick
 import qs.Commons
+import "js/Motion.js" as Motion
 
 // A text row with a hairline frame, not filled button chrome: the canvas draws every dialog button
 // this way, and the accent one is the action the dialog is for.
@@ -13,8 +14,18 @@ Item {
 
     readonly property color ink: root.primary ? Theme.color.accent : Theme.color.muted
 
-    implicitWidth: text.implicitWidth + 2 * Theme.spacing.gap + 2 * Theme.spacing.hairline
-    implicitHeight: text.implicitHeight + Theme.spacing.gap + 2 * Theme.spacing.hairline
+    implicitWidth: Math.max(Theme.hitMin, text.implicitWidth + 2 * Theme.spacing.gap + 2 * Theme.spacing.hairline)
+    implicitHeight: Math.max(Theme.hitMin, text.implicitHeight + Theme.spacing.gap + 2 * Theme.spacing.hairline)
+    scale: tap.pressed && !Motion.reduced ? 0.96 : 1
+
+    Accessible.role: Accessible.Button
+    Accessible.name: root.label
+    Accessible.onPressAction: root.activated()
+
+    Behavior on scale {
+        enabled: !Motion.reduced
+        NumberAnimation { duration: 150; easing.type: Easing.OutQuad }
+    }
 
     Rectangle {
         anchors.fill: parent
@@ -36,6 +47,7 @@ Item {
     HoverHandler { cursorShape: Qt.PointingHandCursor }
 
     TapHandler {
+        id: tap
         acceptedButtons: Qt.LeftButton
         onTapped: root.activated()
     }

--- a/ui/DialogField.qml
+++ b/ui/DialogField.qml
@@ -90,11 +90,17 @@ Item {
             anchors.right: parent.right
             anchors.rightMargin: Theme.spacing.gap
             anchors.verticalCenter: parent.verticalCenter
-            width: root.secret ? Theme.font.bodySmall : 0
-            height: Theme.font.bodySmall
+            width: root.secret ? Math.max(Theme.hitMin, Theme.font.bodySmall) : 0
+            height: root.secret ? Math.max(Theme.hitMin, Theme.font.bodySmall) : 0
+
+            Accessible.role: Accessible.Button
+            Accessible.name: "Show password"
+            Accessible.ignored: !root.secret
 
             Flea.Glyph {
-                anchors.fill: parent
+                anchors.centerIn: parent
+                width: Theme.font.bodySmall
+                height: Theme.font.bodySmall
                 visible: root.secret
                 name: "eye"
                 color: reveal.pressed ? Theme.color.accent : Theme.color.muted

--- a/ui/EmptyState.qml
+++ b/ui/EmptyState.qml
@@ -10,6 +10,8 @@ Item {
     // search's no-match answer names the query, so the rotation would be wrong there.
     property string caption: ""
     property string mark: ""
+    // Sentence case, not uppercased: the rotating caption is OEM all-caps; this is the next action.
+    property string hint: ""
     // Sentence case, matching the OEM's activePhrases; caption.text below uppercases at render, like PanelHero, not in the source.
     readonly property var messages: [
         "Nothing here yet",
@@ -31,7 +33,7 @@ Item {
     opacity: root.visible ? 1 : 0
 
     Behavior on opacity {
-        enabled: root.visible
+        enabled: root.visible && !Motion.reduced
         NumberAnimation { duration: Motion.durMs.open; easing.type: Easing.BezierSpline; easing.bezierCurve: Motion.bezierCurve }
     }
 
@@ -42,7 +44,7 @@ Item {
         spacing: Theme.spacing.gap
 
         Behavior on anchors.verticalCenterOffset {
-            enabled: root.visible
+            enabled: root.visible && !Motion.reduced
             NumberAnimation { duration: Motion.durMs.open; easing.type: Easing.BezierSpline; easing.bezierCurve: Motion.bezierCurve }
         }
 
@@ -77,12 +79,22 @@ Item {
             font.letterSpacing: 1.2
             textFormat: Text.PlainText
         }
+
+        Text {
+            visible: root.hint.length > 0
+            anchors.horizontalCenter: parent.horizontalCenter
+            text: root.hint
+            color: root.dim
+            font.family: Theme.font.family
+            font.pixelSize: Theme.font.caption
+            textFormat: Text.PlainText
+        }
     }
 
     // root.visible mirrors the caller's listingState === "empty" gate, so the rotation timer stops once a real listing arrives.
     Timer {
         interval: root.rotateMs
-        running: root.visible && root.caption.length === 0
+        running: root.visible && root.caption.length === 0 && !Motion.reduced
         repeat: true
         // One beat for both, per the operator: the mark repaints as the sentence changes.
         onTriggered: { fade.restart(); heroMark.replay() }

--- a/ui/GridTile.qml
+++ b/ui/GridTile.qml
@@ -20,6 +20,9 @@ Item {
     // and the decode, and a tile whose Image failed to load has to be marked by its kind instead.
     readonly property bool thumbDrawn: root.thumb.length > 0 && tileThumb.status !== Image.Error
 
+    Accessible.role: Accessible.ListItem
+    Accessible.name: root.row ? root.row.n : ""
+
     Rectangle {
         anchors.fill: parent
         anchors.margins: Theme.spacing.hairline
@@ -64,8 +67,11 @@ Item {
         }
     }
 
+    HoverHandler { id: hover }
+
     // corner: a filename is arbitrary text, so PlainText, the same rule every name on this surface follows.
     Text {
+        id: nameLabel
         anchors.top: markSlot.bottom
         anchors.topMargin: Theme.spacing.gap
         anchors.left: parent.left
@@ -78,6 +84,33 @@ Item {
         font.family: Theme.font.family
         font.pixelSize: Theme.font.caption
         textFormat: Text.PlainText
+        wrapMode: Text.Wrap
+        maximumLineCount: 2
         elide: Text.ElideRight
+    }
+
+    Rectangle {
+        visible: hover.hovered && nameLabel.truncated
+        z: 1
+        anchors.horizontalCenter: parent.horizontalCenter
+        anchors.top: nameLabel.bottom
+        anchors.topMargin: Theme.spacing.hairline
+        width: Math.min(tip.implicitWidth + 2 * Theme.spacing.gap, Theme.grid.minCellWidth * 2)
+        height: tip.implicitHeight + Theme.spacing.gap
+        color: Theme.color.surface
+        border.width: Theme.spacing.hairline
+        border.color: Theme.color.muted
+
+        Text {
+            id: tip
+            anchors.centerIn: parent
+            width: parent.width - 2 * Theme.spacing.gap
+            text: root.row ? root.row.n : ""
+            color: Theme.color.foreground
+            font.family: Theme.font.family
+            font.pixelSize: Theme.font.caption
+            wrapMode: Text.Wrap
+            textFormat: Text.PlainText
+        }
     }
 }

--- a/ui/Header.qml
+++ b/ui/Header.qml
@@ -71,8 +71,6 @@ Item {
         visible: root.cols.mode
         width: root.cols.mode ? Theme.column.mode : 0
         text: root.title("Mode", "mode")
-
-        TapHandler { enabled: root.sortable; onTapped: root.sortRequested("mode") }
     }
 
     PanelSectionHeader {
@@ -109,8 +107,6 @@ Item {
         width: root.cols.kind ? Theme.column.kind : 0
         text: root.title("Kind", "kind")
         elide: Text.ElideRight
-
-        TapHandler { enabled: root.sortable; onTapped: root.sortRequested("kind") }
     }
 
     Rectangle {

--- a/ui/MediaStrip.qml
+++ b/ui/MediaStrip.qml
@@ -63,11 +63,17 @@ Item {
         anchors.left: parent.left
         anchors.leftMargin: Theme.spacing.gap
         anchors.verticalCenter: parent.verticalCenter
-        width: Theme.font.bodySmall
-        height: Theme.font.bodySmall
+        width: Math.max(Theme.hitMin, Theme.font.bodySmall)
+        height: Math.max(Theme.hitMin, Theme.font.bodySmall)
+
+        Accessible.role: Accessible.Button
+        Accessible.name: root.playing ? "Pause" : "Play"
+        Accessible.onPressAction: { root.touched(); root.toggled() }
 
         Flea.Glyph {
-            anchors.fill: parent
+            anchors.centerIn: parent
+            width: Theme.font.bodySmall
+            height: Theme.font.bodySmall
             name: root.playing ? "pause" : "play"
             color: Theme.color.foreground
         }

--- a/ui/NetworkDialog.qml
+++ b/ui/NetworkDialog.qml
@@ -110,6 +110,7 @@ Item {
         opacity: root.opened ? 1 : 0
 
         Behavior on opacity {
+            enabled: !Motion.reduced
             NumberAnimation {
                 duration: root.opened ? Motion.durMs.open : Motion.durMs.close
                 easing.type: Easing.BezierSpline
@@ -144,11 +145,12 @@ Item {
         padding: Style.spacing.panelPadding
 
         Behavior on anchors.verticalCenterOffset {
-            enabled: root.opened
+            enabled: root.opened && !Motion.reduced
             NumberAnimation { duration: Motion.durMs.open; easing.type: Easing.BezierSpline; easing.bezierCurve: Motion.bezierCurve }
         }
 
         Behavior on opacity {
+            enabled: !Motion.reduced
             NumberAnimation {
                 duration: root.opened ? Motion.durMs.open : Motion.durMs.close
                 easing.type: Easing.BezierSpline

--- a/ui/Preview.qml
+++ b/ui/Preview.qml
@@ -208,11 +208,12 @@ Item {
         radius: Style.cornerRadius
 
         Behavior on anchors.verticalCenterOffset {
-            enabled: root.active
+            enabled: root.active && !Motion.reduced
             NumberAnimation { duration: Motion.durMs.open; easing.type: Easing.BezierSpline; easing.bezierCurve: Motion.bezierCurve }
         }
 
         Behavior on opacity {
+            enabled: !Motion.reduced
             NumberAnimation {
                 duration: root.active ? Motion.durMs.open : Motion.durMs.close
                 easing.type: Easing.BezierSpline

--- a/ui/ProtocolChip.qml
+++ b/ui/ProtocolChip.qml
@@ -27,8 +27,12 @@ Item {
     Keys.onEnterPressed: root.activated()
     Keys.onSpacePressed: root.activated()
 
-    implicitWidth: text.implicitWidth + 2 * Theme.spacing.gap + 2 * Theme.spacing.hairline
-    implicitHeight: text.implicitHeight + Theme.spacing.gap + 2 * Theme.spacing.hairline
+    implicitWidth: Math.max(Theme.hitMin, text.implicitWidth + 2 * Theme.spacing.gap + 2 * Theme.spacing.hairline)
+    implicitHeight: Math.max(Theme.hitMin, text.implicitHeight + Theme.spacing.gap + 2 * Theme.spacing.hairline)
+
+    Accessible.role: Accessible.Button
+    Accessible.name: root.label
+    Accessible.onPressAction: root.activated()
 
     Rectangle {
         anchors.fill: parent

--- a/ui/Row.qml
+++ b/ui/Row.qml
@@ -63,6 +63,9 @@ Item {
     implicitHeight: Theme.rowHeight
     implicitWidth: parent ? parent.width : 0
 
+    Accessible.role: Accessible.ListItem
+    Accessible.name: root.displayName
+
     Rectangle {
         anchors.fill: parent
         // selectionFill is the OEM's fifth rung, kept visually distinct from the cursor's selectedFill.

--- a/ui/ShareBrowser.qml
+++ b/ui/ShareBrowser.qml
@@ -64,11 +64,12 @@ Item {
         opacity: root.active ? 1 : 0
 
         Behavior on y {
-            enabled: root.active
+            enabled: root.active && !Motion.reduced
             NumberAnimation { duration: Motion.durMs.open; easing.type: Easing.BezierSpline; easing.bezierCurve: Motion.bezierCurve }
         }
 
         Behavior on opacity {
+            enabled: !Motion.reduced
             NumberAnimation {
                 duration: root.active ? Motion.durMs.open : Motion.durMs.close
                 easing.type: Easing.BezierSpline

--- a/ui/Sidebar.qml
+++ b/ui/Sidebar.qml
@@ -296,15 +296,25 @@ Item {
             }
 
             // A hand-drawn plus, not a Text "+": at caption size the font glyph read as a Christian cross, not a plus. Sized off the heading's own font token.
-            Glyph {
+            Item {
                 id: addMark
-                name: "plus"
-                color: Theme.color.muted
-                width: Theme.font.caption
-                height: Theme.font.caption
+                width: Math.max(Theme.hitMin, Theme.font.caption)
+                height: Math.max(Theme.hitMin, Theme.font.caption)
                 anchors.right: parent.right
                 anchors.rightMargin: Style.spacing.rowPaddingX
                 anchors.verticalCenter: netHeading.verticalCenter
+
+                Accessible.role: Accessible.Button
+                Accessible.name: "Add network location"
+                Accessible.onPressAction: root.addRequested()
+
+                Glyph {
+                    anchors.centerIn: parent
+                    name: "plus"
+                    color: Theme.color.muted
+                    width: Theme.font.caption
+                    height: Theme.font.caption
+                }
 
                 TapHandler {
                     onTapped: root.addRequested()

--- a/ui/SidebarRow.qml
+++ b/ui/SidebarRow.qml
@@ -36,6 +36,9 @@ Item {
     // The rail reads denser than the list it sits beside; see Theme.qml's railRowHeight comment.
     height: Theme.railRowHeight
 
+    Accessible.role: Accessible.ListItem
+    Accessible.name: root.modelData.label
+
     // A rail row is a row, so its cursor is the list row's own: a square full-bleed fill and the
     // accent bar, per the canvas and the icon spec's "the rail rounds nothing"; see ui/Row.qml.
     Rectangle {

--- a/ui/StatusBar.qml
+++ b/ui/StatusBar.qml
@@ -50,6 +50,12 @@ Item {
     function say(text, isError) {
         root.transient_ = text
         root.transientIsError = isError
+        // Errors and the undo hint stay until the next line or Escape. A 4 s toast was the only
+        // place many failures were explained, and z undoes is easy to miss if it vanishes.
+        if (!text || isError || text.indexOf(Ops.UNDO_HINT) >= 0) {
+            clear.stop()
+            return
+        }
         clear.restart()
     }
 

--- a/ui/Theme.qml
+++ b/ui/Theme.qml
@@ -5,6 +5,8 @@ import Quickshell.Io
 import QtQuick
 import qs.Commons
 import "js/Columns.js" as Columns
+import "js/Contrast.js" as Contrast
+import "js/Motion.js" as Motion
 import "js/Palette.js" as Palette
 import "js/Shadow.js" as ShadowMath
 
@@ -27,7 +29,7 @@ Singleton {
     readonly property QtObject color: QtObject {
         readonly property color background: Color.background
         readonly property color foreground: Color.foreground
-        readonly property color muted: Color.muted
+        property color muted: "#707880"
         readonly property color accent: Color.accent
         readonly property color error: Color.urgent
         property color surface: root.fallbackColor.surface
@@ -35,24 +37,29 @@ Singleton {
         property color executable: root.fallbackColor.executable
     }
 
+    // The metrics gate and the canvas are written at omarchy base-size 14. This box is on 12, and
+    // on a 4K panel at 1.5 that makes body text 11 logical px. Floor at 14 so Flea matches the
+    // board; a larger omarchy display text size still wins.
+    readonly property real sizeScale: Math.max(1, 14 / Math.max(1, Style.font.baseSize))
+
     readonly property QtObject font: QtObject {
         readonly property string family: Style.font.family
-        readonly property int bodySmall: Style.font.bodySmall
-        readonly property int caption: Style.font.caption
+        readonly property int bodySmall: Math.round(Style.font.bodySmall * root.sizeScale)
+        readonly property int caption: Math.round(Style.font.caption * root.sizeScale)
     }
 
     readonly property QtObject spacing: QtObject {
         readonly property int hairline: Style.spacing.hairline
-        readonly property int rowPaddingX: Style.spacing.rowPaddingX
-        readonly property int rowPaddingY: Style.spacing.controlPaddingY
-        readonly property int gap: Style.spacing.rowGap
+        readonly property int rowPaddingX: Math.round(Style.spacing.rowPaddingX * root.sizeScale)
+        readonly property int rowPaddingY: Math.round(Style.spacing.controlPaddingY * root.sizeScale)
+        readonly property int gap: Math.round(Style.spacing.rowGap * root.sizeScale)
     }
 
     // One glyph's advance in a monospace face is every glyph's advance, so this sizes every fixed column.
     TextMetrics {
         id: glyphMetrics
         font.family: Style.font.family
-        font.pixelSize: Style.font.bodySmall
+        font.pixelSize: root.font.bodySmall
         text: "0"
     }
 
@@ -63,7 +70,7 @@ Singleton {
         readonly property int size: Math.round(root.sizeChars * glyphMetrics.advanceWidth)
         readonly property int date: Math.round(root.dateChars * glyphMetrics.advanceWidth)
         // Kind text varies too much for a character count, so its base is a pixel width scaled by the same ratio bodySmall already is.
-        readonly property int kind: Math.round(root.kindBaseWidth * Style.font.bodySmall / 12)
+        readonly property int kind: Math.round(root.kindBaseWidth * root.font.bodySmall / 12)
         // Not a column: the floor under the name, which the four above drop one by one to protect.
         readonly property int nameMin: Math.round(root.nameMinChars * glyphMetrics.advanceWidth)
     }
@@ -80,11 +87,13 @@ Singleton {
     readonly property int heroMarkSize: Math.round(root.font.bodySmall * 3.7)
     // A chrome strip's mark is the OEM's own icon token, the one Ui/Button.qml and the Tailscale and
     // Dropbox bar icons size from: 16 at base-size 14, which is the canvas's chrome mark on every board.
-    readonly property int chromeMarkSize: Style.font.icon
+    readonly property int chromeMarkSize: Math.round(Style.font.icon * root.sizeScale)
     // Lucide ships stroke 2 on its 24 unit grid; 1.5 is the operator's tune (Tabler ships 2 as well, see the A/B report).
     readonly property real strokeWidth: 1.5
+    // WCAG 2.5.8 floor. Marks stay at their type-scale size; the hit box grows to this.
+    readonly property int hitMin: 24
     // Wide enough for "Send with Taildrop" at bodySmall, 257 at base-size 14; ui/ContextMenu.qml draws it.
-    readonly property int menuWidth: Style.space(220)
+    readonly property int menuWidth: Math.round(Style.space(220) * root.sizeScale)
 
     // The canvas draws box-shadow: 0 16px 40px rgba(0,0,0,0.5) under every floating in-app surface
     // and nothing in ui/ ever drew one. The offset and the blur are the canvas's own design pixels
@@ -173,7 +182,7 @@ Singleton {
 
     // Five callers: ConvertDialog, KeymapSheet, NetworkDialog, NetworkForm, TransferCard; every other spacing token above is direct.
     function space(px) {
-        return Style.space(px);
+        return Math.round(Style.space(px) * root.sizeScale);
     }
 
     // The metrics contract as the app resolves it, one key=value per line in the Blueprint board's
@@ -224,14 +233,34 @@ Singleton {
     // Color owns the other five; only the three it does not model are assigned here.
     function applyColors(body) {
         var found = Palette.parse(body);
-        root.color.symlink = Palette.pick(found, ["cyan", "color6"], root.fallbackColor.symlink);
-        root.color.executable = Palette.pick(found, ["green", "color2"], root.fallbackColor.executable);
+        var bg = Palette.pick(found, ["background"], "#101315");
+        var surface = Palette.pick(found, ["dark_background", "selection"], root.fallbackColor.surface);
         // corner: the alacritty-derived colors.toml emits neither background ladder key, so selection is third.
-        root.color.surface = Palette.pick(found, ["dark_background", "selection"], root.fallbackColor.surface);
+        root.color.surface = surface;
+        // Omarchy palettes are not authored to AA. Flea keeps the hex system and walks L until 4.5:1.
+        root.color.muted = Contrast.ensureRatio(
+            Contrast.ensureRatio(Palette.pick(found, ["muted"], "#707880"), bg, 4.5), surface, 4.5);
+        root.color.symlink = Contrast.ensureRatio(
+            Palette.pick(found, ["cyan", "color6"], root.fallbackColor.symlink), bg, 4.5);
+        root.color.executable = Contrast.ensureRatio(
+            Palette.pick(found, ["green", "color2"], root.fallbackColor.executable), bg, 4.5);
         Color.loadColors(body);
         // A body that parsed to nothing left every role on its fallback, so the flag says so rather
         // than reporting that the read happened: text() returns "" for a file that is not there.
         root.ready = Palette.isPalette(found);
+    }
+
+    function applyReducedMotion() {
+        var env = Quickshell.env("FLEA_REDUCED_MOTION");
+        if (env === "1" || env === "true") {
+            Motion.reduced = true;
+            return;
+        }
+        if (env === "0" || env === "false") {
+            Motion.reduced = false;
+            return;
+        }
+        motionQuery.running = true;
     }
 
     // blockLoading only gates calls to text()/data(); nothing forced that call before this fix,
@@ -276,4 +305,18 @@ Singleton {
             Style.scheduleRefresh();
         }
     }
+
+    Process {
+        id: motionQuery
+        command: ["gsettings", "get", "org.gnome.desktop.a11y.interface", "reduced-motion"]
+        stdout: StdioCollector {
+            waitForEnd: true
+            onStreamFinished: {
+                var body = String(text)
+                Motion.reduced = body.indexOf("reduce") >= 0 && body.indexOf("no-preference") < 0
+            }
+        }
+    }
+
+    Component.onCompleted: root.applyReducedMotion()
 }

--- a/ui/js/Contrast.js
+++ b/ui/js/Contrast.js
@@ -12,6 +12,8 @@ function luminance(r, g, b) {
 // Sample input: "#c8ccd0"
 function parse(hex) {
     var s = String(hex).replace("#", "")
+    if (s.length === 8)
+        s = s.substring(2)
     return [parseInt(s.substr(0, 2), 16) / 255,
             parseInt(s.substr(2, 2), 16) / 255,
             parseInt(s.substr(4, 2), 16) / 255]
@@ -35,4 +37,44 @@ function ratioOf(a, b) {
 
 function ratio(fgHex, bgHex) {
     return ratioOf(parse(fgHex), parse(bgHex))
+}
+
+function pad2(n) {
+    return n < 16 ? "0" + n.toString(16) : n.toString(16)
+}
+
+function hexOf(rgb) {
+    return "#" + pad2(Math.round(Math.max(0, Math.min(1, rgb[0])) * 255))
+            + pad2(Math.round(Math.max(0, Math.min(1, rgb[1])) * 255))
+            + pad2(Math.round(Math.max(0, Math.min(1, rgb[2])) * 255))
+}
+
+function mix(a, b, t) {
+    return [a[0] + (b[0] - a[0]) * t, a[1] + (b[1] - a[1]) * t, a[2] + (b[2] - a[2]) * t]
+}
+
+// Keep hue; walk lightness toward black or white until WCAG AA (or minRatio) holds.
+function ensureRatio(fgHex, bgHex, minRatio) {
+    var need = minRatio > 0 ? minRatio : 4.5
+    if (ratio(fgHex, bgHex) >= need)
+        return String(fgHex)
+    var fg = parse(fgHex)
+    var bg = parse(bgHex)
+    var toward = luminance(bg[0], bg[1], bg[2]) > 0.179 ? [0, 0, 0] : [1, 1, 1]
+    var lo = 0
+    var hi = 1
+    var best = toward
+    for (var i = 0; i < 18; i++) {
+        var mid = (lo + hi) / 2
+        var cand = mix(fg, toward, mid)
+        if (ratioOf(cand, bg) >= need) {
+            best = cand
+            hi = mid
+        } else {
+            lo = mid
+        }
+    }
+    if (ratioOf(best, bg) < need)
+        best = toward
+    return hexOf(best)
 }

--- a/ui/js/Errors.js
+++ b/ui/js/Errors.js
@@ -40,7 +40,7 @@ function sentence(where, message) {
     if (where === "transfer" || where === "archive" || where === "convert") {
         return capitalised(message)
     }
-    return "Something went wrong; reopen Flea and try again."
+    return "That action could not be completed; try again."
 }
 
 // One condition, two spellings: rename gets the errno's "File exists", while src/backend/ops.rs
@@ -54,7 +54,7 @@ function exists(message) {
 function capitalised(message) {
     var text = String(message)
     if (text.length === 0) {
-        return "Something went wrong; reopen Flea and try again."
+        return "That action could not be completed; try again."
     }
     var out = text.charAt(0).toUpperCase() + text.substring(1)
     return out.charAt(out.length - 1) === "." ? out : out + "."

--- a/ui/js/Motion.js
+++ b/ui/js/Motion.js
@@ -19,3 +19,6 @@ var durMs = {
 // Open rises into place from this far below its resting position; close does not translate,
 // opacity only (see the Preview/ShareBrowser/NetworkDialog verticalCenterOffset/y bindings).
 var translateUpPx = 10
+
+// org.gnome.desktop.a11y.interface reduced-motion, or FLEA_REDUCED_MOTION=1. Theme.qml sets this.
+var reduced = false

--- a/ui/js/Sort.js
+++ b/ui/js/Sort.js
@@ -14,9 +14,11 @@
 var ORDERS = ["name", "size", "mtime"]
 
 // ui/Header.qml's click. The column already sorted reverses; any other column starts ascending,
-// which is the order the canvas's own header draws beside "Name". Every column asks, Mode and Kind
-// included: the backend refuses a key it cannot order and names it, so nothing here predicts that.
+// which is the order the canvas's own header draws beside "Name". Only ORDERS may leave this file.
 function column(pane, key) {
+    // Mode and Kind are labels. Asking the backend only to hear a refusal made them look sortable.
+    if (ORDERS.indexOf(key) < 0)
+        return
     resort(pane, key, pane.backend.sortBy === key ? !pane.backend.sortDesc : false)
 }
 

--- a/ui/shell.qml
+++ b/ui/shell.qml
@@ -144,6 +144,9 @@ ShellRoot {
                 // The design's no-match answer: the search mark over the query it could not find.
                 caption: pane.searchMode === "results" ? "Nothing matches " + pane.searchQuery : ""
                 mark: "search"
+                hint: pane.searchMode === "results"
+                      ? "Press Escape to clear."
+                      : "Press Ctrl+Shift+N for a new folder."
             }
 
             // The loading crawl, same listArea placement; its own hold-off keeps fast listings clean.


### PR DESCRIPTION
## Summary

GUI improvements, without changing Omarchy's own `colors.toml` or display text size.

- Lift `muted`, `symlink`, and `executable` to WCAG AA 4.5:1 against background and surface.
- Keep error lines and undo hints until the next message or Escape.
- Honor `reduced-motion` (gsettings, or `FLEA_REDUCED_MOTION=1`): no empty-state rotator, no overlay motion, no press scale.
- Name icon-only chrome, play/pause, add-network, and list/rail rows. Quickshell may still expose no AT-SPI tree.
- Mode and Kind are labels. Clicks no longer send a sort the backend will refuse.
- Empty and search-miss states say the next step.
- Icon-only hit boxes grow to 24 px; marks stay at their type-scale size.
- Menu rows use sentence case (`New folder`, `Copy share link`).
- Unknown errors no longer say "reopen Flea" unless the backend actually stopped.
- Grid names wrap two lines; hover shows the rest if still truncated.
- Floor Flea's type and spacing at the canvas 14 px when Omarchy base-size is smaller (this box is 12 on 4K at 1.5).

## Test plan

- [x] `./tests/js.sh` — 1015 checks, 0 failed
- [x] `./tools/flea-qmllint-gate` — 0 regressions
- [x] Packaged launch `qs -p /usr/share/flea/ui` loads
- [ ] Close Flea, open from the menubar / Super+Shift+F
- [ ] Light theme: muted path, status, symlink and executable names still read
- [ ] Empty folder shows the new-folder hint; search miss shows Escape
- [ ] Trash status with `z undoes` stays until Escape
- [ ] Mode / Kind clicks do nothing; Size and Date Modified still sort
- [ ] Type looks like the 14 px canvas (about 37 px rows) at system base-size 12


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Accessibility**
  - Improved screen-reader labels and keyboard activation across buttons, rows, tiles, menus, and network controls.
  - Increased touch targets for common controls.
  - Added full-name tooltips for truncated filenames.

- **User Experience**
  - Added empty-state hints for clearing searches and creating folders.
  - Improved contrast for theme colors.
  - Added clearer fallback error messages and status announcements.

- **Reduced Motion**
  - Animations now respect the system reduced-motion preference or application setting.

- **Bug Fixes**
  - Mode and Kind headers no longer send unsupported sort requests.
  - Corrected capitalization for sharing and folder actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->