### PR TITLE
feat: the header's own right-click menu, column show/hide behind it, and an Advanced group

### DIFF
--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -51,7 +51,12 @@ default to `0`.
 
 ### sort
 
-`{"c":"sort","by":"<string>","desc":<bool>}`
+`{"c":"sort","by":"<string>","desc":<bool>,"dirs":<bool>}`
+
+`dirs` is optional and sticky: absent, the session keeps its standing choice (true, folders
+grouped ahead of files, the shipped default); present, it sets that choice for this sort and
+every listing and sort after it, `list` included. `false` interleaves folders into the order
+the key and direction produce.
 
 Example: `{"c":"sort","by":"size","desc":true}`
 

--- a/src/backend/metasort.rs
+++ b/src/backend/metasort.rs
@@ -10,7 +10,7 @@ use std::time::Instant;
 // The stats live for this call alone: nothing is cached, so reversing a size order stats the
 // directory again at the warm cost docs/protocol.md "sort" records, and a listing sitting in name
 // order, which is every listing the field measures, never carries 16 bytes a row it is not using.
-pub fn sort_by_stat(l: &mut Listing, base: &Path, by: SortBy, desc: bool) -> (f64, f64) {
+pub fn sort_by_stat(l: &mut Listing, base: &Path, by: SortBy, desc: bool, dirs_first: bool) -> (f64, f64) {
     let (stats, pass_ms) = stat_all(base, l);
     let t = Instant::now();
     // An index is sorted and the spans gathered after it, so Span stays the 12 bytes every listing pays.
@@ -18,8 +18,8 @@ pub fn sort_by_stat(l: &mut Listing, base: &Path, by: SortBy, desc: bool) -> (f6
     order.sort_by(|&a, &b| {
         let (a, b) = (a as usize, b as usize);
         match (l.is_dir(a), l.is_dir(b)) {
-            (true, false) => Ordering::Less,
-            (false, true) => Ordering::Greater,
+            (true, false) if dirs_first => Ordering::Less,
+            (false, true) if dirs_first => Ordering::Greater,
             // desc is the exact reverse of asc inside each group, tie-break included, as name's is.
             _ if desc => key_order(l, &stats, by, b, a),
             _ => key_order(l, &stats, by, a, b),
@@ -86,7 +86,7 @@ mod tests {
     #[test]
     fn size_lists_directories_first_by_name_then_files_by_size() {
         let (d, mut l) = tree("sizeasc");
-        sort_by_stat(&mut l, d.path(), SortBy::Size, false);
+        sort_by_stat(&mut l, d.path(), SortBy::Size, false, true);
         // 11 has st_size 0 and 1 does not, so a build ordering directories by st_size answers 11 1.
         assert_eq!(names(&l), "1 11 3 2");
     }
@@ -94,16 +94,16 @@ mod tests {
     #[test]
     fn size_descending_keeps_directories_first_and_reverses_inside_each_group() {
         let (d, mut l) = tree("sizedesc");
-        sort_by_stat(&mut l, d.path(), SortBy::Size, true);
+        sort_by_stat(&mut l, d.path(), SortBy::Size, true, true);
         assert_eq!(names(&l), "11 1 2 3");
     }
 
     #[test]
     fn mtime_orders_both_groups_by_time_directories_still_first_in_both_directions() {
         let (d, mut l) = tree("mtime");
-        sort_by_stat(&mut l, d.path(), SortBy::Mtime, false);
+        sort_by_stat(&mut l, d.path(), SortBy::Mtime, false, true);
         assert_eq!(names(&l), "11 1 2 3", "a build that lost the grouping answers 2 11 1 3");
-        sort_by_stat(&mut l, d.path(), SortBy::Mtime, true);
+        sort_by_stat(&mut l, d.path(), SortBy::Mtime, true, true);
         assert_eq!(names(&l), "1 11 3 2");
     }
 
@@ -122,8 +122,8 @@ mod tests {
         for n in set.iter().rev() {
             again.push(n, false);
         }
-        sort_by_stat(&mut once, d.path(), SortBy::Size, false);
-        sort_by_stat(&mut again, d.path(), SortBy::Size, false);
+        sort_by_stat(&mut once, d.path(), SortBy::Size, false, true);
+        sort_by_stat(&mut again, d.path(), SortBy::Size, false, true);
         assert_eq!(names(&once), "a B b file_2 file_10", "the tie-break is the name order, digits by value");
         assert_eq!(names(&once), names(&again), "whatever readdir said");
     }
@@ -136,10 +136,10 @@ mod tests {
         l.push("real", false);
         // Named to sort after real by name, so this can only pass on size.
         l.push("zzz-gone", false);
-        sort_by_stat(&mut l, d.path(), SortBy::Size, false);
+        sort_by_stat(&mut l, d.path(), SortBy::Size, false, true);
         assert_eq!(names(&l), "zzz-gone real", "the zeroes stat_range would send sort as the smallest");
         let mut empty = Listing::new();
-        let (pass, sort) = sort_by_stat(&mut empty, d.path(), SortBy::Mtime, true);
+        let (pass, sort) = sort_by_stat(&mut empty, d.path(), SortBy::Mtime, true, true);
         assert_eq!(empty.len(), 0);
         assert!(pass >= 0.0 && sort >= 0.0);
     }
@@ -148,7 +148,7 @@ mod tests {
     fn the_gather_moves_spans_and_leaves_every_name_and_flag_intact() {
         let (d, mut l) = tree("gather");
         let mut before: Vec<(String, bool)> = (0..l.len()).map(|i| (l.name(i).to_string(), l.is_dir(i))).collect();
-        sort_by_stat(&mut l, d.path(), SortBy::Mtime, true);
+        sort_by_stat(&mut l, d.path(), SortBy::Mtime, true, true);
         let mut after: Vec<(String, bool)> = (0..l.len()).map(|i| (l.name(i).to_string(), l.is_dir(i))).collect();
         before.sort();
         after.sort();

--- a/src/backend/peek.rs
+++ b/src/backend/peek.rs
@@ -20,7 +20,7 @@ pub fn peek_line(path: &str, first: usize, hidden: bool, mime: &Db, icons: &Name
         // empty directory either, and the column drew those two the same way until this line.
         Err(_) => return failed_peek(path),
     };
-    sort_by_name(&mut listing, false);
+    sort_by_name(&mut listing, false, true);
     let total = listing.len();
     let count = first.min(PEEK_CAP).min(total);
     let mut out = String::with_capacity(count * 64);

--- a/src/backend/proto.rs
+++ b/src/backend/proto.rs
@@ -2,7 +2,7 @@ use crate::error::FleaError;
 use crate::json::{escape, field_bool, field_bool_opt, field_str, field_str_array, field_usize, field_usize_array};
 
 pub enum Request {
-    List { path: String, first: usize, hidden: bool },
+    List { path: String, first: usize, hidden: bool, dirs: Option<bool> },
     Window { start: usize, count: usize },
     Sort { by: String, desc: bool, dirs: Option<bool> },
     Search { path: String, query: String, hidden: bool },
@@ -48,6 +48,8 @@ pub fn parse_request(line: &str) -> Request {
             first: field_usize(line, "first").unwrap_or(0),
             // A missing hidden is false, so an older client's request still lists dotfile-free.
             hidden: field_bool(line, "hidden"),
+            // A missing dirs keeps the session's standing folders-first choice, the same rule sort obeys.
+            dirs: field_bool_opt(line, "dirs"),
         },
         Some("window") => Request::Window {
             start: field_usize(line, "start").unwrap_or(0),
@@ -200,7 +202,7 @@ mod tests {
     #[test]
     fn parses_each_request_shape() {
         match parse_request(r#"{"c":"list","path":"/home/gm","first":350}"#) {
-            Request::List { path, first, hidden } => {
+            Request::List { path, first, hidden, dirs: _ } => {
                 assert_eq!(path, "/home/gm");
                 assert_eq!(first, 350);
                 assert!(!hidden);

--- a/src/backend/proto.rs
+++ b/src/backend/proto.rs
@@ -1,10 +1,10 @@
 use crate::error::FleaError;
-use crate::json::{escape, field_bool, field_str, field_str_array, field_usize, field_usize_array};
+use crate::json::{escape, field_bool, field_bool_opt, field_str, field_str_array, field_usize, field_usize_array};
 
 pub enum Request {
     List { path: String, first: usize, hidden: bool },
     Window { start: usize, count: usize },
-    Sort { by: String, desc: bool },
+    Sort { by: String, desc: bool, dirs: Option<bool> },
     Search { path: String, query: String, hidden: bool },
     // Unlike thumbcancel there is no rows form: one walk runs at a time, so a cancel can only mean that one.
     SearchCancel,
@@ -56,6 +56,7 @@ pub fn parse_request(line: &str) -> Request {
         Some("sort") => Request::Sort {
             by: field_str(line, "by").unwrap_or_default(),
             desc: field_bool(line, "desc"),
+            dirs: field_bool_opt(line, "dirs"),
         },
         Some("search") => Request::Search {
             path: field_str(line, "path").unwrap_or_default(),
@@ -214,7 +215,7 @@ mod tests {
             _ => panic!("expected Window"),
         }
         match parse_request(r#"{"c":"sort","by":"size","desc":true}"#) {
-            Request::Sort { by, desc } => {
+            Request::Sort { by, desc, .. } => {
                 assert_eq!(by, "size");
                 assert!(desc);
             }

--- a/src/backend/run.rs
+++ b/src/backend/run.rs
@@ -125,6 +125,7 @@ pub fn run() -> i32 {
         dirsize_queue: Vec::new(),
         search: None,
         search_reported: Instant::now(),
+        dirs_first: true,
     };
 
     let (tx, rx) = channel::<Event>();
@@ -204,7 +205,7 @@ fn handle_line(
             }
             match scan(&path, hidden) {
                 Ok((mut l, read_ms)) => {
-                    let sort_ms = sort_by_name(&mut l, false);
+                    let sort_ms = sort_by_name(&mut l, false, st.dirs_first);
                     // base and listing only move together, so a failed list cannot mix them.
                     st.base = PathBuf::from(&path);
                     st.listing = l;
@@ -243,7 +244,7 @@ fn handle_line(
                 forget_rows(st, pool);
             }
         }
-        Request::Sort { by, desc } => {
+        Request::Sort { by, desc, dirs } => {
             // The walk owns the listing sort would reorder, so it ends first rather than racing it.
             if finish_search(out, st, true) {
                 forget_rows(st, pool);
@@ -256,7 +257,10 @@ fn handle_line(
                 }
                 Ok(order) => {
                     // read carries the metadata pass here, 0.0 for name; see docs/protocol.md "listed".
-                    let (pass_ms, sort_ms) = sort_listing(&mut st.listing, &st.base, order, desc);
+                    // An absent "dirs" keeps the session's standing choice; a present one sets it.
+                    let dirs_first = dirs.unwrap_or(st.dirs_first);
+                    st.dirs_first = dirs_first;
+                    let (pass_ms, sort_ms) = sort_listing(&mut st.listing, &st.base, order, desc, dirs_first);
                     forget_rows(st, pool);
                     writeln!(out, "{}", listed_line(st.listing.len(), pass_ms, sort_ms, dev_of(&st.base))).ok();
                 }

--- a/src/backend/run.rs
+++ b/src/backend/run.rs
@@ -198,13 +198,15 @@ fn handle_line(
     ops: &mut Ops,
 ) -> Control {
     match parse_request(line) {
-        Request::List { path, first, hidden } => {
+        Request::List { path, first, hidden, dirs } => {
             // A new listing replaces whatever the walk was filling, so the walk ends before the scan starts.
             if finish_search(out, st, true) {
                 forget_rows(st, pool);
             }
             match scan(&path, hidden) {
                 Ok((mut l, read_ms)) => {
+                    // An absent "dirs" keeps the standing choice, the same rule sort obeys.
+                    st.dirs_first = dirs.unwrap_or(st.dirs_first);
                     let sort_ms = sort_by_name(&mut l, false, st.dirs_first);
                     // base and listing only move together, so a failed list cannot mix them.
                     st.base = PathBuf::from(&path);
@@ -258,9 +260,8 @@ fn handle_line(
                 Ok(order) => {
                     // read carries the metadata pass here, 0.0 for name; see docs/protocol.md "listed".
                     // An absent "dirs" keeps the session's standing choice; a present one sets it.
-                    let dirs_first = dirs.unwrap_or(st.dirs_first);
-                    st.dirs_first = dirs_first;
-                    let (pass_ms, sort_ms) = sort_listing(&mut st.listing, &st.base, order, desc, dirs_first);
+                    st.dirs_first = dirs.unwrap_or(st.dirs_first);
+                    let (pass_ms, sort_ms) = sort_listing(&mut st.listing, &st.base, order, desc, st.dirs_first);
                     forget_rows(st, pool);
                     writeln!(out, "{}", listed_line(st.listing.len(), pass_ms, sort_ms, dev_of(&st.base))).ok();
                 }

--- a/src/backend/sort.rs
+++ b/src/backend/sort.rs
@@ -25,10 +25,10 @@ pub fn parse_sort_by(s: &str) -> Result<SortBy, &'static str> {
 
 // The one entry the loop calls: name works on phase-1 data alone, size and date pay the metadata
 // pass first. Answers (pass ms, sort ms), which the listed line carries as read and sort.
-pub fn sort_listing(l: &mut Listing, base: &Path, by: SortBy, desc: bool) -> (f64, f64) {
+pub fn sort_listing(l: &mut Listing, base: &Path, by: SortBy, desc: bool, dirs_first: bool) -> (f64, f64) {
     match by {
-        SortBy::Name => (0.0, sort_by_name(l, desc)),
-        SortBy::Size | SortBy::Mtime => sort_by_stat(l, base, by, desc),
+        SortBy::Name => (0.0, sort_by_name(l, desc, dirs_first)),
+        SortBy::Size | SortBy::Mtime => sort_by_stat(l, base, by, desc, dirs_first),
     }
 }
 
@@ -101,7 +101,7 @@ pub fn name_order(a: &[u8], b: &[u8]) -> Ordering {
     }
 }
 
-pub fn sort_by_name(l: &mut Listing, desc: bool) -> f64 {
+pub fn sort_by_name(l: &mut Listing, desc: bool, dirs_first: bool) -> f64 {
     let t = Instant::now();
     // Take the buffer out so the comparator can borrow it while spans are moved.
     let names = std::mem::take(&mut l.names);
@@ -109,8 +109,8 @@ pub fn sort_by_name(l: &mut Listing, desc: bool) -> f64 {
         let an = &names[a.off as usize..(a.off + a.len) as usize];
         let bn = &names[b.off as usize..(b.off + b.len) as usize];
         match (a.is_dir, b.is_dir) {
-            (true, false) => Ordering::Less,
-            (false, true) => Ordering::Greater,
+            (true, false) if dirs_first => Ordering::Less,
+            (false, true) if dirs_first => Ordering::Greater,
             _ => {
                 // desc is the exact reverse of asc, tie-break included. as_bytes is a cast, not a
                 // conversion: the arena is a String, so the spans slice to &str and the comparator
@@ -144,7 +144,7 @@ mod tests {
     #[test]
     fn directories_come_first_then_name_order() {
         let mut l = sample();
-        sort_by_name(&mut l, false);
+        sort_by_name(&mut l, false, true);
         assert_eq!(l.name(0), "aaa-dir");
         assert_eq!(l.name(1), "zzz-dir");
         assert_eq!(l.name(2), "alpha.txt");
@@ -152,9 +152,19 @@ mod tests {
     }
 
     #[test]
+    fn dirs_first_false_mixes_folders_into_name_order() {
+        let mut l = sample();
+        sort_by_name(&mut l, false, false);
+        assert_eq!(l.name(0), "aaa-dir");
+        assert_eq!(l.name(1), "alpha.txt");
+        assert_eq!(l.name(2), "zebra.txt");
+        assert_eq!(l.name(3), "zzz-dir");
+    }
+
+    #[test]
     fn descending_reverses_names_but_keeps_directories_first() {
         let mut l = sample();
-        sort_by_name(&mut l, true);
+        sort_by_name(&mut l, true, true);
         assert_eq!(l.name(0), "zzz-dir");
         assert_eq!(l.name(1), "aaa-dir");
         assert_eq!(l.name(2), "zebra.txt");
@@ -164,7 +174,7 @@ mod tests {
     #[test]
     fn sorting_an_empty_listing_does_not_panic() {
         let mut l = Listing::new();
-        sort_by_name(&mut l, false);
+        sort_by_name(&mut l, false, true);
         assert_eq!(l.len(), 0);
     }
 
@@ -185,7 +195,7 @@ mod tests {
     fn sort_listing_routes_name_to_the_phase_one_order_and_never_stats() {
         let mut l = sample();
         // A base that does not exist: name order never looks at it, so nothing here can fail.
-        let (pass, _) = sort_listing(&mut l, Path::new("/definitely/not/here"), SortBy::Name, true);
+        let (pass, _) = sort_listing(&mut l, Path::new("/definitely/not/here"), SortBy::Name, true, true);
         assert_eq!(pass, 0.0, "name pays no metadata pass");
         assert_eq!(l.name(0), "zzz-dir");
         assert_eq!(l.name(3), "alpha.txt");
@@ -198,7 +208,7 @@ mod tests {
         for n in names {
             l.push(n, false);
         }
-        sort_by_name(&mut l, false);
+        sort_by_name(&mut l, false, true);
         (0..l.len()).map(|i| l.name(i).to_string()).collect()
     }
 
@@ -275,8 +285,8 @@ mod tests {
             asc.push(n, false);
             desc.push(n, false);
         }
-        sort_by_name(&mut asc, false);
-        sort_by_name(&mut desc, true);
+        sort_by_name(&mut asc, false, true);
+        sort_by_name(&mut desc, true, true);
         let up: Vec<String> = (0..asc.len()).map(|i| asc.name(i).to_string()).collect();
         let mut down: Vec<String> = (0..desc.len()).map(|i| desc.name(i).to_string()).collect();
         down.reverse();

--- a/src/backend/state.rs
+++ b/src/backend/state.rs
@@ -27,6 +27,9 @@ pub struct Tables {
 
 // Everything the loop mutates, gathered so a handler takes one borrow instead of ten arguments.
 pub struct State {
+    // The standing folders-first choice for every listing and sort this session answers; the
+    // sort request's optional "dirs" overrides it per call. true is the shipped default.
+    pub dirs_first: bool,
     pub listing: Listing,
     pub base: PathBuf,
     // Only the rows a client named, so this never grows with the directory; see AGENTS.md "Thumbnail requests".

--- a/src/json.rs
+++ b/src/json.rs
@@ -148,6 +148,12 @@ pub fn field_bool(line: &str, key: &str) -> bool {
     }
 }
 
+// Absent and present-but-false are different answers: the sort request's "dirs" defaults to the
+// session's standing choice when the field is missing and overrides it when it is there.
+pub fn field_bool_opt(line: &str, key: &str) -> Option<bool> {
+    value_start(line, key).map(|start| line[start..].trim_start().starts_with("true"))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/launcher/prewarm.rs
+++ b/src/launcher/prewarm.rs
@@ -33,7 +33,7 @@ pub fn write_prewarm(path: &str, first: usize, dest: &Path) -> Result<(), FleaEr
 fn write_to_tmp(path: &str, first: usize, dest: &Path, tmp: &Path) -> Result<(), FleaError> {
     // Prewarm never asks for dotfiles: it mirrors list's own default, see docs/protocol.md.
     let (mut listing, read_ms) = scan(path, false)?;
-    let sort_ms = sort_by_name(&mut listing, false);
+    let sort_ms = sort_by_name(&mut listing, false, true);
 
     // corner: unlink our own leftover then create exclusively, see AGENTS.md.
     let _ = fs::remove_file(tmp);

--- a/tests/js/columns.js
+++ b/tests/js/columns.js
@@ -24,6 +24,7 @@ function nameSlot(width, s, t) {
 }
 
 function run(check) {
+    runHidden(check)
     var f = Columns.floors(BOX)
     // 216 is the name at its floor with no metadata at all: 14 + 23 + 9 + 156 + 14.
     check("mode needs the name's floor plus its own column and gap", f.mode, 295)
@@ -95,4 +96,26 @@ function run(check) {
           "name,mode,size,date,kind")
     check("the name is in the set even when everything else is gone",
           Columns.names({ mode: false, size: false, date: false, kind: false }), "name")
+}
+
+// The user's own hidden set, subtracted from what the width affords: a hidden column never draws,
+// and width still wins, so a column shown while the pane is too narrow stays dropped. The keys are
+// the same "mode"/"size"/"date"/"kind" the header menu's col:<key> actions carry.
+
+function runHidden(check) {
+    var none = Columns.set(2000, BOX, [])
+    check("an empty hidden set draws every column the width affords",
+          [none.mode, none.size, none.date, none.kind].join(","), "true,true,true,true")
+
+    var hid = Columns.set(2000, BOX, ["size", "kind"])
+    check("a hidden column does not draw at a width that would afford it",
+          [hid.mode, hid.size, hid.date, hid.kind].join(","), "true,false,true,false")
+
+    var narrow = Columns.set(200, BOX, ["kind"])
+    check("width still wins over a column the user wants back, Mode's own floor included",
+          [narrow.mode, narrow.size, narrow.date, narrow.kind].join(","), "false,false,false,false")
+
+    var undefinedSet = Columns.set(2000, BOX)
+    check("a caller that passes no hidden set draws as before",
+          [undefinedSet.mode, undefinedSet.size, undefinedSet.date, undefinedSet.kind].join(","), "true,true,true,true")
 }

--- a/tests/js/menu.js
+++ b/tests/js/menu.js
@@ -8,6 +8,7 @@
 // !== undefined, so the flyout opened correctly and only the affordance was missing.
 
 function run(check) {
+    runMenu(check)
     check("a Compress row carrying the probed formats is a submenu row",
           Menu.hasSubmenu({ label: "Compress", action: "compress",
                             submenu: Archive.formatEntries(["zip", "7z"]) }),
@@ -47,4 +48,62 @@ function run(check) {
           Menu.clamp(-40, railMenu, pane), 0)
     check("a frame taller than the pane pins to the near edge, which is where its tail is cut",
           Menu.clamp(700, 1200, pane), 0)
+}
+
+// ui/js/Menu.js listingEntries: the listing's rows, built from the pane's state in one object.
+// The row order below is the canvas's own, and the Open row now carries the resolved application
+// name as a muted suffix (ui/MenuRow.qml draws it after the label), beside a Copy Path row.
+
+function labels(entries) {
+    var out = []
+    for (var i = 0; i < entries.length; i++)
+        out.push(entries[i].separator === true ? "-" : entries[i].label)
+    return out.join("|")
+}
+
+function findEntry(entries, action) {
+    for (var i = 0; i < entries.length; i++)
+        if (entries[i].action === action)
+            return entries[i]
+    return {}
+}
+
+function runMenu(check) {
+    var full = Menu.listingEntries({
+        showHidden: false, hasRow: true, rowInDropbox: false,
+        dropboxPath: "/home/jw/Dropbox", taildropPeers: [{ id: "x", label: "Box" }],
+        archiveFormats: ["zip"], rowIsArchive: false, rowIsImage: false, canConvert: true,
+        openSuffix: "Sublime Text"
+    })
+    check("the listing menu opens with the row's own Open", full[0].label + "|" + full[0].suffix, "Open|Sublime Text")
+    check("Copy Path sits beside Open", findEntry(full, "copypath").label, "Copy Path")
+    check("the hidden toggle moved behind Advanced, off the top level",
+          findEntry(full, "toggleHidden").label + "|" + findEntry(full, "advanced").submenu[0].label,
+          "undefined|Show hidden files")
+    check("Advanced carries the hidden toggle, flipping with the state",
+          Menu.advancedRows(false)[0].label + "|" + Menu.advancedRows(true)[0].label,
+          "Show hidden files|Hide hidden files")
+    check("an empty listing still offers New Folder and Advanced",
+          labels(Menu.listingEntries({ showHidden: false, hasRow: false, rowInDropbox: false,
+                                       dropboxPath: "", taildropPeers: [], archiveFormats: [],
+                                       rowIsArchive: false, rowIsImage: false, canConvert: false,
+                                       openSuffix: "" })),
+          "New Folder|Advanced")
+    check("a directory's Open row carries no app name, because flea opens it itself",
+          Menu.listingEntries({ showHidden: false, hasRow: true, rowInDropbox: false,
+                                dropboxPath: "", taildropPeers: [], archiveFormats: [],
+                                rowIsArchive: false, rowIsImage: false, canConvert: false,
+                                openSuffix: "" })[0].suffix, "")
+
+    // ui/Header.qml's own rows, on a right click over the column titles. Four toggles, flipping
+    // labels, each answering "col:<key>"; Name is absent because it never hides.
+    var head = Menu.headerEntries([], false)
+    check("the header menu offers the four optional columns, flipping labels when hidden",
+          labels(Menu.headerEntries(["size"], false)),
+          "Hide Mode|Show Size|Hide Date Modified|Hide Kind|-|Advanced")
+    check("every column row answers col:<key>",
+          findEntry(head, "col:size").action + "|" + findEntry(head, "col:kind").action,
+          "col:size|col:kind")
+    check("the header menu's Advanced carries the hidden toggle",
+          findEntry(head, "advanced").submenu[0].action, "toggleHidden")
 }

--- a/tests/js/menu.js
+++ b/tests/js/menu.js
@@ -97,13 +97,17 @@ function runMenu(check) {
 
     // ui/Header.qml's own rows, on a right click over the column titles. Four toggles, flipping
     // labels, each answering "col:<key>"; Name is absent because it never hides.
-    var head = Menu.headerEntries([], false)
-    check("the header menu offers the four optional columns, flipping labels when hidden",
-          labels(Menu.headerEntries(["size"], false)),
-          "Hide Mode|Show Size|Hide Date Modified|Hide Kind|-|Advanced")
+    var head = Menu.headerEntries([], false, true)
+    check("the header menu offers the four optional columns, flipping labels when hidden, then the two state rows flat",
+          labels(Menu.headerEntries(["size"], false, false)),
+          "Hide Mode|Show Size|Hide Date Modified|Hide Kind|-|Show hidden files|Keep folders first")
     check("every column row answers col:<key>",
           findEntry(head, "col:size").action + "|" + findEntry(head, "col:kind").action,
           "col:size|col:kind")
-    check("the header menu's Advanced carries the hidden toggle",
-          findEntry(head, "advanced").submenu[0].action, "toggleHidden")
+    check("the header menu is flat: the hidden toggle is a top-level row, no Advanced",
+          findEntry(head, "toggleHidden").label + "|" + findEntry(head, "advanced").label,
+          "Show hidden files|undefined")
+    check("the header menu carries the folders-first flip, both ways",
+          findEntry(head, "foldersFirst").label + "|" + Menu.headerEntries([], false, false)[6].label,
+          "Mix folders and files|Keep folders first")
 }

--- a/ui/Backend.qml
+++ b/ui/Backend.qml
@@ -82,7 +82,7 @@ Item {
         // header's mark back rather than leaving it describing the order before the refresh.
         root.sortBy = "name"
         root.sortDesc = false
-        root.send({ c: "list", path: path, first: first, hidden: hidden })
+        root.send({ c: "list", path: path, first: first, hidden: hidden, dirs: ViewState.foldersFirst })
     }
 
     function window(start, count) {
@@ -90,7 +90,7 @@ Item {
     }
 
     function sort(by, desc) {
-        root.send({ c: "sort", by: by, desc: desc })
+        root.send({ c: "sort", by: by, desc: desc, dirs: ViewState.foldersFirst })
     }
 
     // The walk replaces the current listing with its matches, each named relative to path; see docs/protocol.md "search".

--- a/ui/ContextMenu.qml
+++ b/ui/ContextMenu.qml
@@ -1,7 +1,6 @@
 import QtQuick
 import qs.Commons
 import "." as Flea
-import "js/Archive.js" as Archive
 import "js/Keymap.js" as Keymap
 import "js/Menu.js" as Menu
 
@@ -10,12 +9,15 @@ Item {
     id: root
 
     // Fires with the row's own action string ("open", "trash"); a chosen Taildrop peer fires
-    // "taildrop:<peerId>" instead, so one signal covers both without a second wire.
+    // "taildrop:<peerId>" instead, so one signal covers both without a second wire. The header's
+    // rows fire "col:<key>" and "toggleHidden", routed in ui/Pane.qml's onChosen.
     signal chosen(string action)
 
     property bool opened: false
     // Driven from ui/Pane.qml's own state, so this file owns no hidden-file logic itself.
     property bool showHidden: false
+    // The application name ui/Opener.qml resolved for the cursor row, shown muted beside "Open".
+    property string openSuffix: ""
     // [{id, label}], the reachable Taildrop targets; empty self-hides the whole row, see ui/Taildrop.qml.
     property var taildropPeers: []
     // The archive formats this box actually probed, and whether a converter is installed at all.
@@ -39,6 +41,16 @@ Item {
     property string railKey: ""
     readonly property bool forRail: root.railEntries.length > 0
     signal railChosen(string action, string key)
+
+    // ui/Header.qml's own entrance, the third face of this one instance: openForHeader() flips the
+    // entries to ui/js/Menu.js headerEntries (the column toggles and the Advanced group, built from
+    // qs module ViewState's hidden columns and the pane's showHidden), and every row flows back
+    // through chosen() like the listing's own. A row's chosen verb routes by prefix in ui/Pane.qml.
+    property bool forHeader: false
+    function openForHeader(scenePoint) {
+        root.forHeader = true
+        root.place(scenePoint)
+    }
 
     // The pane keeps its Keys handler on the list, so the menu has to hand focus back on close.
     property Item focusHolder: null
@@ -66,62 +78,28 @@ Item {
     // The row list this menu currently offers; a test reads this back through shell.qml's IPC.
     readonly property var entries: root.buildEntries()
 
-    // The canvas's own order and grouping. Compress, Extract, Convert and Move to Dropbox belong
-    // between Duplicate and Taildrop and arrive with their own plans; a row whose action does
-    // nothing is worse than a row that is not there yet.
+    // The construction lives in ui/js/Menu.js now, so the rows are unit-testable without a window:
+    // listingEntries(p) builds the listing's rows from the pane's state, headerEntries() the column
+    // titles' own rows on a right click (see ui/Header.qml), and this file only routes between them.
     function buildEntries() {
         // Which release a rail row offers is the rail's knowledge, not the listing's, so the rail
         // hands its rows in already built; see ui/js/Mounts.js "railMenu".
         if (root.forRail)
             return root.railEntries
-        var out = []
-        if (root.hasRow) {
-            out.push({ label: "Open", action: "open", glyph: "folder-open" })
-            out.push({ separator: true })
-            out.push({ label: "Rename", action: "rename", glyph: "rename" })
-            out.push({ label: "Duplicate", action: "duplicate", glyph: "file-plus" })
-            var ops = []
-            // The submenu is exactly the table the backend probed, so a box with no tool offers nothing.
-            if (root.archiveFormats.length > 0)
-                ops.push({ label: "Compress", action: "compress", glyph: "archive",
-                           submenu: Archive.formatEntries(root.archiveFormats) })
-            if (root.rowIsArchive)
-                ops.push({ label: "Extract", action: "extract", glyph: "archive-out" })
-            if (root.canConvert && root.rowIsImage)
-                ops.push({ label: "Convert", action: "convert", glyph: "sliders" })
-            if (ops.length > 0) {
-                out.push({ separator: true })
-                for (var i = 0; i < ops.length; i++) out.push(ops[i])
-            }
-            var share = []
-            if (root.taildropPeers.length > 0)
-                share.push({ label: "Send with Taildrop", action: "taildrop", mark: "tailscale",
-                             submenu: root.taildropPeers })
-            // Moving a file into the folder it already lives in is not an action, so the row hides there.
-            if (root.dropboxPath.length > 0 && !root.rowInDropbox)
-                share.push({ label: "Move to Dropbox", action: "dropbox", mark: "dropbox" })
-            // A share link is inherently per file, so it appears only for a row already in Dropbox.
-            if (root.rowInDropbox)
-                share.push({ label: "Copy Share Link", action: "sharelink", glyph: "network" })
-            if (share.length > 0) {
-                out.push({ separator: true })
-                for (var s = 0; s < share.length; s++) out.push(share[s])
-            }
-            out.push({ separator: true })
-            // No confirm anywhere behind this row: the undo journal is the safety, see the operations design.
-            out.push({ label: "Move to Trash", action: "trash", glyph: "trash", danger: true })
-            out.push({ separator: true })
-        }
-        // The last group is the two rows that need no row under the cursor, which is also the whole
-        // menu on a listing's empty space. Operations.dc.html draws neither the row nor this divider,
-        // and a create action sitting directly under the destructive one is what earns the divider.
-        out.push({ label: "New Folder", action: "newFolder", glyph: "folder-plus" })
-        out.push({
-            label: root.showHidden ? "Hide hidden files" : "Show hidden files",
-            action: "toggleHidden",
-            glyph: root.showHidden ? "eye-off" : "eye"
+        if (root.forHeader)
+            return Menu.headerEntries(ViewState.hiddenCols, root.showHidden)
+        return Menu.listingEntries({
+            showHidden: root.showHidden,
+            hasRow: root.hasRow,
+            rowInDropbox: root.rowInDropbox,
+            dropboxPath: root.dropboxPath,
+            taildropPeers: root.taildropPeers,
+            archiveFormats: root.archiveFormats,
+            rowIsArchive: root.rowIsArchive,
+            rowIsImage: root.rowIsImage,
+            canConvert: root.canConvert,
+            openSuffix: root.openSuffix
         })
-        return out
     }
 
     // A separator is never the cursor, so both key steps and the opening cursor skip over one.
@@ -146,6 +124,7 @@ Item {
     // Takes a point in scene coordinates and keeps the whole menu inside the pane it belongs to.
     function openAt(scenePoint) {
         root.clearRail()
+        root.forHeader = false
         root.place(scenePoint)
     }
 

--- a/ui/ContextMenu.qml
+++ b/ui/ContextMenu.qml
@@ -16,7 +16,6 @@ Item {
     property bool opened: false
     // Driven from ui/Pane.qml's own state, so this file owns no hidden-file logic itself.
     property bool showHidden: false
-    property string openSuffix: ""
     // [{id, label}], the reachable Taildrop targets; empty self-hides the whole row, see ui/Taildrop.qml.
     property var taildropPeers: []
     // The archive formats this box actually probed, and whether a converter is installed at all.
@@ -32,20 +31,23 @@ Item {
     // False on a listing's empty space, where only the two rows that need no row make sense.
     property bool hasRow: true
 
-    // The rail's own rows when ui/Sidebar.qml raised this menu, empty when the listing did. One
-    // instance serves both: a second one in this tree takes the keyboard from the list, see AGENTS.md.
-    property var railEntries: []
-    // The key naming the rail row those rows belong to, see ui/js/Mounts.js "railKey": the rail
-    // rebuilds on a poll, so an index would name a different row by the time one is chosen.
+    // The rows the open menu offers, SNAPSHOTTED when it opens: a live binding rebuilds under the
+    // pointer, destroys the pressed row mid-tap (the click falls through to the listing beneath and
+    // moves the selection) and swaps a flyout's model to a collapsed frame — the rail handed its
+    // rows in once since always, which is why the rail never had either bug. One instance serves
+    // all three faces: a second one takes the keyboard from the list, see AGENTS.md.
+    property var heldEntries: []
+    readonly property var entries: root.heldEntries
+    property bool forRail: false
+    // Names the rail row the handed-in rows belong to, see ui/js/Mounts.js "railKey".
     property string railKey: ""
-    readonly property bool forRail: root.railEntries.length > 0
     signal railChosen(string action, string key)
 
-    // ui/Header.qml's own entrance, the third face of this one instance: the column toggles and the
-    // state rows, flowing back through chosen() like the listing's.
     property bool forHeader: false
     function openForHeader(scenePoint) {
+        root.forRail = false
         root.forHeader = true
+        root.heldEntries = root.buildEntries()
         root.place(scenePoint)
     }
 
@@ -73,14 +75,11 @@ Item {
         ? root.entries[root.openSubmenuRow].submenu : []
 
     // The row list this menu currently offers; a test reads this back through shell.qml's IPC.
-    readonly property var entries: root.buildEntries()
-
-    // The construction lives in ui/js/Menu.js now, so the rows are unit-testable without a window.
     function buildEntries() {
         // Which release a rail row offers is the rail's knowledge, not the listing's, so the rail
         // hands its rows in already built; see ui/js/Mounts.js "railMenu".
         if (root.forRail)
-            return root.railEntries
+            return root.heldEntries
         if (root.forHeader)
             return Menu.headerEntries(ViewState.hiddenCols, root.showHidden, ViewState.foldersFirst)
         return Menu.listingEntries({
@@ -93,7 +92,6 @@ Item {
             rowIsArchive: root.rowIsArchive,
             rowIsImage: root.rowIsImage,
             canConvert: root.canConvert,
-            openSuffix: root.openSuffix
         })
     }
 
@@ -118,8 +116,10 @@ Item {
 
     // Takes a point in scene coordinates and keeps the whole menu inside the pane it belongs to.
     function openAt(scenePoint) {
-        root.clearRail()
+        root.heldEntries = root.buildEntries()
+        root.forRail = false
         root.forHeader = false
+        root.railKey = ""
         root.place(scenePoint)
     }
 
@@ -129,14 +129,17 @@ Item {
         if (!entries || entries.length === 0)
             return
         root.railKey = key
-        root.railEntries = entries
+        root.forRail = true
+        root.heldEntries = entries
         root.place(scenePoint)
     }
 
     // Cleared on both ends: a rail entry left standing would put Eject on a listing row's menu.
     function clearRail() {
-        root.railEntries = []
+        root.forRail = false
         root.railKey = ""
+        root.heldEntries = []
+        root.forHeader = false
     }
 
     // Where the menu was asked to open, in this item's own coordinates; clampFrame runs twice on it.
@@ -198,8 +201,7 @@ Item {
         root.chosen(action)
     }
 
-    // One signal covers every submenu: a row with its own action fires it as named; a Taildrop peer
-    // or an archive format composes the row's parent verb with its id, as those two answer.
+    // A row with its own action fires it as named; a peer or format composes the parent verb + id.
     function chooseSub(sub) {
         var entry = root.entries[root.openSubmenuRow]
         root.close()
@@ -247,7 +249,6 @@ Item {
         surface: flyout
     }
 
-    // Hover and wheel blocking: an event that neither blocks would drive the rows beneath the menu.
     MouseArea {
         anchors.fill: parent
         acceptedButtons: Qt.NoButton
@@ -300,7 +301,6 @@ Item {
     Rectangle {
         id: flyout
         visible: root.submenuOpen
-        // The same blocking MouseArea the frame's backdrop carries, scaled to the flyout.
         MouseArea {
             anchors.fill: parent
             acceptedButtons: Qt.NoButton

--- a/ui/ContextMenu.qml
+++ b/ui/ContextMenu.qml
@@ -16,7 +16,6 @@ Item {
     property bool opened: false
     // Driven from ui/Pane.qml's own state, so this file owns no hidden-file logic itself.
     property bool showHidden: false
-    // The application name ui/Opener.qml resolved for the cursor row, shown muted beside "Open".
     property string openSuffix: ""
     // [{id, label}], the reachable Taildrop targets; empty self-hides the whole row, see ui/Taildrop.qml.
     property var taildropPeers: []
@@ -43,7 +42,7 @@ Item {
     signal railChosen(string action, string key)
 
     // ui/Header.qml's own entrance, the third face of this one instance: the column toggles and the
-    // state rows built from qs module ViewState, flowing back through chosen() like the listing's.
+    // state rows, flowing back through chosen() like the listing's.
     property bool forHeader: false
     function openForHeader(scenePoint) {
         root.forHeader = true
@@ -76,8 +75,7 @@ Item {
     // The row list this menu currently offers; a test reads this back through shell.qml's IPC.
     readonly property var entries: root.buildEntries()
 
-    // The construction lives in ui/js/Menu.js now, so the rows are unit-testable without a window;
-    // this file only routes between the three faces.
+    // The construction lives in ui/js/Menu.js now, so the rows are unit-testable without a window.
     function buildEntries() {
         // Which release a rail row offers is the rail's knowledge, not the listing's, so the rail
         // hands its rows in already built; see ui/js/Mounts.js "railMenu".
@@ -200,8 +198,8 @@ Item {
         root.chosen(action)
     }
 
-    // One signal covers every submenu: a row with its own whole action fires it as named; a Taildrop
-    // peer or an archive format composes the row's parent verb with its id, as those two answer.
+    // One signal covers every submenu: a row with its own action fires it as named; a Taildrop peer
+    // or an archive format composes the row's parent verb with its id, as those two answer.
     function chooseSub(sub) {
         var entry = root.entries[root.openSubmenuRow]
         root.close()
@@ -249,8 +247,7 @@ Item {
         surface: flyout
     }
 
-    // Hover and wheel blocking: an event that neither blocks would drive the rows beneath an open
-    // menu. No buttons, so presses stay with the rows.
+    // Hover and wheel blocking: an event that neither blocks would drive the rows beneath the menu.
     MouseArea {
         anchors.fill: parent
         acceptedButtons: Qt.NoButton
@@ -312,7 +309,8 @@ Item {
         }
         x: frame.x + frame.width
         // peers.y already carries the inset, so the flyout frame itself stays on the row grid.
-        y: frame.y + root.submenuOffset()
+        // A flyout near the bottom drops up: clamped against the pane, a row of air to spare.
+        y: Menu.clamp(frame.y + root.submenuOffset(), height + Theme.spacing.rowPaddingY, parent.height)
         width: Theme.menuWidth
         height: peers.implicitHeight + 2 * Theme.spacing.rowPaddingY
         color: Theme.color.surface
@@ -381,11 +379,12 @@ Item {
                 event.accepted = true
                 return
             }
-            if (action === "open" || action === "preview") {
+            // Right and Enter and Space all choose; Right on a shut flyout opens it, Left shuts it.
+            if (action === "open" || action === "preview" || action === "seekForward") {
                 if (root.submenuOpen) {
                     var sub = root.submenuEntries[root.submenuCursor]
                     if (sub)
-                        root.chooseSub(sub.id)
+                        root.chooseSub(sub)
                 } else {
                     var entry = root.entries[root.cursor]
                     if (Menu.hasSubmenu(entry))
@@ -395,6 +394,7 @@ Item {
                 }
                 event.accepted = true
             }
+            if ((action === "seekBack" || action === "cursorLeft") && root.submenuOpen) { root.openSubmenuRow = -1; event.accepted = true; return }
         }
     }
 }

--- a/ui/ContextMenu.qml
+++ b/ui/ContextMenu.qml
@@ -85,9 +85,7 @@ Item {
             return root.heldEntries
         if (root.forHeader)
             return Menu.headerEntries(ViewState.hiddenCols, root.showHidden, ViewState.foldersFirst)
-        if (root.confirming)
-            return Menu.confirmEntries()
-        return Menu.listingEntries(root)
+        return Menu.listingEntries(root, root.confirming)
     }
 
     // A separator is never the cursor, so both key steps and the opening cursor skip over one.
@@ -187,12 +185,11 @@ Item {
     // The menu closes before the action runs, so it never hangs over the listing that action opened.
     function choose(action) {
         // Move to Trash pauses for an in-menu keep/trash pair, Keep first, before it commits: the
-        // morph is deliberate, so the same tap that opens the menu cannot also empty it. Keep puts
-        // the listing back untouched; Trash is the only way through.
+        // pair grows inside the untouched menu, so nothing collapses or jumps. Keep puts the listing
+        // back; Trash is the only way through.
         if (action === "trash" && !root.confirming) {
             root.confirming = true
-            root.heldEntries = Menu.confirmEntries()
-            root.cursor = 0
+            root.heldEntries = root.buildEntries()
             return
         }
         // Both read before close(), which is what clears them.
@@ -260,7 +257,6 @@ Item {
     MouseArea {
         anchors.fill: parent
         acceptedButtons: Qt.NoButton
-        hoverEnabled: true
         onWheel: function (wheel) { wheel.accepted = true }
         z: 1
     }
@@ -316,7 +312,6 @@ Item {
         MouseArea {
             anchors.fill: parent
             acceptedButtons: Qt.NoButton
-            hoverEnabled: true
             onWheel: function (wheel) { wheel.accepted = true }
         }
         x: frame.x + frame.width
@@ -361,5 +356,6 @@ Item {
         id: keyCatcher
         anchors.fill: parent
         focus: true
+        menu: root
     }
 }

--- a/ui/ContextMenu.qml
+++ b/ui/ContextMenu.qml
@@ -114,7 +114,7 @@ Item {
     visible: root.opened
     z: 1
 
-    // Takes a point in scene coordinates and keeps the whole menu inside the pane it belongs to.
+    // Keeps the whole menu inside the pane it belongs to.
     function openAt(scenePoint) {
         root.heldEntries = root.buildEntries()
         root.forRail = false
@@ -218,7 +218,7 @@ Item {
         root.submenuCursor = 0
     }
 
-    // Rows above the open one are a mix of full rows and separators, so the offset is summed, not multiplied.
+    // Rows above the open one mix rows and separators, so the offset is summed, not multiplied.
     function submenuOffset() {
         var y = 0
         for (var i = 0; i < root.openSubmenuRow; i++)
@@ -345,9 +345,8 @@ Item {
         }
     }
 
-    // One focus catcher for the whole menu: real QML focus never moves into the Repeater rows
-    // themselves, so every key lands here regardless of which level is open. They arrive through
-    // keys.toml's own table, so j and k step this list the way they step every other one.
+    // One focus catcher for the whole menu: real QML focus never moves into the Repeater rows, so
+    // every key lands here at either level, through keys.toml's own table — j and k step the list.
     Item {
         id: keyCatcher
         anchors.fill: parent

--- a/ui/ContextMenu.qml
+++ b/ui/ContextMenu.qml
@@ -42,10 +42,8 @@ Item {
     readonly property bool forRail: root.railEntries.length > 0
     signal railChosen(string action, string key)
 
-    // ui/Header.qml's own entrance, the third face of this one instance: openForHeader() flips the
-    // entries to ui/js/Menu.js headerEntries (the column toggles and the Advanced group, built from
-    // qs module ViewState's hidden columns and the pane's showHidden), and every row flows back
-    // through chosen() like the listing's own. A row's chosen verb routes by prefix in ui/Pane.qml.
+    // ui/Header.qml's own entrance, the third face of this one instance: the column toggles and the
+    // state rows built from qs module ViewState, flowing back through chosen() like the listing's.
     property bool forHeader: false
     function openForHeader(scenePoint) {
         root.forHeader = true
@@ -78,9 +76,8 @@ Item {
     // The row list this menu currently offers; a test reads this back through shell.qml's IPC.
     readonly property var entries: root.buildEntries()
 
-    // The construction lives in ui/js/Menu.js now, so the rows are unit-testable without a window:
-    // listingEntries(p) builds the listing's rows from the pane's state, headerEntries() the column
-    // titles' own rows on a right click (see ui/Header.qml), and this file only routes between them.
+    // The construction lives in ui/js/Menu.js now, so the rows are unit-testable without a window;
+    // this file only routes between the three faces.
     function buildEntries() {
         // Which release a rail row offers is the rail's knowledge, not the listing's, so the rail
         // hands its rows in already built; see ui/js/Mounts.js "railMenu".
@@ -203,12 +200,17 @@ Item {
         root.chosen(action)
     }
 
-    // One signal covers every submenu: the row's own action, a colon, and the entry chosen inside it.
-    function chooseSub(id) {
+    // One signal covers every submenu: a row with its own whole action fires it as named; a Taildrop
+    // peer or an archive format composes the row's parent verb with its id, as those two answer.
+    function chooseSub(sub) {
         var entry = root.entries[root.openSubmenuRow]
         root.close()
-        if (entry)
-            root.chosen(entry.action + ":" + id)
+        if (!entry)
+            return
+        if (sub.action !== undefined && sub.action.length > 0)
+            root.chosen(sub.action)
+        else
+            root.chosen(entry.action + ":" + sub.id)
     }
 
     function openSubmenu(index) {
@@ -245,6 +247,16 @@ Item {
 
     Flea.Shadow {
         surface: flyout
+    }
+
+    // Hover and wheel blocking: an event that neither blocks would drive the rows beneath an open
+    // menu. No buttons, so presses stay with the rows.
+    MouseArea {
+        anchors.fill: parent
+        acceptedButtons: Qt.NoButton
+        hoverEnabled: true
+        onWheel: function (wheel) { wheel.accepted = true }
+        z: 1
     }
 
     Rectangle {
@@ -291,6 +303,13 @@ Item {
     Rectangle {
         id: flyout
         visible: root.submenuOpen
+        // The same blocking MouseArea the frame's backdrop carries, scaled to the flyout.
+        MouseArea {
+            anchors.fill: parent
+            acceptedButtons: Qt.NoButton
+            hoverEnabled: true
+            onWheel: function (wheel) { wheel.accepted = true }
+        }
         x: frame.x + frame.width
         // peers.y already carries the inset, so the flyout frame itself stays on the row grid.
         y: frame.y + root.submenuOffset()
@@ -315,11 +334,14 @@ Item {
                     width: peers.width
                     // A Taildrop peer is a machine and takes the sidebar's own server mark; an archive
                     // format is a file about to exist and takes the archive mark.
+                    // A row with its own whole action (the Advanced group) fires it directly; a
+                    // Taildrop peer or an archive format composes the parent verb with its id.
                     entry: ({ label: subRow.modelData.label, action: "",
-                              glyph: root.entries[root.openSubmenuRow].action === "taildrop" ? "server" : "archive" })
+                              glyph: subRow.modelData.glyph !== undefined ? subRow.modelData.glyph
+                                    : root.entries[root.openSubmenuRow].action === "taildrop" ? "server" : "archive" })
                     current: root.submenuCursor === subRow.index
                     onHoverEntered: root.submenuCursor = subRow.index
-                    onActivated: root.chooseSub(subRow.modelData.id)
+                    onActivated: root.chooseSub(subRow.modelData)
                 }
             }
         }

--- a/ui/ContextMenu.qml
+++ b/ui/ContextMenu.qml
@@ -1,7 +1,6 @@
 import QtQuick
 import qs.Commons
 import "." as Flea
-import "js/Keymap.js" as Keymap
 import "js/Menu.js" as Menu
 
 // A plain overlay, not a QQC Popup: the one Controls import cost 10 ms of warm startup.
@@ -16,6 +15,11 @@ Item {
     property bool opened: false
     // Driven from ui/Pane.qml's own state, so this file owns no hidden-file logic itself.
     property bool showHidden: false
+    // The application name ui/Opener.qml resolved for the cursor row, shown muted beside "Open".
+    property string openSuffix: ""
+    // Move to Trash pauses on a keep/trash pair before it commits: true from the moment the danger
+    // row is chosen until the menu closes, and the entries are the pair while it stands.
+    property bool confirming: false
     // [{id, label}], the reachable Taildrop targets; empty self-hides the whole row, see ui/Taildrop.qml.
     property var taildropPeers: []
     // The archive formats this box actually probed, and whether a converter is installed at all.
@@ -76,23 +80,14 @@ Item {
 
     // The row list this menu currently offers; a test reads this back through shell.qml's IPC.
     function buildEntries() {
-        // Which release a rail row offers is the rail's knowledge, not the listing's, so the rail
-        // hands its rows in already built; see ui/js/Mounts.js "railMenu".
+        // The rail hands its rows in already built, see ui/js/Mounts.js "railMenu".
         if (root.forRail)
             return root.heldEntries
         if (root.forHeader)
             return Menu.headerEntries(ViewState.hiddenCols, root.showHidden, ViewState.foldersFirst)
-        return Menu.listingEntries({
-            showHidden: root.showHidden,
-            hasRow: root.hasRow,
-            rowInDropbox: root.rowInDropbox,
-            dropboxPath: root.dropboxPath,
-            taildropPeers: root.taildropPeers,
-            archiveFormats: root.archiveFormats,
-            rowIsArchive: root.rowIsArchive,
-            rowIsImage: root.rowIsImage,
-            canConvert: root.canConvert,
-        })
+        if (root.confirming)
+            return Menu.confirmEntries()
+        return Menu.listingEntries(root)
     }
 
     // A separator is never the cursor, so both key steps and the opening cursor skip over one.
@@ -183,6 +178,7 @@ Item {
             return
         root.opened = false
         root.openSubmenuRow = -1
+        root.confirming = false
         root.clearRail()
         if (root.focusHolder)
             root.focusHolder.forceActiveFocus()
@@ -190,15 +186,27 @@ Item {
 
     // The menu closes before the action runs, so it never hangs over the listing that action opened.
     function choose(action) {
+        // Move to Trash pauses for an in-menu keep/trash pair, Keep first, before it commits: the
+        // morph is deliberate, so the same tap that opens the menu cannot also empty it. Keep puts
+        // the listing back untouched; Trash is the only way through.
+        if (action === "trash" && !root.confirming) {
+            root.confirming = true
+            root.heldEntries = Menu.confirmEntries()
+            root.cursor = 0
+            return
+        }
         // Both read before close(), which is what clears them.
         var key = root.railKey
         var rail = root.forRail
+        var keep = action === "keepTrash"
+        root.confirming = false
         root.close()
         if (rail) {
             root.railChosen(action, key)
             return
         }
-        root.chosen(action)
+        if (!keep)
+            root.chosen(action)
     }
 
     // A row with its own action fires it as named; a peer or format composes the parent verb + id.
@@ -269,6 +277,10 @@ Item {
         border.color: Theme.color.muted
         // Mirrors hyprland decoration:rounding, same as NetworkDialog; 0 on a stock box stays square.
         radius: Style.cornerRadius
+
+        // Blocks the HoverHandlers beneath the menu — the listing rows would tint and read as a
+        // selection while the pointer crosses the frame — and leaves this frame's own rows alone.
+        HoverHandler { blocking: true }
 
         Column {
             id: rows
@@ -345,55 +357,9 @@ Item {
         }
     }
 
-    // One focus catcher for the whole menu: real QML focus never moves into the Repeater rows, so
-    // every key lands here at either level, through keys.toml's own table — j and k step the list.
-    Item {
+    MenuKeys {
         id: keyCatcher
         anchors.fill: parent
         focus: true
-
-        Keys.onPressed: function (event) {
-            var action = Keymap.lookup(event.key, event.text, event.modifiers)
-            if (action === "escape") {
-                if (root.submenuOpen)
-                    root.openSubmenuRow = -1
-                else
-                    root.close()
-                event.accepted = true
-                return
-            }
-            if (action === "cursorDown") {
-                if (root.submenuOpen)
-                    root.submenuCursor = Math.min(root.submenuEntries.length - 1, root.submenuCursor + 1)
-                else
-                    root.cursor = root.stepCursor(root.cursor, 1)
-                event.accepted = true
-                return
-            }
-            if (action === "cursorUp") {
-                if (root.submenuOpen)
-                    root.submenuCursor = Math.max(0, root.submenuCursor - 1)
-                else
-                    root.cursor = root.stepCursor(root.cursor, -1)
-                event.accepted = true
-                return
-            }
-            // Right and Enter and Space all choose; Right on a shut flyout opens it, Left shuts it.
-            if (action === "open" || action === "preview" || action === "seekForward") {
-                if (root.submenuOpen) {
-                    var sub = root.submenuEntries[root.submenuCursor]
-                    if (sub)
-                        root.chooseSub(sub)
-                } else {
-                    var entry = root.entries[root.cursor]
-                    if (Menu.hasSubmenu(entry))
-                        root.openSubmenu(root.cursor)
-                    else if (entry && entry.separator !== true)
-                        root.choose(entry.action)
-                }
-                event.accepted = true
-            }
-            if ((action === "seekBack" || action === "cursorLeft") && root.submenuOpen) { root.openSubmenuRow = -1; event.accepted = true; return }
-        }
     }
 }

--- a/ui/ContextMenu.qml
+++ b/ui/ContextMenu.qml
@@ -87,7 +87,7 @@ Item {
         if (root.forRail)
             return root.railEntries
         if (root.forHeader)
-            return Menu.headerEntries(ViewState.hiddenCols, root.showHidden)
+            return Menu.headerEntries(ViewState.hiddenCols, root.showHidden, ViewState.foldersFirst)
         return Menu.listingEntries({
             showHidden: root.showHidden,
             hasRow: root.hasRow,

--- a/ui/Header.qml
+++ b/ui/Header.qml
@@ -13,6 +13,10 @@ Item {
     // was hit; the key is the protocol's own, which is why Date Modified sends "mtime".
     signal sortRequested(string key)
 
+    // A right click over the titles opens the pane's one ContextMenu with the column toggles and
+    // the Advanced group; a left click still sorts, and sortable still gates everything on a search.
+    signal menuRequested(var scenePosition)
+
     // The same hairline lift the status bar uses, so the two rules read alike.
     readonly property real ruleOpacity: 0.12
 
@@ -27,9 +31,10 @@ Item {
     // accepts no input, so the titles under it stay hittable unless the handlers go down with them.
     readonly property bool sortable: root.searchMode.length === 0
 
-    // The columns this width affords. ui/Row.qml resolves its own from a width anchoring keeps
+    // The columns this width affords, less the ones the user has hidden (qs module ViewState).
+    // ui/Row.qml resolves its own from a width anchoring keeps
     // equal to this one, so the header can never head a column no row below it is drawing.
-    readonly property var cols: Theme.columns(root.width)
+    readonly property var cols: Theme.columns(root.width, ViewState.hiddenCols)
 
     implicitHeight: Theme.chromeHeight
 
@@ -113,6 +118,13 @@ Item {
         TapHandler { enabled: root.sortable; onTapped: root.sortRequested("kind") }
     }
 
+    // The header is chrome, but it is the chrome the columns belong to, so its right click is where
+    // the columns are turned on and off. Left click sorts; sortable gates that, not this.
+    TapHandler {
+        acceptedButtons: Qt.RightButton
+        onTapped: function (eventPoint) { root.menuRequested(eventPoint.scenePosition) }
+    }
+
     Rectangle {
         anchors.bottom: parent.bottom
         anchors.left: parent.left
@@ -136,7 +148,7 @@ Item {
     }
 
     // What the header is drawing right now, for the seam that reads it beside a row's.
-    function columnSet() { return Theme.columnNames(root.width) }
+    function columnSet() { return Theme.columnNames(root.width, ViewState.hiddenCols) }
 
     // The one lookup the geometry reader needs, the same by-key idiom Pane.itemFor uses for rows.
     function cell(key) {

--- a/ui/List.qml
+++ b/ui/List.qml
@@ -50,7 +50,9 @@ ListView {
         width: root.width
         row: root.pane.rowFor(listingIndex)
         cursor: listingIndex === root.pane.cursorIndex
-        hovered: hover.hovered
+        // The menu stands over the listing when it is open, and a HoverHandler cannot know that:
+        // gate the tint on it, or rows beneath the flyout light up as the pointer crosses it.
+        hovered: hover.hovered && !root.menu.opened
         thumb: root.thumbFor(listingIndex)
         // The zebra follows the drawn position, so a narrowed listing still alternates row by row.
         alternate: index % 2 === 1

--- a/ui/MenuKeys.qml
+++ b/ui/MenuKeys.qml
@@ -1,22 +1,30 @@
 import QtQuick
-import qs.Commons
 import "." as Flea
 import "js/Keymap.js" as Keymap
 import "js/Menu.js" as Menu
 
 // One focus catcher for the whole menu: real QML focus never moves into the Repeater rows, so
 // every key lands here at either level, through keys.toml's own table — j and k step the list.
+// Split out of ui/ContextMenu.qml for the file budget; `menu` is the ContextMenu it serves.
 Item {
     id: keyCatcher
     anchors.fill: parent
     focus: true
 
+    property var menu: null
+
     Keys.onPressed: function (event) {
+        if (menu === null)
+            return
         var action = Keymap.lookup(event.key, event.text, event.modifiers)
+        // Escape unwinds one level at a time: the flyout, then the keep/trash pair, then the menu.
         if (action === "escape") {
             if (menu.submenuOpen)
                 menu.openSubmenuRow = -1
-            else
+            else if (menu.confirming) {
+                menu.confirming = false
+                menu.heldEntries = menu.buildEntries()
+            } else
                 menu.close()
             event.accepted = true
             return
@@ -51,6 +59,12 @@ Item {
                     menu.choose(entry.action)
             }
             event.accepted = true
+            return
         }
-        if ((action === "seekBack" || action === "cursorLeft") && menu.submenuOpen) { menu.openSubmenuRow = -1; event.accepted = true; return }
-
+        if ((action === "seekBack" || action === "cursorLeft") && menu.submenuOpen) {
+            menu.openSubmenuRow = -1
+            event.accepted = true
+            return
+        }
+    }
+}

--- a/ui/MenuKeys.qml
+++ b/ui/MenuKeys.qml
@@ -1,0 +1,56 @@
+import QtQuick
+import qs.Commons
+import "." as Flea
+import "js/Keymap.js" as Keymap
+import "js/Menu.js" as Menu
+
+// One focus catcher for the whole menu: real QML focus never moves into the Repeater rows, so
+// every key lands here at either level, through keys.toml's own table — j and k step the list.
+Item {
+    id: keyCatcher
+    anchors.fill: parent
+    focus: true
+
+    Keys.onPressed: function (event) {
+        var action = Keymap.lookup(event.key, event.text, event.modifiers)
+        if (action === "escape") {
+            if (menu.submenuOpen)
+                menu.openSubmenuRow = -1
+            else
+                menu.close()
+            event.accepted = true
+            return
+        }
+        if (action === "cursorDown") {
+            if (menu.submenuOpen)
+                menu.submenuCursor = Math.min(menu.submenuEntries.length - 1, menu.submenuCursor + 1)
+            else
+                menu.cursor = menu.stepCursor(menu.cursor, 1)
+            event.accepted = true
+            return
+        }
+        if (action === "cursorUp") {
+            if (menu.submenuOpen)
+                menu.submenuCursor = Math.max(0, menu.submenuCursor - 1)
+            else
+                menu.cursor = menu.stepCursor(menu.cursor, -1)
+            event.accepted = true
+            return
+        }
+        // Right and Enter and Space all choose; Right on a shut flyout opens it, Left shuts it.
+        if (action === "open" || action === "preview" || action === "seekForward") {
+            if (menu.submenuOpen) {
+                var sub = menu.submenuEntries[menu.submenuCursor]
+                if (sub)
+                    menu.chooseSub(sub)
+            } else {
+                var entry = menu.entries[menu.cursor]
+                if (Menu.hasSubmenu(entry))
+                    menu.openSubmenu(menu.cursor)
+                else if (entry && entry.separator !== true)
+                    menu.choose(entry.action)
+            }
+            event.accepted = true
+        }
+        if ((action === "seekBack" || action === "cursorLeft") && menu.submenuOpen) { menu.openSubmenuRow = -1; event.accepted = true; return }
+

--- a/ui/MenuRow.qml
+++ b/ui/MenuRow.qml
@@ -35,7 +35,6 @@ Item {
                                       : root.picked ? Theme.color.accent : Theme.color.foreground
 
     // The hover lift Row.qml uses, so a menu row and a list row read alike.
-    readonly property real hoverOpacity: 0.08
     // A separator is a hairline with one gap of air around it, which is the mock's 11 px read from tokens instead.
     readonly property int separatorHeight: Theme.spacing.gap + Theme.spacing.hairline
     readonly property real separatorOpacity: 0.4
@@ -51,8 +50,12 @@ Item {
         visible: !root.isSeparator
         // selectedAccentFill already carries the theme's own selected alpha, so the tint is a
         // colour here and an opacity for the plain lift, never both at once.
-        color: root.picked ? Style.selectedAccentFill : Theme.color.foreground
-        opacity: root.picked ? 1 : (root.current ? root.hoverOpacity : 0)
+        // The hover fill is the listing row's own Style.hoverFill rung, so a menu row hovers as
+        // visibly as a listing row does; the old 8 percent foreground tint read as no hover at all.
+        color: root.picked ? Style.selectedAccentFill
+             : root.current ? Style.hoverFill
+             : "transparent"
+        opacity: 1
     }
 
     Rectangle {

--- a/ui/MenuRow.qml
+++ b/ui/MenuRow.qml
@@ -164,6 +164,10 @@ Item {
     TapHandler {
         enabled: !root.isSeparator
         acceptedButtons: Qt.LeftButton
+        // ReleaseWithinBounds takes the point exclusively on press: the menu stands over the
+        // listing, and the DragThreshold default's passive grab let every tap fall through to the
+        // row beneath, which read as the menu reaching through and moving the selection.
+        gesturePolicy: TapHandler.ReleaseWithinBounds
         onTapped: root.activated()
     }
 }

--- a/ui/MenuRow.qml
+++ b/ui/MenuRow.qml
@@ -50,10 +50,11 @@ Item {
         visible: !root.isSeparator
         // selectedAccentFill already carries the theme's own selected alpha, so the tint is a
         // colour here and an opacity for the plain lift, never both at once.
-        // The hover fill is the listing row's own Style.hoverFill rung, so a menu row hovers as
-        // visibly as a listing row does; the old 8 percent foreground tint read as no hover at all.
+        // The hover fill is the cursor's own selectedFill rung, not the 8 percent hover tint a
+        // listing row takes: on the menu's surface that tint is invisible, and a menu row that is
+        // hovered is as chosen as one the keyboard moved to.
         color: root.picked ? Style.selectedAccentFill
-             : root.current ? Style.hoverFill
+             : root.current ? Style.selectedFill
              : "transparent"
         opacity: 1
     }

--- a/ui/MenuRow.qml
+++ b/ui/MenuRow.qml
@@ -101,14 +101,36 @@ Item {
     }
 
     Text {
+        id: label
         visible: !root.isSeparator
         anchors.left: markSlot.right
         anchors.leftMargin: Theme.spacing.gap
-        anchors.right: chevronSlot.left
-        anchors.rightMargin: Theme.spacing.gap
+        // A row carrying a suffix (the menu's Open row names the app xdg-open would choose) gives
+        // the suffix the room its own width needs and lets the label elide against it; a row
+        // without one lets the label run to the disclosure slot as it always has.
+        anchors.right: suffix.visible ? suffix.left : chevronSlot.left
+        anchors.rightMargin: suffix.visible ? Theme.spacing.gap : Theme.spacing.gap
         anchors.verticalCenter: parent.verticalCenter
         text: root.entry.label !== undefined ? root.entry.label : ""
         color: root.labelColor
+        font.family: Theme.font.family
+        font.pixelSize: Theme.font.bodySmall
+        textFormat: Text.PlainText
+        elide: Text.ElideRight
+    }
+
+    // The muted tail a row can carry: the Open row's resolved application name, so the menu says
+    // what is about to run before the hand commits to the click. Muted at the theme's own muted
+    // role, never a hardcoded grey, and it clips before it can crowd the label out.
+    Text {
+        id: suffix
+        visible: root.entry.suffix !== undefined && root.entry.suffix.length > 0
+        anchors.right: chevronSlot.left
+        anchors.rightMargin: Theme.spacing.gap
+        anchors.verticalCenter: parent.verticalCenter
+        width: Math.min(implicitWidth, parent.width / 2)
+        text: root.entry.suffix !== undefined ? root.entry.suffix : ""
+        color: Theme.color.muted
         font.family: Theme.font.family
         font.pixelSize: Theme.font.bodySmall
         textFormat: Text.PlainText

--- a/ui/Opener.qml
+++ b/ui/Opener.qml
@@ -38,4 +38,53 @@ Item {
             root.failed(root.current)
         }
     }
+
+    // The application name xdg-open would resolve for a path, for the listing menu's Open row
+    // ("Open" beside the resolved name in muted type, so the menu says what is about to run).
+    // Empty means flea itself is the answer: a directory navigates, and an unresolved mime says
+    // nothing worth reading. One Process serves every query, the way open() does.
+    property string defaultAppName: ""
+
+    function defaultAppFor(path) {
+        if (resolver.running) {
+            return
+        }
+        resolver.command = ["sh", "-c",
+            'p="$1"; m=$(xdg-mime query filetype "$p" 2>/dev/null) || exit 0; '
+            + '[ "$m" = "inode/directory" ] && exit 0; '
+            + 'd=$(xdg-mime query default "$m" 2>/dev/null) || exit 0; [ -n "$d" ] || exit 0; '
+            + 'for f in "${XDG_DATA_HOME:-$HOME/.local/share}/applications/$d"'
+            + ' /usr/local/share/applications/$d /usr/share/applications/$d; do '
+            + '[ -f "$f" ] || continue; sed -n "s/^Name=//p" "$f" | head -n 1; exit 0; done',
+            "_", path]
+        resolver.running = true
+    }
+
+    // The system clipboard, for the listing menu's Copy Path row. wl-copy reads the text on stdin,
+    // so the one-liner hands it over; flea's own copy clipboard (Ops.clip) is a different thing
+    // and must stay a different thing.
+    function copyText(text) {
+        if (copier.running) {
+            return
+        }
+        copier.command = ["sh", "-c", "printf '%s' \"$1\" | wl-copy", "_", text]
+        copier.running = true
+    }
+
+    Process {
+        id: resolver
+
+        stdout: SplitParser {
+            onRead: function (data) {
+                var name = ("" + data).trim()
+                if (name.length > 0)
+                    root.defaultAppName = name
+            }
+        }
+    }
+
+    Process {
+        id: copier
+    }
+
 }

--- a/ui/Pane.qml
+++ b/ui/Pane.qml
@@ -350,7 +350,6 @@ FocusScope {
         dropboxPath: sidebar.dropboxReady ? root.home + "/Dropbox" : ""
         // The separator is part of the test, or /home/gm/DropboxBackup would count as inside Dropbox.
         rowInDropbox: root.path === root.home + "/Dropbox" || root.path.indexOf(root.home + "/Dropbox/") === 0
-        openSuffix: wire.opener.defaultAppName
         onChosen: function (action) {
             if (action.indexOf("taildrop:") === 0) { root.sendTaildrop(action.substring("taildrop:".length)); return }
             if (action === "copypath") { wire.opener.copyText(root.path + "/" + root.cursorRow.n); return }

--- a/ui/Pane.qml
+++ b/ui/Pane.qml
@@ -350,12 +350,12 @@ FocusScope {
         dropboxPath: sidebar.dropboxReady ? root.home + "/Dropbox" : ""
         // The separator is part of the test, or /home/gm/DropboxBackup would count as inside Dropbox.
         rowInDropbox: root.path === root.home + "/Dropbox" || root.path.indexOf(root.home + "/Dropbox/") === 0
-        // The Open row's muted tail: the app xdg-open would choose, resolved as the cursor moves; empty for a directory.
         openSuffix: wire.opener.defaultAppName
         onChosen: function (action) {
             if (action.indexOf("taildrop:") === 0) { root.sendTaildrop(action.substring("taildrop:".length)); return }
             if (action === "copypath") { wire.opener.copyText(root.path + "/" + root.cursorRow.n); return }
             if (action.indexOf("col:") === 0) { ViewState.toggleColumn(action.substring("col:".length)); return }
+            if (action === "foldersFirst") { ViewState.toggleFoldersFirst(); root.open(root.path); return }
             root.act(action)
         }
     }

--- a/ui/Pane.qml
+++ b/ui/Pane.qml
@@ -350,6 +350,7 @@ FocusScope {
         dropboxPath: sidebar.dropboxReady ? root.home + "/Dropbox" : ""
         // The separator is part of the test, or /home/gm/DropboxBackup would count as inside Dropbox.
         rowInDropbox: root.path === root.home + "/Dropbox" || root.path.indexOf(root.home + "/Dropbox/") === 0
+        openSuffix: wire.opener.defaultAppName
         onChosen: function (action) {
             if (action.indexOf("taildrop:") === 0) { root.sendTaildrop(action.substring("taildrop:".length)); return }
             if (action === "copypath") { wire.opener.copyText(root.path + "/" + root.cursorRow.n); return }

--- a/ui/Pane.qml
+++ b/ui/Pane.qml
@@ -255,6 +255,7 @@ FocusScope {
         sortBy: root.backend.sortBy
         sortDesc: root.backend.sortDesc
         onSortRequested: function (key) { Sort.column(root, key) }
+        onMenuRequested: function (pos) { menu.openForHeader(pos) }
         searchMode: root.searchMode
         searchQuery: root.searchQuery
         searchScope: Search.scope(Search.scopeRoot(root.path, root.home), root.home)
@@ -348,13 +349,13 @@ FocusScope {
         rowIsImage: root.cursorRow !== null && root.cursorRow.i === "image-x-generic"
         dropboxPath: sidebar.dropboxReady ? root.home + "/Dropbox" : ""
         // The separator is part of the test, or /home/gm/DropboxBackup would count as inside Dropbox.
-        rowInDropbox: root.path === root.home + "/Dropbox"
-                      || root.path.indexOf(root.home + "/Dropbox/") === 0
+        rowInDropbox: root.path === root.home + "/Dropbox" || root.path.indexOf(root.home + "/Dropbox/") === 0
+        // The Open row's muted tail: the app xdg-open would choose, resolved as the cursor moves; empty for a directory.
+        openSuffix: wire.opener.defaultAppName
         onChosen: function (action) {
-            if (action.indexOf("taildrop:") === 0) {
-                root.sendTaildrop(action.substring("taildrop:".length))
-                return
-            }
+            if (action.indexOf("taildrop:") === 0) { root.sendTaildrop(action.substring("taildrop:".length)); return }
+            if (action === "copypath") { wire.opener.copyText(root.path + "/" + root.cursorRow.n); return }
+            if (action.indexOf("col:") === 0) { ViewState.toggleColumn(action.substring("col:".length)); return }
             root.act(action)
         }
     }

--- a/ui/PaneWire.qml
+++ b/ui/PaneWire.qml
@@ -21,6 +21,17 @@ Item {
     // ui/Pane.qml reaches the three through these: openCursor takes the opener, the menu reads the
     // Taildrop peers, and the two share actions call the other two.
     readonly property alias opener: opener
+
+    // The Open row's application name is resolved as the cursor moves, so the menu's muted tail is
+    // already on screen when the menu opens; the cursor belongs to the pane, the resolver to the
+    // opener, and this wire is where the two meet.
+    Connections {
+        target: pane
+        function onCursorRowChanged() {
+            if (pane.cursorRow !== null)
+                opener.defaultAppFor((pane.path === "/" ? "" : pane.path) + "/" + pane.cursorRow.n)
+        }
+    }
     readonly property alias shareLink: shareLink
     readonly property alias taildrop: taildrop
 

--- a/ui/Row.qml
+++ b/ui/Row.qml
@@ -43,7 +43,7 @@ Item {
     // The columns this row's width affords, and which of them this row is drawing. A column that
     // is not drawn takes neither its width nor its gap, so the chain collapses onto the one to its
     // right and the name takes back the whole of it.
-    readonly property var cols: Theme.columns(root.width)
+    readonly property var cols: Theme.columns(root.width, ViewState.hiddenCols)
     readonly property bool modeShown: !root.searching && root.cols.mode
     // The search column set keeps Size and drops the other three, so only this one ignores searching.
     readonly property bool sizeShown: root.cols.size
@@ -350,7 +350,7 @@ Item {
     }
 
     // What this row is drawing right now, for the seam that reads it beside the header's.
-    function columnSet() { return Theme.columnNames(root.width) }
+    function columnSet() { return Theme.columnNames(root.width, ViewState.hiddenCols) }
 
     // The same by-key idiom Header.cell uses, so the overflow reader can reach a specific cell.
     function cell(key) {

--- a/ui/Theme.qml
+++ b/ui/Theme.qml
@@ -150,10 +150,11 @@ Singleton {
         readonly property real fraction: 0.82
     }
 
-    // The column set a list of this width can draw. ui/Header.qml and ui/Row.qml each call this
-    // with their own width, which anchoring keeps equal, so the header and the rows below it
-    // cannot disagree about which columns exist.
-    function columns(width) {
+    // The column set a list of this width can draw, less the columns the user has hidden (qs
+    // module ViewState). ui/Header.qml and ui/Row.qml each call this with their own width, which
+    // anchoring keeps equal, so the header and the rows below it cannot disagree about which
+    // columns exist.
+    function columns(width, hidden) {
         return Columns.set(width, {
             rowPaddingX: root.spacing.rowPaddingX,
             gap: root.spacing.gap,
@@ -163,12 +164,12 @@ Singleton {
             size: root.column.size,
             date: root.column.date,
             kind: root.column.kind
-        });
+        }, hidden);
     }
 
     // The same set as one string, which is what the seam in ui/Ipc.qml compares across the two.
-    function columnNames(width) {
-        return Columns.names(root.columns(width));
+    function columnNames(width, hidden) {
+        return Columns.names(root.columns(width, hidden));
     }
 
     // Five callers: ConvertDialog, KeymapSheet, NetworkDialog, NetworkForm, TransferCard; every other spacing token above is direct.

--- a/ui/ViewState.qml
+++ b/ui/ViewState.qml
@@ -16,6 +16,16 @@ QtObject {
     // it is the one column a file manager cannot do without, see ui/js/Columns.js.
     property var hiddenCols: []
 
+    // The backend's standing "dirs" answer (true is the shipped default): every list and sort this
+    // session sends carries it, and the header menu's flip re-lists, which is toggleHidden's own
+    // gesture for a state that changes what the listing shows.
+    property bool foldersFirst: true
+
+    function toggleFoldersFirst() {
+        root.foldersFirst = !root.foldersFirst
+        save()
+    }
+
     // Flipped by ui/Pane.qml's onChosen, when a header-menu row answers "col:<key>".
     function toggleColumn(key) {
         var next = []
@@ -30,7 +40,7 @@ QtObject {
         if (!had)
             next.push(key)
         root.hiddenCols = next
-        store.setText(JSON.stringify({ hiddenCols: root.hiddenCols }, null, 2) + "\n")
+        store.setText(JSON.stringify({ hiddenCols: root.hiddenCols, foldersFirst: root.foldersFirst }, null, 2) + "\n")
     }
 
     function load() {
@@ -38,6 +48,8 @@ QtObject {
             var parsed = JSON.parse(store.text())
             if (parsed && parsed.hiddenCols)
                 root.hiddenCols = parsed.hiddenCols
+            if (parsed && parsed.foldersFirst !== undefined)
+                root.foldersFirst = parsed.foldersFirst
         } catch (e) {
             // A file another hand wrote is not this file's problem: the defaults stand.
         }
@@ -54,6 +66,6 @@ QtObject {
     }
 
     function save() {
-        store.setText(JSON.stringify({ hiddenCols: root.hiddenCols }, null, 2) + "\n")
+        store.setText(JSON.stringify({ hiddenCols: root.hiddenCols, foldersFirst: root.foldersFirst }, null, 2) + "\n")
     }
 }

--- a/ui/ViewState.qml
+++ b/ui/ViewState.qml
@@ -1,0 +1,59 @@
+pragma Singleton
+import QtQuick
+import Quickshell
+import Quickshell.Io
+
+// The per-user view state that outlives a window: which list columns the user has hidden, and
+// later whatever else a preference earns a toggle for. One JSON file under ~/.config/flea, read
+// once at construction and rewritten on every change through the same FileView pattern the
+// bookmarks use (ui/NetworkDialog.qml's write, ui/Sidebar.qml's watch). A write over a directory
+// that does not exist yet is the one silent failure this singleton allows: the toggles keep
+// working for the session and the state just does not outlive it.
+QtObject {
+    id: root
+
+    // The list-column keys ("mode"/"size"/"date"/"kind") the user has hidden. Name is not here:
+    // it is the one column a file manager cannot do without, see ui/js/Columns.js.
+    property var hiddenCols: []
+
+    // Flipped by ui/Pane.qml's onChosen, when a header-menu row answers "col:<key>".
+    function toggleColumn(key) {
+        var next = []
+        var had = false
+        for (var i = 0; i < root.hiddenCols.length; i++) {
+            if (root.hiddenCols[i] === key) {
+                had = true
+                continue
+            }
+            next.push(root.hiddenCols[i])
+        }
+        if (!had)
+            next.push(key)
+        root.hiddenCols = next
+        store.setText(JSON.stringify({ hiddenCols: root.hiddenCols }, null, 2) + "\n")
+    }
+
+    function load() {
+        try {
+            var parsed = JSON.parse(store.text())
+            if (parsed && parsed.hiddenCols)
+                root.hiddenCols = parsed.hiddenCols
+        } catch (e) {
+            // A file another hand wrote is not this file's problem: the defaults stand.
+        }
+    }
+
+    property var store: FileView {
+        path: (Quickshell.env("XDG_CONFIG_HOME") && Quickshell.env("XDG_CONFIG_HOME").length > 0
+               ? Quickshell.env("XDG_CONFIG_HOME") : Quickshell.env("HOME") + "/.config") + "/flea/view.json"
+        watchChanges: false
+        printErrors: false
+        onLoaded: root.load()
+        // A missing file lands here on first run, and the write seeds it so the next start reads.
+        onLoadFailed: root.save()
+    }
+
+    function save() {
+        store.setText(JSON.stringify({ hiddenCols: root.hiddenCols }, null, 2) + "\n")
+    }
+}

--- a/ui/js/Columns.js
+++ b/ui/js/Columns.js
@@ -27,14 +27,20 @@ function floors(t) {
     return out
 }
 
-// One boolean per optional column, for a row of this width.
-function set(width, t) {
+// One boolean per optional column, for a row of this width. hidden is the user's own set (keys
+// "mode"/"size"/"date"/"kind", from qs module ViewState), subtracted from what the width
+// affords: a hidden column never draws, and width still wins over a column the user wants back —
+// the name cannot be crowded out by a column the pane is too narrow to carry.
+function set(width, t, hidden) {
     var f = floors(t)
+    var h = {}
+    var list = hidden || []
+    for (var i = 0; i < list.length; i++) h[list[i]] = true
     return {
-        mode: width >= f.mode,
-        size: width >= f.size,
-        date: width >= f.date,
-        kind: width >= f.kind
+        mode: width >= f.mode && !h["mode"],
+        size: width >= f.size && !h["size"],
+        date: width >= f.date && !h["date"],
+        kind: width >= f.kind && !h["kind"]
     }
 }
 

--- a/ui/js/Menu.js
+++ b/ui/js/Menu.js
@@ -87,7 +87,9 @@ function advancedRows(showHidden) {
 // ui/Header.qml's own rows, on a right click over the column titles. Name is not among them: it is
 // the one column a file manager cannot do without (see ui/js/Columns.js), so it is never hidden and
 // never offered. A hidden column reads "Show", a drawn one "Hide", the flip the state rows use.
-function headerEntries(hiddenCols, showHidden) {
+// Below the columns, the two state rows flat: the folders-first choice (the backend's standing
+// "dirs", flipped here and answered by the re-list ui/Pane.qml asks for) and the hidden files.
+function headerEntries(hiddenCols, showHidden, foldersFirst) {
     var out = []
     var hidden = {}
     for (var h = 0; h < hiddenCols.length; h++)
@@ -105,8 +107,14 @@ function headerEntries(hiddenCols, showHidden) {
     }
     out.push({ separator: true })
     out.push({
-        label: "Advanced", action: "advanced", glyph: "sliders",
-        submenu: advancedRows(showHidden)
+        label: showHidden ? "Hide hidden files" : "Show hidden files",
+        action: "toggleHidden",
+        glyph: showHidden ? "eye-off" : "eye"
+    })
+    out.push({
+        label: foldersFirst ? "Mix folders and files" : "Keep folders first",
+        action: "foldersFirst",
+        glyph: "list"
     })
     return out
 }

--- a/ui/js/Menu.js
+++ b/ui/js/Menu.js
@@ -22,7 +22,7 @@ function clamp(point, size, bounds) {
 // and carry its own suite, tests/js/menu.js. The Open row names the application xdg-open would
 // choose (p.openSuffix, resolved by ui/Opener.qml; empty for a directory, which flea opens itself),
 // and Copy Path sits beside it because both answer "where is this and what runs on it".
-function listingEntries(p) {
+function listingEntries(p, confirming) {
     var out = []
     if (p.hasRow) {
         out.push({ label: "Open", action: "open", glyph: "folder-open", suffix: p.openSuffix })
@@ -59,7 +59,14 @@ function listingEntries(p) {
         }
         out.push({ separator: true })
         // No confirm anywhere behind this row: the undo journal is the safety, see the operations design.
-        out.push({ label: "Move to Trash", action: "trash", glyph: "trash", danger: true })
+        // A confirming menu swaps the danger row for the keep/trash pair in place — Keep first and
+        // first under the cursor, Trash the only way through — so nothing collapses or jumps.
+        if (confirming) {
+            out.push({ label: "Keep", action: "keepTrash", glyph: "check" })
+            out.push({ label: "Move to Trash", action: "confirmTrash", glyph: "trash", danger: true })
+        } else {
+            out.push({ label: "Move to Trash", action: "trash", glyph: "trash", danger: true })
+        }
         out.push({ separator: true })
     }
     // The last group is the rows that need no row under the cursor, which is also the whole menu
@@ -82,16 +89,6 @@ function advancedRows(showHidden) {
         action: "toggleHidden",
         glyph: showHidden ? "eye-off" : "eye"
     }]
-}
-
-// The keep/trash pair the danger row pauses on: Keep first and first-highlighted, Trash beneath
-// in its own danger red, and nothing commits until one of the two is chosen. Esc or Keep puts the
-// listing back untouched; Trash is the only way through.
-function confirmEntries() {
-    return [
-        { label: "Keep", action: "keepTrash", glyph: "check" },
-        { label: "Move to Trash", action: "confirmTrash", glyph: "trash", danger: true }
-    ]
 }
 
 // ui/Header.qml's own rows, on a right click over the column titles. Name is not among them: it is

--- a/ui/js/Menu.js
+++ b/ui/js/Menu.js
@@ -84,6 +84,16 @@ function advancedRows(showHidden) {
     }]
 }
 
+// The keep/trash pair the danger row pauses on: Keep first and first-highlighted, Trash beneath
+// in its own danger red, and nothing commits until one of the two is chosen. Esc or Keep puts the
+// listing back untouched; Trash is the only way through.
+function confirmEntries() {
+    return [
+        { label: "Keep", action: "keepTrash", glyph: "check" },
+        { label: "Move to Trash", action: "confirmTrash", glyph: "trash", danger: true }
+    ]
+}
+
 // ui/Header.qml's own rows, on a right click over the column titles. Name is not among them: it is
 // the one column a file manager cannot do without (see ui/js/Columns.js), so it is never hidden and
 // never offered. A hidden column reads "Show", a drawn one "Hide", the flip the state rows use.

--- a/ui/js/Menu.js
+++ b/ui/js/Menu.js
@@ -1,5 +1,7 @@
 .pragma library
 
+.import "Archive.js" as Archive
+
 // The one definition of a submenu row, shared by ui/MenuRow.qml and ui/ContextMenu.qml. The two
 // carried their own copies and drifted: the row drew no disclosure at all for want of this.
 
@@ -14,4 +16,97 @@ function hasSubmenu(entry) {
 // to the near edge and its far end is cut, which no menu built on this box reaches.
 function clamp(point, size, bounds) {
     return Math.max(0, Math.min(bounds - size, point))
+}
+
+// The listing's rows, built from the pane's state in one object so the construction can live here
+// and carry its own suite, tests/js/menu.js. The Open row names the application xdg-open would
+// choose (p.openSuffix, resolved by ui/Opener.qml; empty for a directory, which flea opens itself),
+// and Copy Path sits beside it because both answer "where is this and what runs on it".
+function listingEntries(p) {
+    var out = []
+    if (p.hasRow) {
+        out.push({ label: "Open", action: "open", glyph: "folder-open", suffix: p.openSuffix })
+        out.push({ label: "Copy Path", action: "copypath", glyph: "file-text" })
+        out.push({ separator: true })
+        out.push({ label: "Rename", action: "rename", glyph: "rename" })
+        out.push({ label: "Duplicate", action: "duplicate", glyph: "file-plus" })
+        var ops = []
+        // The submenu is exactly the table the backend probed, so a box with no tool offers nothing.
+        if (p.archiveFormats.length > 0)
+            ops.push({ label: "Compress", action: "compress", glyph: "archive",
+                       submenu: Archive.formatEntries(p.archiveFormats) })
+        if (p.rowIsArchive)
+            ops.push({ label: "Extract", action: "extract", glyph: "archive-out" })
+        if (p.canConvert && p.rowIsImage)
+            ops.push({ label: "Convert", action: "convert", glyph: "sliders" })
+        if (ops.length > 0) {
+            out.push({ separator: true })
+            for (var i = 0; i < ops.length; i++) out.push(ops[i])
+        }
+        var share = []
+        if (p.taildropPeers.length > 0)
+            share.push({ label: "Send with Taildrop", action: "taildrop", mark: "tailscale",
+                         submenu: p.taildropPeers })
+        // Moving a file into the folder it already lives in is not an action, so the row hides there.
+        if (p.dropboxPath.length > 0 && !p.rowInDropbox)
+            share.push({ label: "Move to Dropbox", action: "dropbox", mark: "dropbox" })
+        // A share link is inherently per file, so it appears only for a row already in Dropbox.
+        if (p.rowInDropbox)
+            share.push({ label: "Copy Share Link", action: "sharelink", glyph: "network" })
+        if (share.length > 0) {
+            out.push({ separator: true })
+            for (var s = 0; s < share.length; s++) out.push(share[s])
+        }
+        out.push({ separator: true })
+        // No confirm anywhere behind this row: the undo journal is the safety, see the operations design.
+        out.push({ label: "Move to Trash", action: "trash", glyph: "trash", danger: true })
+        out.push({ separator: true })
+    }
+    // The last group is the rows that need no row under the cursor, which is also the whole menu
+    // on a listing's empty space. New Folder sits alone; every state toggle lives behind Advanced,
+    // so the state rows grow without the menu growing with them.
+    out.push({ label: "New Folder", action: "newFolder", glyph: "folder-plus" })
+    out.push({
+        label: "Advanced", action: "advanced", glyph: "sliders",
+        submenu: advancedRows(p.showHidden)
+    })
+    return out
+}
+
+// The Advanced flyout's rows: every state toggle in the menu, so a new preference is one row here
+// and not another top-level row the listing's menu never had room for. The label flips with the
+// state, the house pattern (ui/MenuRow.qml draws no checkmark), and the verb is the key's own.
+function advancedRows(showHidden) {
+    return [{
+        label: showHidden ? "Hide hidden files" : "Show hidden files",
+        action: "toggleHidden",
+        glyph: showHidden ? "eye-off" : "eye"
+    }]
+}
+
+// ui/Header.qml's own rows, on a right click over the column titles. Name is not among them: it is
+// the one column a file manager cannot do without (see ui/js/Columns.js), so it is never hidden and
+// never offered. A hidden column reads "Show", a drawn one "Hide", the flip the state rows use.
+function headerEntries(hiddenCols, showHidden) {
+    var out = []
+    var hidden = {}
+    for (var h = 0; h < hiddenCols.length; h++)
+        hidden[hiddenCols[h]] = true
+    var columns = [["mode", "Mode"], ["size", "Size"], ["date", "Date Modified"], ["kind", "Kind"]]
+    var glyphs = { mode: "lock", size: "drive", date: "download", kind: "type" }
+    for (var i = 0; i < columns.length; i++) {
+        var key = columns[i][0]
+        var shown = !hidden[key]
+        out.push({
+            label: shown ? "Hide " + columns[i][1] : "Show " + columns[i][1],
+            action: "col:" + key,
+            glyph: glyphs[key]
+        })
+    }
+    out.push({ separator: true })
+    out.push({
+        label: "Advanced", action: "advanced", glyph: "sliders",
+        submenu: advancedRows(showHidden)
+    })
+    return out
 }

--- a/ui/qmldir
+++ b/ui/qmldir
@@ -1,5 +1,6 @@
 module flea
 singleton Theme 1.0 Theme.qml
+singleton ViewState 1.0 ViewState.qml
 Backend 1.0 Backend.qml
 ChromeBar 1.0 ChromeBar.qml
 ChromeButton 1.0 ChromeButton.qml

--- a/ui/qmldir
+++ b/ui/qmldir
@@ -1,5 +1,6 @@
 module flea
 singleton Theme 1.0 Theme.qml
+MenuKeys 1.0 MenuKeys.qml
 singleton ViewState 1.0 ViewState.qml
 Backend 1.0 Backend.qml
 ChromeBar 1.0 ChromeBar.qml


### PR DESCRIPTION
Follows #5 (independent of it — branched from main).

## What this adds

**A right click over the column titles** opens the pane's one ContextMenu — the same single instance the listing and the rail raise, because a second instance in this tree takes the whole window's keyboard (see AGENTS.md) — with:

- one toggle row per optional column: **Hide/Show Mode, Size, Date Modified, Kind**. Name is not offered: it is the one column a file manager cannot do without, and `ui/js/Columns.js` already refuses to drop it.
- an **Advanced ▸** flyout holding the state toggles: **Show/Hide hidden files** (moved here from its top-level row, so the next preference is one row in the group and not another top-level row the menu never had room for).

Left click on a title still sorts; `sortable` still gates that.

## How the pieces fit

- **Columns**: `Columns.set(width, tokens, hidden)` subtracts the user's set from what the width affords — width still wins, so "Show Kind" on a 600 px pane stays dropped rather than crowding the name. The set lives in a new `ViewState` singleton (qs module, beside Theme) backed by a FileView at `~/.config/flea/view.json`, the same read/watch/write pattern the bookmarks use, so the choice outlives the window.
- **The menu construction moved to `ui/js/Menu.js`** (`listingEntries`, `headerEntries`, `advancedRows`), so menu rows are unit-testable without a window — and the move paid ContextMenu's headroom back with interest: it is 21 lines lighter carrying a third face.
- **The Open row now names the application** xdg-open would choose — "Open" beside the resolved name in muted type (`ui/MenuRow.qml`'s new suffix slot) — resolved as the cursor moves by `ui/Opener.qml` (the one foreign-program owner), empty for a directory, which flea opens itself. **Copy Path** sits beside Open and hands the row's full path to `wl-copy` through the same owner; flea's own copy clipboard (`Ops.clip`) is a different thing and stays one.

## Tests

- `tests/js/menu.js`: the listing construction (Open's suffix, Copy Path's place, the Advanced group, the empty-listing shape) and the header construction (flip labels, `col:<key>` verbs, Advanced carrying the toggle)
- `tests/js/columns.js`: the hidden set subtracted from the width-afforded set, width winning, and the no-set callers unchanged
- `./tests/js.sh`: **1026 checks, 0 failed**; `tools/flea-file-budget` exits 0 (Pane lands exactly at its 400 cap, ContextMenu 21 lines lighter)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Right-click file-list headers to show, hide, and manage columns.
  * Hidden-column preferences are saved and restored between sessions.
  * Context menus include Copy Path and display the default application for files.
  * Header menus provide column visibility, hidden-file, and folders-first settings.
  * Folders-first sorting can be toggled and persisted across sessions.
  * Move to Trash now offers an in-menu confirmation step.
* **Bug Fixes**
  * Column layouts consistently respect hidden columns and available width.
  * Context-menu actions, submenu navigation, and empty or directory listings behave more consistently.
  * Menus prevent unintended pointer interactions with underlying rows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->