### PR TITLE
feat: add directory tabs in the window

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -445,6 +445,7 @@ huge pages" below for what it is worth and what it cost.
   `flea --open`, see "Opening a file".
 - `ui/ContextMenu.qml` is the one pane-owned right-click popup and its single Open action.
 - `ui/StatusBar.qml` renders the path, row counts and transient messages.
+- `ui/TabBar.qml` is the window's tab strip, hidden with no height until a second tab exists.
 - `keys.toml` is the one key table, and `tools/flea-keymap-gen` turns it into `Keymap.js`.
 - `ui/js/Keymap.js` is the generated key-to-action lookup and imports no QML.
 - `ui/js/Format.js` is the pure size, date and permission formatter.
@@ -453,6 +454,7 @@ huge pages" below for what it is worth and what it cost.
   its own.
 - `ui/js/Thumbs.js` is the pure row-to-path map and the visible-row request plan, and
   imports no QML so `./tests/js.sh` can redden on a mutation.
+- `ui/js/Tabs.js` is the directory-tab snapshots and the t/w/1-9 policy, and imports no QML.
 
 ## Where the backend binary comes from
 
@@ -2727,9 +2729,11 @@ filename as rich text, so it is never safe for backend-provided names.
 
 The rule, applied on 2026-09-02 after two silent-by-accident keys and one silent-by-design: every
 row in `keys.toml` either works or says why it does not, in a sentence written for the user and
-never an action name. `t`, `w` and `1` to `9` (tabs) and `:` (the path bar), all drawn on the Tui
-board, stay in the table and `Focus.act` answers them with `Tabs are not built yet.` and `The path
-bar is not built yet.`; the old `lookup` gate that dropped `:` in silence is gone. The generic
+never an action name. `:` (the path bar), drawn on the Tui board, stays in the table and
+`Focus.act` answers it with `The path bar is not built yet.`; the old `lookup` gate that dropped
+`:` in silence is gone. `t`, `w` and `1` to `9` open, close and switch directory tabs: one live
+listing, a snapshot per hidden tab, the strip only once there are two. Closing the last tab is
+refused. Nine is the cap, because those digits are the jump keys. The generic
 `<action> is not built yet.` fallback below those stays as the loud failure for a row the
 dispatcher does not answer, and should never be reachable from the shipped table. `Ctrl+Shift+N`
 was on this list for one afternoon and is not on it now: `295e757` routed the action through

--- a/README.md
+++ b/README.md
@@ -475,6 +475,9 @@ and the application cannot disagree.
 | `s`, `S` | Step the sort column, reverse the sort |
 | `.`, Ctrl-Shift-. | Show hidden files |
 | Tab | Move focus between the rail and the view |
+| `t` | Open a new tab at the current folder |
+| `w` | Close the current tab |
+| `1`–`9` | Switch to that tab |
 | Escape | Cancel a search, clear the filter, drop the selection, clear the status line |
 
 Finder hands land: every Cmd chord above is its Ctrl twin, added beside the vim key rather
@@ -516,9 +519,11 @@ hides leaves the selection with it, because a selection you cannot see is one yo
 on by accident. It filters the rows the pane holds, and says so in the strip when that is
 less than the whole directory.
 
-Bound ahead of their features, and saying so until they land: `:` for the path bar, and `t`,
-`w` and `1` through `9` for tabs, all drawn on the TUI board. Each answers with a sentence in
-the status line rather than doing nothing.
+Bound ahead of its feature, and saying so until it lands: `:` for the path bar, drawn on the TUI
+board. It answers with a sentence in the status line rather than doing nothing. `t` opens a new
+tab at the current folder, `w` closes the current one, and `1` through `9` switch. The tab strip
+shows only when there are two or more, so a single listing keeps the chrome the first paint uses.
+The last tab cannot close; the window still closes with the compositor's close chord.
 
 ## Testing
 

