### PR TITLE
Fall back to OpenGL when Vulkan initialization fails

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,9 +33,11 @@ this tree yet: `flea --tui` says so and exits 2.
    was rejected as slower and stale-capable; it remains disabled until the wire carries
    the requested path and a new measurement proves a real win.
 
-5. **Vulkan now, lazy multimedia later.** `ui/shell.qml` sets
-   `QSG_RHI_BACKEND=vulkan`, which costs 2.4x less memory than the OpenGL default and
-   initialises 35 ms faster, with identical frame timing. Preview and QtMultimedia
+5. **Vulkan first with an OpenGL fallback, lazy multimedia later.** `src/gui.rs` sets
+   `QSG_RHI_BACKEND=vulkan` when the user did not choose a renderer, which costs 2.4x less
+   memory than the OpenGL default and initialises 35 ms faster, with identical frame timing.
+   A scene-graph initialization failure relaunches once with OpenGL and drains the failed
+   backend; an explicit `QSG_RHI_BACKEND` is never replaced. Preview and QtMultimedia
    are now in the tree and the laziness held: `ui/PreviewMedia.qml` is the only file
    that imports QtMultimedia, reached through a `Loader` built by the first press of
    play, because QtMultimedia costs 20 MB before it plays anything.

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -7,6 +7,9 @@ use std::process::Command;
 pub fn exec_qs(ui: &Path, start: Option<&str>, select: Option<&str>) -> i32 {
     let mut cmd = Command::new("qs");
     cmd.arg("-p").arg(ui);
+    if let Ok(binary) = std::env::current_exe() {
+        cmd.env("FLEA_BIN", binary);
+    }
     // Vulkan is Flea's measured fast path. Mark only this implicit choice so
     // the QML side can retry OpenGL without overriding a user's explicit
     // QSG_RHI_BACKEND selection.

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -7,6 +7,15 @@ use std::process::Command;
 pub fn exec_qs(ui: &Path, start: Option<&str>, select: Option<&str>) -> i32 {
     let mut cmd = Command::new("qs");
     cmd.arg("-p").arg(ui);
+    // Vulkan is Flea's measured fast path. Mark only this implicit choice so
+    // the QML side can retry OpenGL without overriding a user's explicit
+    // QSG_RHI_BACKEND selection.
+    if std::env::var_os("QSG_RHI_BACKEND").is_none() {
+        cmd.env("QSG_RHI_BACKEND", "vulkan");
+        cmd.env("FLEA_RENDERER_AUTOMATIC", "1");
+    } else {
+        cmd.env_remove("FLEA_RENDERER_AUTOMATIC");
+    }
     if let Some(path) = start {
         cmd.env("FLEA_PATH", path);
     }

--- a/tests/modes.sh
+++ b/tests/modes.sh
@@ -55,12 +55,14 @@ check "--tui --gui names the conflict" "1" "$(echo "$out" | grep -c 'mutually ex
 # The prctl and renderer choice have to survive exec, so a stub qs reports the launched child.
 D="$FIXTURE_ROOT/flea-thp-test-$$"
 sandbox_make "$D"
-printf '#!/bin/sh\ngrep -i "^THP_enabled" /proc/self/status\nprintf "RENDERER %%s\\n" "$QSG_RHI_BACKEND"\nprintf "AUTOMATIC %%s\\n" "${FLEA_RENDERER_AUTOMATIC-unset}"\n' > "$D/qs"
+printf '#!/bin/sh\ngrep -i "^THP_enabled" /proc/self/status\nprintf "FLEA_BIN %%s\\n" "$FLEA_BIN"\nprintf "RENDERER %%s\\n" "$QSG_RHI_BACKEND"\nprintf "AUTOMATIC %%s\\n" "${FLEA_RENDERER_AUTOMATIC-unset}"\n' > "$D/qs"
 chmod +x "$D/qs"
-out=$(env -u QSG_RHI_BACKEND -u FLEA_RENDERER_AUTOMATIC WAYLAND_DISPLAY=flea-modes-test-display PATH="$D:/usr/bin:/bin" $BIN --gui 2>&1 </dev/null)
+out=$(env -u QSG_RHI_BACKEND -u FLEA_RENDERER_AUTOMATIC FLEA_BIN=stale WAYLAND_DISPLAY=flea-modes-test-display PATH="$D:/usr/bin:/bin" $BIN --gui 2>&1 </dev/null)
 check "the launched shell has transparent huge pages off" "1" \
   "$(echo "$out" | grep -c 'THP_enabled:[[:space:]]*0')"
 check "the launched shell reported its THP state at all" "1" "$(echo "$out" | grep -c 'THP_enabled')"
+check "the launched shell uses this Flea binary" "FLEA_BIN $PWD/target/debug/flea" \
+  "$(echo "$out" | grep '^FLEA_BIN ')"
 check "the automatic renderer starts with Vulkan" "1" "$(echo "$out" | grep -c '^RENDERER vulkan$')"
 check "the automatic renderer permits one fallback" "1" "$(echo "$out" | grep -c '^AUTOMATIC 1$')"
 out=$(env QSG_RHI_BACKEND=opengl FLEA_RENDERER_AUTOMATIC=stale WAYLAND_DISPLAY=flea-modes-test-display PATH="$D:/usr/bin:/bin" $BIN --gui 2>&1 </dev/null)

--- a/tests/modes.sh
+++ b/tests/modes.sh
@@ -52,15 +52,20 @@ rc=$?
 check "--tui --gui is a usage error" "2" "$rc"
 check "--tui --gui names the conflict" "1" "$(echo "$out" | grep -c 'mutually exclusive')"
 
-# The prctl has to survive exec, so a stub qs reports the kernel's own view of the launched child.
+# The prctl and renderer choice have to survive exec, so a stub qs reports the launched child.
 D="$FIXTURE_ROOT/flea-thp-test-$$"
 sandbox_make "$D"
-printf '#!/bin/sh\ngrep -i "^THP_enabled" /proc/self/status\n' > "$D/qs"
+printf '#!/bin/sh\ngrep -i "^THP_enabled" /proc/self/status\nprintf "RENDERER %%s\\n" "$QSG_RHI_BACKEND"\nprintf "AUTOMATIC %%s\\n" "${FLEA_RENDERER_AUTOMATIC-unset}"\n' > "$D/qs"
 chmod +x "$D/qs"
-out=$(env WAYLAND_DISPLAY=flea-modes-test-display PATH="$D:/usr/bin:/bin" $BIN --gui 2>&1 </dev/null)
+out=$(env -u QSG_RHI_BACKEND -u FLEA_RENDERER_AUTOMATIC WAYLAND_DISPLAY=flea-modes-test-display PATH="$D:/usr/bin:/bin" $BIN --gui 2>&1 </dev/null)
 check "the launched shell has transparent huge pages off" "1" \
   "$(echo "$out" | grep -c 'THP_enabled:[[:space:]]*0')"
 check "the launched shell reported its THP state at all" "1" "$(echo "$out" | grep -c 'THP_enabled')"
+check "the automatic renderer starts with Vulkan" "1" "$(echo "$out" | grep -c '^RENDERER vulkan$')"
+check "the automatic renderer permits one fallback" "1" "$(echo "$out" | grep -c '^AUTOMATIC 1$')"
+out=$(env QSG_RHI_BACKEND=opengl FLEA_RENDERER_AUTOMATIC=stale WAYLAND_DISPLAY=flea-modes-test-display PATH="$D:/usr/bin:/bin" $BIN --gui 2>&1 </dev/null)
+check "an explicit renderer is preserved" "1" "$(echo "$out" | grep -c '^RENDERER opengl$')"
+check "an explicit renderer cannot trigger fallback" "1" "$(echo "$out" | grep -c '^AUTOMATIC unset$')"
 sandbox_remove "$D"
 
 # --open resolves the target, refuses a directory, and hands anything else to xdg-open.

--- a/ui/shell.qml
+++ b/ui/shell.qml
@@ -1,7 +1,6 @@
 //@ pragma AppId com.thisisgm.flea
 //@ pragma ShellId flea
 //@ pragma NativeTextRendering
-//@ pragma DefaultEnv QSG_RHI_BACKEND=vulkan
 //@ pragma CacheDir $BASE/flea
 
 import Quickshell
@@ -18,6 +17,25 @@ ShellRoot {
         title: "Flea"
         implicitWidth: 900
         implicitHeight: 600
+        property bool rendererFallbackStarted: false
+
+        function handleSceneGraphError(error, message) {
+            var backendName = Quickshell.env("QSG_RHI_BACKEND")
+            console.warn("graphics backend " + backendName + " failed (" + error + "): " + message)
+            if (!rendererFallbackStarted && backendName === "vulkan"
+                    && Quickshell.env("FLEA_RENDERER_AUTOMATIC") === "1") {
+                rendererFallbackStarted = true
+                var fleaBin = Quickshell.env("FLEA_BIN") || "flea"
+                Quickshell.execDetached(["/usr/bin/env", "QSG_RHI_BACKEND=opengl", fleaBin, "--gui"])
+            }
+            backend.quit()
+        }
+
+        Connections {
+            target: view.Window.window
+            function onSceneGraphError(error, message) { fleaWindow.handleSceneGraphError(error, message) }
+        }
+
         // Quickshell 0.3.1 has no exit API and Qt.quit() is a no-op, so the shell signals itself.
         // The backend is told first and answers when it has drained: a quit cancels the operation in
         // flight, and a cancelled copy removes its own partial, so closing never leaves a half file.


### PR DESCRIPTION
## Summary

- keep Vulkan as the default fast path when no renderer was explicitly selected
- catch Qt scene-graph initialization failure and relaunch once with OpenGL
- drain the failed backend, prevent retry loops, and preserve explicit QSG_RHI_BACKEND choices
- cover the default, retry marker, and explicit-override contract in modes.sh

## Verification

- cargo build and cargo build --release: clean, zero warnings
- cargo test and cargo test --release: 335 passed in each profile, zero warnings
- tests/modes.sh: all checks passed
- tests/js.sh: 1013 checks, 0 failed
- tools/flea-qmllint-gate: 0 regressions
- live-tested on an Intel HD 3000 system without usable Vulkan: the failed Vulkan frontend/backend exited and one visible OpenGL instance replaced it

Fixes #14


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Flea now automatically prefers Vulkan when no renderer is explicitly selected.
  * If automatic Vulkan initialization fails, Flea relaunches once using OpenGL.
  * Explicit renderer selections are preserved and never overridden.
  * Renderer fallback handling improves startup compatibility across supported graphics environments.

* **Bug Fixes**
  * Improved handling of scene-graph initialization failures to prevent startup issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->