### PR TITLE
feat: accelerate pointer scrolling across vertical views

### DIFF
--- a/ui/ColumnPane.qml
+++ b/ui/ColumnPane.qml
@@ -46,6 +46,11 @@ Item {
         boundsBehavior: Flickable.StopAtBounds
         reuseItems: true
 
+        Flea.FastScrollHandler {
+            parent: view
+            flickable: view
+        }
+
         delegate: Flea.ColumnRow {
             required property int index
             width: view.width

--- a/ui/FastScrollHandler.qml
+++ b/ui/FastScrollHandler.qml
@@ -1,0 +1,53 @@
+import QtQuick
+
+// Multiplies both smooth touchpad deltas and discrete wheel notches, then writes the bounded
+// position directly. A MouseArea is intentional: a Flickable consumes wheel events before a child
+// WheelHandler can answer them, while acceptedButtons: Qt.NoButton leaves taps and drags alone.
+MouseArea {
+    id: root
+
+    required property var flickable
+    property real speedMultiplier: 4
+    property real mouseWheelStep: Math.max(1,
+        Number(Application.styleHints.wheelScrollLines) || 3) * 24
+
+    anchors.fill: parent
+    acceptedButtons: Qt.NoButton
+    z: 1000
+
+    function scrollDistance(pixelDeltaY, angleDeltaY) {
+        var distance = Number(pixelDeltaY) || 0
+        if (distance === 0)
+            distance = (Number(angleDeltaY) || 0) / 120 * root.mouseWheelStep
+        return distance * root.speedMultiplier
+    }
+
+    function boundedContentY(value) {
+        var minimum = Number(root.flickable.originY) || 0
+        var maximum = Math.max(minimum,
+                               minimum + Math.max(0, Number(root.flickable.contentHeight) || 0)
+                               - Math.max(0, Number(root.flickable.height) || 0))
+        return Math.max(minimum, Math.min(maximum, value))
+    }
+
+    function scrollByDeltas(pixelDeltaY, angleDeltaY) {
+        var distance = root.scrollDistance(pixelDeltaY, angleDeltaY)
+        if (distance === 0 || !root.flickable.interactive)
+            return root.flickable.contentY
+        var previous = root.flickable.contentY
+        root.flickable.cancelFlick()
+        root.flickable.contentY = root.boundedContentY(root.flickable.contentY - distance)
+        return root.flickable.contentY
+    }
+
+    onWheel: function (wheel) {
+        var distance = root.scrollDistance(wheel.pixelDelta.y, wheel.angleDelta.y)
+        if (distance === 0 || !root.flickable.interactive) {
+            wheel.accepted = false
+            return
+        }
+        var previous = root.flickable.contentY
+        var current = root.scrollByDeltas(wheel.pixelDelta.y, wheel.angleDelta.y)
+        wheel.accepted = Math.abs(current - previous) > 0.01
+    }
+}

--- a/ui/GridArea.qml
+++ b/ui/GridArea.qml
@@ -34,6 +34,11 @@ GridView {
     boundsBehavior: Flickable.StopAtBounds
     reuseItems: true
 
+    Flea.FastScrollHandler {
+        parent: root
+        flickable: root
+    }
+
     delegate: Flea.GridTile {
         required property int index
         width: root.cellWidth

--- a/ui/List.qml
+++ b/ui/List.qml
@@ -41,6 +41,11 @@ ListView {
     // Every property the delegate draws is a binding on index, so a row leaving the buffer is re-bound rather than rebuilt.
     reuseItems: true
 
+    Flea.FastScrollHandler {
+        parent: root
+        flickable: root
+    }
+
     delegate: Flea.Row {
         id: cell
         required property int index

--- a/ui/PdfViewer.qml
+++ b/ui/PdfViewer.qml
@@ -149,6 +149,11 @@ Item {
         contentHeight: height * root.zoom
         boundsBehavior: Flickable.StopAtBounds
 
+        Flea.FastScrollHandler {
+            parent: pageFlick
+            flickable: pageFlick
+        }
+
         Rectangle {
             width: pageFlick.contentWidth
             height: pageFlick.contentHeight

--- a/ui/PreviewText.qml
+++ b/ui/PreviewText.qml
@@ -31,11 +31,17 @@ Item {
     }
 
     Flickable {
+        id: textFlick
         anchors.fill: parent
         clip: true
         contentWidth: width
         contentHeight: Math.max(height, body.implicitHeight)
         visible: !root.tooLarge && !root.readFailed
+
+        FastScrollHandler {
+            parent: textFlick
+            flickable: textFlick
+        }
 
         Text {
             id: body

--- a/ui/Sidebar.qml
+++ b/ui/Sidebar.qml
@@ -238,6 +238,11 @@ Item {
         contentHeight: rail.height + 2 * Style.spacing.rowPaddingX
         boundsBehavior: Flickable.StopAtBounds
 
+        FastScrollHandler {
+            parent: scroller
+            flickable: scroller
+        }
+
         Column {
             id: rail
             anchors.top: parent.top

--- a/ui/qmldir
+++ b/ui/qmldir
@@ -21,6 +21,7 @@ MediaStrip 1.0 MediaStrip.qml
 MenuRow 1.0 MenuRow.qml
 RenameField 1.0 RenameField.qml
 EmptyState 1.0 EmptyState.qml
+FastScrollHandler 1.0 FastScrollHandler.qml
 DeviceMounts 1.0 DeviceMounts.qml
 DropboxMark 1.0 DropboxMark.qml
 Glyph 1.0 Glyph.qml


### PR DESCRIPTION
## What changes

- adds one shared `FastScrollHandler` with a 4x multiplier
- applies it to the list, grid, Miller columns, places rail, text preview, and zoomed PDF pane
- handles smooth `pixelDelta` input and discrete `angleDelta` wheel notches
- clamps every write to the Flickable origin and content end

## Why 4x

This ports the behavior from [Omarchy Spotify commit 7499123](https://github.com/stappmus/Omarchy-Spotify/commit/74991237230ba29afa1300cdd895b7272f45dbd5), where the multiplier was calibrated to feel about as fast as Chromium.

Discrete wheels still honor `Application.styleHints.wheelScrollLines`; the multiplier sits on top of that platform preference. Touchpads keep their fractional pixel deltas, multiplied by the same amount.

## Event handling

The handler uses a `MouseArea` overlay with `acceptedButtons: Qt.NoButton`, so taps and drags remain owned by the existing row handlers. This follows the live finding from #5 that a child `WheelHandler` loses wheel events to its `Flickable` parent.

The scroll stays immediate and animation-free, matching the existing motion rule. A wheel event is accepted only when it actually moves the target, so boundary events can continue propagating.

## Verification

- `cargo build --release`
- `./tools/flea-qmllint-gate` — 0 actionable regressions
- `./tools/flea-file-budget` — passes; existing soft warnings unchanged
- live Wayland smoke launch reaches `Configuration Loaded`

No new automated tests are included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added faster scrolling to lists, grids, sidebars, PDF pages, and text previews.
  * Improved mouse wheel and touchpad scrolling with configurable speed and bounded movement.
  * Preserved normal tapping and dragging interactions while enhancing wheel-based navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->