--- a/tests/js/focus.js
+++ b/tests/js/focus.js
@@ -145,18 +145,12 @@ function run(check) {
     Focus.previewAct("parent", { preview: reader })
     check("l turns the page forward and h turns it back", reader.page, 1)
 
-    // Bound ahead of their features, by the rule that a mapped key says why rather than doing nothing:
-    // the Tui board draws a typeable path bar on colon and tabs on t, w and the digits. lookup lets
-    // them through and act answers each with a sentence written for the user, never an action name.
+    // Bound ahead of its feature: the Tui board draws a typeable path bar on colon.
     var colon = key(Qt.Key_Colon, ":", shift)
     check("colon reaches act until the path bar exists", Focus.lookup(colon, pane(closed())), "palette")
     var early = listPane(true)
     Focus.act("palette", early)
     check("colon says the path bar is not built", early.said, "The path bar is not built yet.")
-    Focus.act("tabNew", early)
-    check("t says tabs are not built, in words and not an action name", early.said, "Tabs are not built yet.")
-    Focus.act("tab3", early)
-    check("a digit says the same", early.said, "Tabs are not built yet.")
 
     // The filter narrows rows already on screen, which only the list view draws; the GridView and
     // Columns boards draw no filter, so / is dropped there rather than narrowing a view nothing shows.

--- a/tests/js/harness.qml
+++ b/tests/js/harness.qml
@@ -25,6 +25,7 @@ import "shadow.js" as ShadowSuite
 import "sort.js" as SortSuite
 import "taildrop.js" as TaildropSuite
 import "tap.js" as TapSuite
+import "tabs.js" as TabsSuite
 import "thumbs.js" as ThumbsSuite
 
 Item {
@@ -66,6 +67,7 @@ Item {
         SortSuite.run(check)
         TaildropSuite.run(check)
         TapSuite.run(check)
+        TabsSuite.run(check)
         ThumbsSuite.run(check)
 
         for (var i = 0; i < failures.length; i++) {

--- a/tests/js/tabs.js
+++ b/tests/js/tabs.js
@@ -1,0 +1,123 @@
+.import "../../ui/js/Selection.js" as Selection
+.import "../../ui/js/Tabs.js" as Tabs
+
+function pane(path) {
+    var p = {
+        path: path || "/home/gm/Work",
+        home: "/home/gm",
+        history: ["/home/gm"],
+        cursorIndex: 4,
+        viewMode: "list",
+        showHidden: false,
+        searchMode: "",
+        searchFrom: "",
+        searchQuery: "",
+        searchRunning: false,
+        searchCancelled: false,
+        searchScanned: 0,
+        filterQuery: "",
+        filterTyping: false,
+        listInFlight: false,
+        tabs: null,
+        total: 20,
+        windowSize: 40,
+        said: [],
+        listed: [],
+        sorted: [],
+        windows: [],
+        preview: { active: false, closed: 0, close: function () { this.active = false; this.closed += 1 } },
+        selection: Selection.create(),
+        selectionVersion: 0
+    }
+    p.selectedIndices = function () { return p.selection.indices() }
+    p.clearSelection = function () { p.selection.clear(); p.selectionVersion++ }
+    p.setCursor = function (i) { p.cursorIndex = i }
+    p.message = function (text) { p.said.push(text) }
+    p.openWithoutHistory = function (next) { p.listed.push(next); p.path = next; p.cursorIndex = 0 }
+    p.backend = {
+        sortBy: "name",
+        sortDesc: false,
+        sort: function (by, desc) { p.sorted.push(by + ":" + desc); this.sortBy = by; this.sortDesc = desc },
+        window: function (start, count) { p.windows.push(start + ":" + count) },
+        searchcancel: function () { p.searchRunning = false }
+    }
+    return p
+}
+
+function run(check) {
+    check("a root tab is labelled with its separator", Tabs.label("/", ""), "/")
+    check("the home directory uses the rail's own Home label", Tabs.label("/home/gm", "/home/gm"), "Home")
+    check("a home child is labelled with its leaf, not the tilde form",
+          Tabs.label("/home/gm/Work", "/home/gm"), "Work")
+    check("one pane with no tab state still counts as one tab", Tabs.count(pane()), 1)
+
+    var born = pane()
+    Tabs.act("tabNew", born)
+    check("t seeds the current folder and opens a second tab on it", Tabs.count(born), 2)
+    check("and lands on the new tab", Tabs.currentIndex(born), 1)
+    check("and does not re-list, because both tabs name the same directory", born.listed.length, 0)
+
+    born.path = "/home/gm/Downloads"
+    check("a navigate updates the current tab's label without a switch",
+          Tabs.labelAt(born, 1), "Downloads")
+    check("and leaves the other tab's snapshot alone", Tabs.labelAt(born, 0), "Work")
+
+    Tabs.act("tab1", born)
+    check("1 switches to the first tab", Tabs.currentIndex(born), 0)
+    check("and lists the snapshot path, because it is a different directory",
+          born.listed.join(","), "/home/gm/Work")
+    check("and keeps the cursor to restore after rows arrive", born.tabs.pendingCursor, 4)
+
+    Tabs.applyPending(born)
+    check("the pending cursor lands once rows arrive", born.cursorIndex, 4)
+
+    var missing = pane()
+    Tabs.act("tab3", missing)
+    check("a digit with no such tab says so in words", missing.said.join(""), "No tab 3.")
+
+    var last = pane()
+    Tabs.act("tabClose", last)
+    check("w on the only tab refuses rather than closing the window",
+          last.said.join(""), "Can't close the last tab.")
+
+    var pair = pane("/home/gm/a")
+    Tabs.act("tabNew", pair)
+    pair.path = "/home/gm/b"
+    Tabs.act("tabClose", pair)
+    check("w on a second tab leaves one", Tabs.count(pair), 1)
+    check("and lists the tab that remains", pair.listed.join(","), "/home/gm/a")
+
+    var capped = pane()
+    var n
+    for (n = 0; n < 12; n++)
+        Tabs.act("tabNew", capped)
+    check("the ninth tab is the last one t will open", Tabs.count(capped), 9)
+    check("and the tenth says so", capped.said[capped.said.length - 1], "Nine tabs is the most.")
+
+    var loading = pane()
+    loading.listInFlight = true
+    Tabs.act("tabNew", loading)
+    check("t while a listing is in flight uses the same sentence navigation does",
+          loading.said.join(""), "A directory is already loading.")
+
+    var previewing = pane()
+    previewing.preview.active = true
+    Tabs.act("tabNew", previewing)
+    check("t closes an open preview, so the new tab is not sitting under one",
+          previewing.preview.closed, 1)
+
+    var pending = pane("/home/gm/a")
+    pending.tabs = {
+        items: [],
+        index: 0,
+        pendingCursor: 9,
+        pendingSelected: null,
+        pendingSortBy: "size",
+        pendingSortDesc: true
+    }
+    Tabs.applyPending(pending)
+    check("a pending size order is asked for before the cursor is restored",
+          pending.sorted.join(",") + "|" + pending.cursorIndex, "size:true|4")
+    Tabs.applyPending(pending)
+    check("the next rows reply restores the cursor", pending.cursorIndex, 9)
+}

--- a/tests/ui.sh
+++ b/tests/ui.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Drives the real Quickshell window with omarchy-drive and asserts through the read-only IPC seam.
-# Usage: ./tests/ui.sh [cursor|terminal|open|click|menu|hidden|selection|select|colour|lifted|icons|thumbs|hashcache|stale|nosweep|oem|header|overflow|focus|preview|network|sharebrowser|unmount|eject|rename|renamelife|taildrop|grid|columns|operations ...]; no argument runs all thirty.
+# Usage: ./tests/ui.sh [cursor|terminal|open|click|menu|hidden|selection|select|colour|lifted|icons|thumbs|hashcache|stale|nosweep|oem|header|overflow|focus|preview|network|sharebrowser|unmount|eject|rename|renamelife|taildrop|grid|columns|operations|tabs ...]; no argument runs all thirty-one.
 set -u
 set -o pipefail
 # Hard rule 9's guard, which owns FIXTURE_ROOT and every create and delete this suite makes.
@@ -1750,6 +1750,54 @@ case_focus() {
     kill_flea
 }
 
+# Catches t not opening a tab, 1-9 not switching, w not closing, or the bar showing with one tab.
+case_tabs() {
+    local dir="$fixture_root/tabs"
+    sandbox_scratch "$dir"
+    mkdir -p "$dir/alpha" "$dir/beta"
+    : > "$dir/note.txt"
+    launch "$dir"
+    wait_listing 3
+    [[ "$(ipc tabCount)" == "1" ]] || fail "tabs: started with $(ipc tabCount) tabs, not 1"
+    [[ "$(ipc tabBarVisible)" == "false" ]] || fail "tabs: the bar showed with one tab"
+    key t >/dev/null
+    settle
+    [[ "$(ipc tabCount)" == "2" ]] || fail "tabs: t did not open a second tab, count=$(ipc tabCount)"
+    [[ "$(ipc tabBarVisible)" == "true" ]] || fail "tabs: the bar stayed hidden after t"
+    [[ "$(ipc tabIndex)" == "1" ]] || fail "tabs: t did not land on the new tab, index=$(ipc tabIndex)"
+    seek_row_named "alpha" || fail "tabs: could not find alpha"
+    key -k Return >/dev/null
+    wait_path "$dir/alpha"
+    key 1 >/dev/null
+    wait_path "$dir"
+    [[ "$(ipc tabIndex)" == "0" ]] || fail "tabs: 1 did not return to the first tab, index=$(ipc tabIndex)"
+    key 2 >/dev/null
+    wait_path "$dir/alpha"
+    [[ "$(ipc tabIndex)" == "1" ]] || fail "tabs: 2 did not return to the second tab, index=$(ipc tabIndex)"
+    key w >/dev/null
+    wait_path "$dir"
+    [[ "$(ipc tabCount)" == "1" ]] || fail "tabs: w did not close the current tab, count=$(ipc tabCount)"
+    [[ "$(ipc tabBarVisible)" == "false" ]] || fail "tabs: the bar stayed up after the last extra tab closed"
+    key w >/dev/null
+    wait_message "Can't close the last tab."
+    key 3 >/dev/null
+    wait_message "No tab 3."
+    shot tabs-one
+    key t >/dev/null
+    settle
+    local centre cx cy wx wy
+    centre=$(ipc tabCentre 0)
+    [[ -n "$centre" ]] || fail "tabs: tab 0 has no centre"
+    read -r cx cy <<< "$centre"
+    read -r wx wy _ww _wh < <(window_box)
+    omarchy-drive click "$((cx + wx))" "$((cy + wy))" >/dev/null
+    settle
+    [[ "$(ipc tabIndex)" == "0" ]] || fail "tabs: clicking tab 0 did not select it, index=$(ipc tabIndex)"
+    shot tabs-two
+    printf 'TABS count=%s index=%s labels=%s\n' "$(ipc tabCount)" "$(ipc tabIndex)" "$(ipc tabLabels)"
+    kill_flea
+}
+
 # Catches Space not opening a preview, the kind dispatch misclassifying a row, or the size gate not firing.
 case_preview() {
     command -v ffmpeg >/dev/null || fail "ffmpeg is missing, so the mp4 fixture cannot be built"
@@ -2941,7 +2989,7 @@ cache_snapshot
 trap cleanup EXIT
 
 declare -a wanted=("$@")
-[[ ${#wanted[@]} -eq 0 ]] && wanted=(cursor terminal open click menu hidden selection select colour lifted icons thumbs hashcache stale nosweep oem header overflow focus preview network sharebrowser unmount eject rename renamelife taildrop grid columns operations)
+[[ ${#wanted[@]} -eq 0 ]] && wanted=(cursor terminal open click menu hidden selection select colour lifted icons thumbs hashcache stale nosweep oem header overflow focus preview network sharebrowser unmount eject rename renamelife taildrop grid columns operations tabs)
 
 : > "$run_log"
 : > "$flea_log"

--- a/tools/flea-acceptance-drive
+++ b/tools/flea-acceptance-drive
@@ -406,6 +406,13 @@ reset_state() {
     k "${chord[@]}"
     settle
   fi
+  local tabs
+  for tabs in 1 2 3 4 5 6 7 8 9; do
+    [ "$(ipc tabCount)" -le 1 ] && break
+    mapfile -t closech < <(first_chord tabClose)
+    k "${closech[@]}"
+    settle
+  done
   for attempt in 1 2 3 4 5; do
     [ "$(ipc path)" = "$DRIVE_FIXTURE" ] && break
     mapfile -t chord < <(first_chord parent)
@@ -1003,11 +1010,49 @@ keycase_message_is() {
 
 keycase_palette()   { keycase_message_is "The path bar is not built yet." "$@"; }
 
-# ui/js/Focus.js answers every action starting "tab" from one branch, so tabNew, tabClose and the
-# nine keys the [digits] range binds share one driver rather than eleven copies of it.
-keycase_tabs()      { keycase_message_is "Tabs are not built yet." "$@"; }
-keycase_tabNew()    { keycase_tabs "$@"; }
-keycase_tabClose()  { keycase_tabs "$@"; }
+keycase_tabNew() {
+  local before after
+  reset_state || return 1
+  before=$(ipc tabCount)
+  k "$@"; settle
+  after=$(ipc tabCount)
+  changed_to "the tab count" "$before" "$after" "$((before + 1))"
+}
+
+keycase_tabClose() {
+  local before after
+  reset_state || return 1
+  mapfile -t newc < <(first_chord tabNew)
+  k "${newc[@]}"; settle
+  before=$(ipc tabCount)
+  k "$@"; settle
+  after=$(ipc tabCount)
+  changed_to "the tab count" "$before" "$after" "$((before - 1))"
+}
+
+# The digit keys share one driver. TAB_DIGIT is the number the runner pulled off the action name.
+keycase_tabDigit() {
+  local n=$TAB_DIGIT before after i
+  reset_state || return 1
+  if [ "$n" = 1 ]; then
+    mapfile -t newc < <(first_chord tabNew)
+    k "${newc[@]}"; settle
+    before=$(ipc tabIndex)
+    k "$@"; settle
+    after=$(ipc tabIndex)
+    changed_to "the current tab" "$before" "$after" "0"
+    return
+  fi
+  mapfile -t newc < <(first_chord tabNew)
+  for i in $(seq 2 "$n"); do
+    k "${newc[@]}"; settle
+  done
+  k 1; settle
+  before=$(ipc tabIndex)
+  k "$@"; settle
+  after=$(ipc tabIndex)
+  changed_to "the current tab" "$before" "$after" "$((n - 1))"
+}
 
 # The backend answers mkdir with the first free "New Folder", so the assertion is a directory that
 # was not there before, read off the filesystem: a status line would also be set by a dead handler.
@@ -1119,7 +1164,7 @@ drive_key_action() {
   # The digit keys are named by the [digits] prefix, which is read from keys.toml rather than
   # spelled here, so renaming the prefix moves the whole range onto the shared driver with it.
   case $action in
-    "$DIGIT_PREFIX"[0-9]) fn=keycase_tabs ;;
+    "$DIGIT_PREFIX"[0-9]) fn=keycase_tabDigit; TAB_DIGIT=${action#"$DIGIT_PREFIX"} ;;
   esac
   if ! declare -F "$fn" >/dev/null; then
     skip key "$action" "bound in keys.toml, and this battery has no driver for it yet"

--- a/ui/Ipc.qml
+++ b/ui/Ipc.qml
@@ -1,6 +1,7 @@
 import QtQuick
 import Quickshell.Io
 import qs.Commons
+import "js/Tabs.js" as Tabs
 
 // The seam the tests drive, see AGENTS.md "Testing". Read-only: it reports, never acts.
 QtObject {
@@ -11,6 +12,7 @@ QtObject {
     property var bar: null
     property var backend: null
     property var chrome: null
+    property var tabBar: null
     property var convertDialog: null
     property var keymapSheet: null
     property var networkDialog: null
@@ -210,6 +212,15 @@ QtObject {
             return item && item.visible ? root.fleaWindow.centreOf(item) : ""
         }
         function chromeHeight(): int { return Math.round(Theme.chromeHeight) }
+        function tabCount(): int { return Tabs.count(root.pane) }
+        function tabIndex(): int { return Tabs.currentIndex(root.pane) }
+        function tabLabels(): string { return Tabs.labels(root.pane).join("|") }
+        function tabBarVisible(): bool { return root.tabBar ? root.tabBar.visible : false }
+        function tabCentre(i: int): string {
+            if (!root.tabBar)
+                return ""
+            return root.fleaWindow.centreOf(root.tabBar.itemAt(i))
+        }
         // The chrome's buttons carry a glyph and no text, so a test reaches one by name and clicks
         // its centre, exactly the way rowCentre already works for a row.
         function chromeButtonCentre(glyph: string): string { return root.fleaWindow.centreOf(root.chrome.buttonFor(glyph)) }

--- a/ui/Pane.qml
+++ b/ui/Pane.qml
@@ -126,6 +126,7 @@ FocusScope {
     // Directories already visited, newest last, so the chrome's back arrow has somewhere to go.
     // Deliberately not a forward stack: the canvas draws one arrow, not two.
     property var history: []
+    property var tabs: null
     readonly property bool canGoBack: root.history.length > 0
     readonly property bool canGoUp: root.path.length > 1
 

--- a/ui/PaneWire.qml
+++ b/ui/PaneWire.qml
@@ -5,6 +5,7 @@ import "js/Errors.js" as Errors
 import "js/Nav.js" as Nav
 import "js/Ops.js" as Ops
 import "js/Search.js" as Search
+import "js/Tabs.js" as Tabs
 import "js/Thumbs.js" as Thumbs
 import "js/Transfer.js" as Transfer
 
@@ -88,6 +89,7 @@ Item {
             if (pane.rowsAt === 0 && pane.inputAt > 0 && pane.rowFor(pane.cursorIndex))
                 pane.rowsAt = Date.now()
             pane.applyPendingSelect()
+            Tabs.applyPending(pane)
             root.openRenameOnArrival()
             pane.listArea.restartSettle()
             if (pane.listInFlight) {

--- a/ui/TabBar.qml
+++ b/ui/TabBar.qml
@@ -1,0 +1,171 @@
+import QtQuick
+import "." as Flea
+import "js/Tabs.js" as Tabs
+
+// The window's tab strip. Hidden with no height until a second tab exists, so the default window
+// keeps the chrome-to-list layout every existing click test and the first-paint path already have.
+Item {
+    id: root
+
+    property var pane: null
+
+    // pane.tabs is a replaced JS object, so these bindings have to read it directly; a helper
+    // call alone would not re-run when t opens a second tab.
+    readonly property var tabs: pane ? pane.tabs : null
+    readonly property string path: pane ? pane.path : ""
+    readonly property int tabCount: root.tabs && root.tabs.items && root.tabs.items.length > 0 ? root.tabs.items.length : 1
+    readonly property int currentIndex: root.tabs ? root.tabs.index : 0
+    readonly property bool open: root.tabCount > 1
+    readonly property int tabWidth: {
+        var n = Math.max(1, root.tabCount)
+        var avail = Math.max(0, root.width - Theme.hitMin)
+        var maxW = Math.round(Theme.font.caption * 12) + Theme.hitMin + 2 * Theme.spacing.rowPaddingX
+        var minW = Theme.hitMin * 3
+        return Math.round(Math.max(minW, Math.min(maxW, avail / n)))
+    }
+
+    visible: root.open
+    implicitHeight: Theme.chromeHeight
+    height: visible ? implicitHeight : 0
+
+    function itemAt(index) {
+        return repeater.itemAt(index)
+    }
+
+    Rectangle {
+        anchors.fill: parent
+        color: Theme.color.surface
+    }
+
+    Rectangle {
+        anchors.bottom: parent.bottom
+        anchors.left: parent.left
+        anchors.right: parent.right
+        height: Theme.spacing.hairline
+        color: Theme.color.foreground
+        opacity: 0.12
+    }
+
+    Row {
+        id: strip
+        anchors.left: parent.left
+        anchors.leftMargin: Theme.spacing.rowPaddingX
+        anchors.top: parent.top
+        anchors.bottom: parent.bottom
+        spacing: 0
+
+        Repeater {
+            id: repeater
+            model: root.open ? root.tabCount : 0
+            delegate: Item {
+                id: tab
+                required property int index
+                width: root.tabWidth
+                height: strip.height
+
+                readonly property bool current: root.currentIndex === tab.index
+                readonly property string title: (root.tabs, root.path, pane) ? Tabs.labelAt(pane, tab.index) : ""
+
+                Accessible.role: Accessible.PageTab
+                Accessible.name: tab.title
+                Accessible.onPressAction: if (pane) Tabs.selectAt(pane, tab.index)
+
+                HoverHandler { cursorShape: Qt.PointingHandCursor }
+
+                Rectangle {
+                    anchors.fill: parent
+                    color: tab.current ? Theme.color.background : "transparent"
+                }
+
+                Rectangle {
+                    anchors.bottom: parent.bottom
+                    anchors.left: parent.left
+                    anchors.right: parent.right
+                    height: Theme.spacing.hairline * 2
+                    color: Theme.color.accent
+                    visible: tab.current
+                }
+
+                Rectangle {
+                    anchors.right: parent.right
+                    anchors.verticalCenter: parent.verticalCenter
+                    width: Theme.spacing.hairline
+                    height: parent.height * 0.45
+                    color: Theme.color.foreground
+                    opacity: 0.12
+                    visible: tab.index < root.tabCount - 1 && !tab.current
+                }
+
+                Text {
+                    id: titleText
+                    anchors.left: parent.left
+                    anchors.leftMargin: Theme.spacing.rowPaddingX
+                    anchors.right: closeHit.left
+                    anchors.verticalCenter: parent.verticalCenter
+                    text: tab.title
+                    color: tab.current ? Theme.color.foreground : Theme.color.muted
+                    font.family: Theme.font.family
+                    font.pixelSize: Theme.font.caption
+                    textFormat: Text.PlainText
+                    elide: Text.ElideRight
+                }
+
+                Item {
+                    id: closeHit
+                    anchors.right: parent.right
+                    anchors.verticalCenter: parent.verticalCenter
+                    width: Theme.hitMin
+                    height: parent.height
+
+                    Flea.Glyph {
+                        anchors.centerIn: parent
+                        width: Theme.chromeMarkSize
+                        height: Theme.chromeMarkSize
+                        name: "x"
+                        color: Theme.color.muted
+                    }
+                }
+
+                TapHandler {
+                    acceptedButtons: Qt.LeftButton | Qt.MiddleButton
+                    onTapped: function (eventPoint, button) {
+                        if (!pane)
+                            return
+                        if (button === Qt.MiddleButton) {
+                            Tabs.closeAt(pane, tab.index)
+                            return
+                        }
+                        var local = closeHit.mapFromItem(tab, eventPoint.position.x, eventPoint.position.y)
+                        if (local.x >= 0 && local.x <= closeHit.width && local.y >= 0 && local.y <= closeHit.height)
+                            Tabs.closeAt(pane, tab.index)
+                        else
+                            Tabs.selectAt(pane, tab.index)
+                    }
+                }
+            }
+        }
+
+        Item {
+            id: addButton
+            width: Theme.hitMin
+            height: strip.height
+            Accessible.role: Accessible.Button
+            Accessible.name: "New tab"
+            Accessible.onPressAction: if (pane) Tabs.openNew(pane)
+            HoverHandler { cursorShape: Qt.PointingHandCursor }
+
+            Flea.Glyph {
+                anchors.centerIn: parent
+                width: Theme.chromeMarkSize
+                height: Theme.chromeMarkSize
+                name: "plus"
+                color: Theme.color.muted
+            }
+
+            TapHandler {
+                acceptedButtons: Qt.LeftButton
+                onTapped: if (pane) Tabs.openNew(pane)
+            }
+        }
+    }
+}

--- a/ui/js/Focus.js
+++ b/ui/js/Focus.js
@@ -7,6 +7,7 @@
 .import "Ops.js" as Ops
 .import "Search.js" as Search
 .import "Sort.js" as Sort
+.import "Tabs.js" as Tabs
 
 var LIST = "list"
 var RAIL = "rail"
@@ -129,9 +130,8 @@ function act(action, root) {
         Ops.compress(root, action.substring("compress:".length))
         return
     }
-    // Bound ahead of their features, by the rule that a mapped key says why rather than doing nothing:
-    // the Tui board draws tabs on t, w and the digits, and a typeable path bar on colon.
-    if (action.indexOf("tab") === 0) { root.message("Tabs are not built yet.", false); return }
+    if (action.indexOf("tab") === 0) { Tabs.act(action, root); return }
+    // Bound ahead of its feature, by the rule that a mapped key says why rather than doing nothing.
     if (action === "palette") { root.message("The path bar is not built yet.", false); return }
     root.message(action + " is not built yet.", false)
 }
@@ -229,6 +229,11 @@ function handleKey(event, root, sidebar) {
     // takes active focus itself, so nothing below has to route keys into it while it stands.
     if (action === "keymapSheet") {
         root.keymapSheet.open(root)
+        return true
+    }
+    // Tabs are window-level, so t, w and the digits answer from the rail as well as the list.
+    if (action.indexOf("tab") === 0) {
+        root.act(action)
         return true
     }
     if (root.focusView === RAIL) {

--- a/ui/js/Tabs.js
+++ b/ui/js/Tabs.js
@@ -1,0 +1,241 @@
+.pragma library
+
+.import "Filter.js" as Filter
+.import "Format.js" as Format
+
+// Directory tabs in one window. The pane and the backend still hold one listing: a hidden tab is a
+// snapshot, not a second view, because a hidden view is not a free view. t, w and 1-9 are already
+// in keys.toml; this file is what they do. Nine is the cap because those digits are the jump keys.
+
+var MAX = 9
+
+function snapshot(pane) {
+    var path = pane.path
+    if (pane.searchMode === "results" && pane.searchFrom.length > 0)
+        path = pane.searchFrom
+    return {
+        path: path,
+        history: pane.history.slice(),
+        cursorIndex: pane.cursorIndex,
+        viewMode: pane.viewMode,
+        showHidden: pane.showHidden,
+        selected: pane.selectedIndices().slice(),
+        sortBy: pane.backend.sortBy,
+        sortDesc: pane.backend.sortDesc
+    }
+}
+
+function pack(items, index) {
+    return {
+        items: items,
+        index: index,
+        pendingCursor: -1,
+        pendingSelected: null,
+        pendingSortBy: "",
+        pendingSortDesc: false
+    }
+}
+
+function label(path, home) {
+    if (!path || path === "/")
+        return "/"
+    if (home && path === home)
+        return "Home"
+    var leaf = Format.leafPart(Format.tilde(path, home || ""))
+    return leaf.length > 0 ? leaf : path
+}
+
+// The current tab's path lives on the pane, not in the snapshot, so a navigate does not wait for a switch.
+function labelAt(pane, i) {
+    if (i === currentIndex(pane))
+        return label(pane.path, pane.home)
+    return label(pane.tabs.items[i].path, pane.home)
+}
+
+function labels(pane) {
+    var n = count(pane)
+    var out = []
+    for (var i = 0; i < n; i++)
+        out.push(labelAt(pane, i))
+    return out
+}
+
+function count(pane) {
+    return pane.tabs && pane.tabs.items && pane.tabs.items.length > 0 ? pane.tabs.items.length : 1
+}
+
+function currentIndex(pane) {
+    return pane.tabs ? pane.tabs.index : 0
+}
+
+function dropOverlay(pane) {
+    if (pane.searchMode.length > 0) {
+        if (pane.searchRunning)
+            pane.backend.searchcancel()
+        pane.searchMode = ""
+        pane.searchQuery = ""
+        pane.searchRunning = false
+        pane.searchCancelled = false
+        pane.searchFrom = ""
+        pane.searchScanned = 0
+    }
+    Filter.close(pane)
+}
+
+function closePreview(pane) {
+    if (pane.preview && pane.preview.active)
+        pane.preview.close()
+}
+
+function busy(pane) {
+    if (pane.listInFlight) {
+        pane.message("A directory is already loading.", false)
+        return true
+    }
+    return false
+}
+
+function restoreSelection(pane, selected) {
+    pane.clearSelection()
+    if (!selected || selected.length === 0)
+        return
+    for (var i = 0; i < selected.length; i++)
+        pane.selection.toggle(selected[i])
+    pane.selectionVersion++
+}
+
+function apply(pane, item) {
+    var same = pane.path === item.path && pane.showHidden === item.showHidden
+    pane.history = item.history.slice()
+    pane.viewMode = item.viewMode
+    pane.showHidden = item.showHidden
+    if (same) {
+        if (pane.backend && (pane.backend.sortBy !== item.sortBy || pane.backend.sortDesc !== item.sortDesc)) {
+            pane.backend.sort(item.sortBy, item.sortDesc)
+            pane.backend.sortBy = item.sortBy
+            pane.backend.sortDesc = item.sortDesc
+            pane.backend.window(0, pane.windowSize)
+            pane.tabs.pendingCursor = item.cursorIndex
+            pane.tabs.pendingSelected = item.selected
+            return
+        }
+        pane.setCursor(item.cursorIndex)
+        restoreSelection(pane, item.selected)
+        return
+    }
+    pane.tabs.pendingCursor = item.cursorIndex
+    pane.tabs.pendingSelected = item.selected
+    pane.tabs.pendingSortBy = item.sortBy
+    pane.tabs.pendingSortDesc = item.sortDesc
+    pane.openWithoutHistory(item.path)
+}
+
+function applyPending(pane) {
+    if (!pane.tabs)
+        return
+    var t = pane.tabs
+    if (t.pendingSortBy && t.pendingSortBy.length > 0
+            && pane.backend
+            && (pane.backend.sortBy !== t.pendingSortBy || pane.backend.sortDesc !== t.pendingSortDesc)) {
+        var by = t.pendingSortBy
+        var desc = t.pendingSortDesc
+        t.pendingSortBy = ""
+        pane.backend.sort(by, desc)
+        pane.backend.sortBy = by
+        pane.backend.sortDesc = desc
+        pane.backend.window(0, pane.windowSize)
+        return
+    }
+    if (t.pendingCursor >= 0) {
+        var last = pane.total > 0 ? pane.total - 1 : 0
+        pane.setCursor(Math.min(t.pendingCursor, last))
+        t.pendingCursor = -1
+    }
+    if (t.pendingSelected) {
+        restoreSelection(pane, t.pendingSelected)
+        t.pendingSelected = null
+    }
+}
+
+function currentItems(pane) {
+    if (pane.tabs && pane.tabs.items && pane.tabs.items.length > 0)
+        return pane.tabs.items.slice()
+    return [snapshot(pane)]
+}
+
+function openNew(pane) {
+    if (busy(pane))
+        return
+    closePreview(pane)
+    dropOverlay(pane)
+    var items = currentItems(pane)
+    var index = currentIndex(pane)
+    items[index] = snapshot(pane)
+    if (items.length >= MAX) {
+        pane.tabs = pack(items, index)
+        pane.message("Nine tabs is the most.", false)
+        return
+    }
+    items.push(snapshot(pane))
+    pane.tabs = pack(items, items.length - 1)
+}
+
+function selectAt(pane, i) {
+    if (busy(pane))
+        return
+    var items = currentItems(pane)
+    if (i < 0 || i >= items.length) {
+        pane.message("No tab " + (i + 1) + ".", false)
+        return
+    }
+    var index = currentIndex(pane)
+    if (i === index)
+        return
+    closePreview(pane)
+    dropOverlay(pane)
+    items[index] = snapshot(pane)
+    pane.tabs = pack(items, i)
+    apply(pane, items[i])
+}
+
+function closeAt(pane, i) {
+    if (busy(pane))
+        return
+    var items = currentItems(pane)
+    if (items.length <= 1) {
+        pane.message("Can't close the last tab.", false)
+        return
+    }
+    if (i < 0 || i >= items.length) {
+        pane.message("No tab " + (i + 1) + ".", false)
+        return
+    }
+    closePreview(pane)
+    var index = currentIndex(pane)
+    items.splice(i, 1)
+    var next = index
+    if (i < index)
+        next = index - 1
+    else if (i === index)
+        next = Math.min(i, items.length - 1)
+    if (i === index) {
+        dropOverlay(pane)
+        pane.tabs = pack(items, next)
+        apply(pane, items[next])
+    } else {
+        pane.tabs = pack(items, next)
+    }
+}
+
+function act(action, pane) {
+    if (action === "tabNew") {
+        openNew(pane)
+        return
+    }
+    if (action === "tabClose") {
+        closeAt(pane, currentIndex(pane))
+        return
+    }
+    if (action.length === 4 && action.indexOf("tab") === 0 && action.charAt(3) >= "1" && action.charAt(3) <= "9")
+        selectAt(pane, parseInt(action.charAt(3), 10) - 1)
+}

--- a/ui/qmldir
+++ b/ui/qmldir
@@ -52,6 +52,7 @@ ShareLink 1.0 ShareLink.qml
 StateMessage 1.0 StateMessage.qml
 TailscaleMark 1.0 TailscaleMark.qml
 StatusBar 1.0 StatusBar.qml
+TabBar 1.0 TabBar.qml
 TransferCard 1.0 TransferCard.qml
 Taildrop 1.0 Taildrop.qml
 FactsTable 1.0 FactsTable.qml

--- a/ui/shell.qml
+++ b/ui/shell.qml
@@ -66,11 +66,19 @@ ShellRoot {
                 onViewChosen: function (mode) { pane.viewMode = mode }
             }
 
+            Flea.TabBar {
+                id: tabBar
+                anchors.left: parent.left
+                anchors.right: parent.right
+                anchors.top: chrome.bottom
+                pane: pane
+            }
+
             Flea.Pane {
                 id: pane
                 anchors.left: parent.left
                 anchors.right: parent.right
-                anchors.top: chrome.bottom
+                anchors.top: tabBar.bottom
                 anchors.bottom: bar.top
                 backend: backend
                 preview: preview
@@ -182,6 +190,7 @@ ShellRoot {
         bar: bar
         backend: backend
         chrome: chrome
+        tabBar: tabBar
         convertDialog: convertDialog
         keymapSheet: keymapSheet
         networkDialog: networkDialog


### PR DESCRIPTION
A Flea window can hold more than one directory. `t` opens a tab at the current folder, `w` closes it, and `1` through `9` switch.

The strip appears only after a second tab, so a single listing keeps the chrome the first paint uses. Closing the last tab is refused. Nine is the cap, because those digits are the jump keys.

One listing stays live. A hidden tab is a snapshot (path, cursor, view, history, sort, selection), not a second view. That keeps per-file work inside the viewport.

`:` is still not built and still says so.

## Test plan

- `./tests/js.sh` — 1036 checks, 0 failed
- `./tests/ui.sh tabs` — not run here (`omarchy-drive` was missing)
- On a live window: `t`, navigate, `1`/`2`, `w`, last-tab refuse


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added directory tabs with support for opening, switching, and closing tabs.
  - Added keyboard shortcuts: `t` to open, `w` to close, and `1`–`9` to switch tabs.
  - Added a tab bar with selectable tabs, close controls, and a new-tab button.
  - Tab state preserves folder location, cursor, view settings, sorting, and selections.
  - The tab bar appears when two or more tabs are open, with a maximum of nine tabs.
  - Prevented closing the final remaining tab.

- **Tests**
  - Added comprehensive tab behavior and UI test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->