### PR TITLE
Network places: edit, remove, and live SFTP matching

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3621,3 +3621,18 @@ key press fires a compositor bind, so `omarchy-drive hotkey --global super w` is
 on the ACTIVE window, so assert the active window is the one the run launched before sending it, and
 never call `hl.dsp.window.close()` with no argument: it returns `ok` rather than printing a signature
 and acts on whatever is active, which may be a window you did not open.
+
+### Editing a network place rewrites the bookmark line, not just its label
+
+`r` on a NETWORK row still only relabels. The URI itself is edited through the same dialog Add
+uses: right-click (or `m`) on a share, **Edit**, which fills `ui/NetworkForm.qml` from
+`Protocols.parse` and Save writes through `Places.replace`. An unmounted bookmark's menu is Edit
+alone, so a URI that will not mount (the operator's real `sftp://user@host:22/~`; gio does not
+expand `~`) can still be rewritten. A mounted share keeps **Unmount** first so Ctrl+E still
+releases; `Mounts.releaseAction` is what Ctrl+E reads, never `railMenu()[0]`, because Edit is a
+menu row and not a release.
+
+`Places.replace(body, oldUri, newUri, label)` is the write: normalized match like `relabel`, every
+duplicate rewritten, control characters stripped from the label, an empty old URI appends (Add).
+`tests/js/places.js`, `tests/js/protocols.js`, `tests/js/mounts.js` and `tests/ui.sh case_networkedit`
+hold it.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3634,5 +3634,6 @@ menu row and not a release.
 
 `Places.replace(body, oldUri, newUri, label)` is the write: normalized match like `relabel`, every
 duplicate rewritten, control characters stripped from the label, an empty old URI appends (Add).
-`tests/js/places.js`, `tests/js/protocols.js`, `tests/js/mounts.js` and `tests/ui.sh case_networkedit`
-hold it.
+`Places.remove(body, uri)` drops matching lines. Remove on a live share also unmounts, so the row
+leaves instead of becoming a mount-only leftover. `tests/js/places.js`, `tests/js/protocols.js`,
+`tests/js/mounts.js` and `tests/ui.sh case_networkedit` hold it.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3513,6 +3513,12 @@ session) and drop the bookmark's, so `r` rewrote the file and the next poll put 
 `Places.networkEntries` keeps the bookmark label on the live row. Unmount of a share whose FUSE
 path is the current listing goes Home first; otherwise gio refuses as busy.
 
+gvfsd-sftp mounts one connection per host: `gio mount -l` lists `sftp://user@host/` even when the
+bookmark is `sftp://user@host/home/tom`. A second path on that host now stays its own rail row and
+reads as mounted. Unmount sends gio the live root URI, and leaving Home is keyed on the connection
+not the path, so a listing inside `/home/tom` no longer keeps the root "in use". SMB/NFS stay
+per-share: a live `smb://nas/data` does not light `smb://nas/isos`.
+
 ### The rail menu, tested with a stubbed gio and a stubbed lsblk
 
 `tests/ui.sh case_unmount` and `case_eject` drive the rail menu through the real window.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3646,6 +3646,9 @@ menu row and not a release.
 
 `Places.replace(body, oldUri, newUri, label)` is the write: normalized match like `relabel`, every
 duplicate rewritten, control characters stripped from the label, an empty old URI appends (Add).
-`Places.remove(body, uri)` drops matching lines. Remove on a live share also unmounts, so the row
-leaves instead of becoming a mount-only leftover. `tests/js/places.js`, `tests/js/protocols.js`,
-`tests/js/mounts.js` and `tests/ui.sh case_networkedit` hold it.
+`Places.remove(body, uri)` drops matching lines. An unmounted bookmark is dropped immediately. A
+live one is unmounted first and the file is rewritten only from `unmountProcess.onExited` when
+gio succeeds, so a busy share keeps its row. `Protocols.parse` splits the path off before it
+looks for `@`, so a path like `inbox@2026` is not stolen as a username. `tests/js/places.js`,
+`tests/js/protocols.js`, `tests/js/mounts.js`, `tests/ui.sh case_networkedit` and
+`case_networkremove` hold it.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3508,6 +3508,11 @@ returning whatever form their own source actually carries; only the write path a
 comparison were ever the places two spellings needed to agree. `tests/js/mounts.js` proves a
 trailing slash, a default sftp port, and a bare root all collapse, and a non-default port does not.
 
+Once collapsed, the live `gio mount -l` row used to keep gio's own label ("tom" for an SFTP
+session) and drop the bookmark's, so `r` rewrote the file and the next poll put "tom" back.
+`Places.networkEntries` keeps the bookmark label on the live row. Unmount of a share whose FUSE
+path is the current listing goes Home first; otherwise gio refuses as busy.
+
 ### The rail menu, tested with a stubbed gio and a stubbed lsblk
 
 `tests/ui.sh case_unmount` and `case_eject` drive the rail menu through the real window.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3496,16 +3496,17 @@ with its own trailing slash; nothing forced the two to agree, so `smb://h/data` 
 `smb://h/data/` (gio's own report of the same share once mounted) compared unequal everywhere a
 uri was used as a dedup key, and could show as two rows for one share. `ui/js/Mounts.js` gained
 `normalize(uri)`: every trailing slash is stripped, except a bare server root (nothing left but
-`scheme://host`), which keeps exactly one, the shape `gio` itself needs to parse it back. Applied
-in two places, per the ruling ("apply it... on write and on compare"): `ui/NetworkDialog.qml`'s
-`appendBookmark()` writes the normalized form rather than the raw typed string, and
-`ui/NetworkMounts.qml`'s `rebuild()` dedups live mounts against bookmarks using normalized keys
-rather than the raw `uri` fields, so a live mount (gio's trailing-slash form) and a bookmark (now
-also normalized, but an old hand-edited line might not be) still collapse to one row. `parseMounts()`
-and `nonFileBookmarks()` themselves are left returning whatever form their own source actually
-carries; only the write path and the dedup comparison were ever the places two spellings needed to
-agree. `tests/js/mounts.js` proves `normalize("smb://h/data") === normalize("smb://h/data/")` and
-that a bare root normalizes to its one-trailing-slash form regardless of how it was typed.
+`scheme://host`), which keeps exactly one, the shape `gio` itself needs to parse it back. A scheme's
+default port is dropped too: the add form writes `sftp://user@host:22/path` and `gio mount -l`
+reports `sftp://user@host/path`, which used to show as two rail rows (a dim bookmark the cursor
+stayed on, and a brighter live mount of the same share). Applied in two places, per the ruling
+("apply it... on write and on compare"): `ui/NetworkDialog.qml`'s write path uses the normalized
+form rather than the raw typed string, and `ui/NetworkMounts.qml`'s `rebuild()` dedups live mounts
+against bookmarks using normalized keys rather than the raw `uri` fields, so a live mount and a
+bookmark still collapse to one row. `parseMounts()` and `nonFileBookmarks()` themselves are left
+returning whatever form their own source actually carries; only the write path and the dedup
+comparison were ever the places two spellings needed to agree. `tests/js/mounts.js` proves a
+trailing slash, a default sftp port, and a bare root all collapse, and a non-default port does not.
 
 ### The rail menu, tested with a stubbed gio and a stubbed lsblk
 

--- a/tests/js/mounts.js
+++ b/tests/js/mounts.js
@@ -48,13 +48,13 @@ function run(check) {
     var bareRoot = 'smb://192.168.1.10/\n'
     check("a bare server root with no label falls back to the host", Mounts.nonFileBookmarks(bareRoot)[0].label, "192.168.1.10")
 
-    // Item 4: one canonical form, so a share dedupes against itself regardless of who typed the slash.
+    // Item 4: one canonical form, so a share dedupes against itself regardless of slash or default port.
     check("a share uri normalizes its trailing slash away", Mounts.normalize("smb://h/data/"), "smb://h/data")
-    check("a share uri with no trailing slash is already canonical", Mounts.normalize("smb://h/data"), "smb://h/data")
-    check("smb://h/data and smb://h/data/ cannot coexist as two rows", Mounts.normalize("smb://h/data") === Mounts.normalize("smb://h/data/"), true)
-    check("a bare server root keeps its one trailing slash", Mounts.normalize("smb://h/"), "smb://h/")
-    check("a bare server root typed with no slash still canonicalizes to one", Mounts.normalize("smb://h"), "smb://h/")
+    check("a bare server root keeps one trailing slash either way", Mounts.normalize("smb://h/") + "|" + Mounts.normalize("smb://h"), "smb://h/|smb://h/")
     check("two different shares stay distinct after normalizing", Mounts.normalize("smb://h/data/") === Mounts.normalize("smb://h/other/"), false)
+    check("the form's default sftp port is the same share gio reports without one", Mounts.normalize("sftp://tom@h:22/home/tom"), "sftp://tom@h/home/tom")
+    check("a default port on a bare root still keeps the slash", Mounts.normalize("sftp://tom@h:22/"), "sftp://tom@h/")
+    check("a non-default port is kept", Mounts.normalize("sftp://tom@h:2222/home"), "sftp://tom@h:2222/home")
 
     // Real lsblk --json output, captured on the box with a USB stick plugged in (2026-09-02).
     // ui/DeviceMounts.qml feeds this exact command's stdout to parseDevices on the rail's own clock.

--- a/tests/js/mounts.js
+++ b/tests/js/mounts.js
@@ -196,21 +196,19 @@ function run(check) {
     var dropbox = { label: "Dropbox", group: "network", kind: "dropbox", uri: "", mounted: true }
     var favourite = { label: "Home", group: "favorite", kind: "favorite", path: "/home/user" }
 
-    check("a mounted removable volume offers one row", Mounts.railMenu(volume).length, 1)
-    check("and that row is Eject", Mounts.railMenu(volume)[0].label, "Eject")
-    check("the Eject row carries the eject action", Mounts.railMenu(volume)[0].action, "eject")
-    check("the Eject row draws the eject mark", Mounts.railMenu(volume)[0].glyph, "eject")
-    check("a mounted network share offers one row", Mounts.railMenu(share).length, 1)
-    check("and that row is Unmount", Mounts.railMenu(share)[0].label, "Unmount")
-    check("the Unmount row carries the unmount action", Mounts.railMenu(share)[0].action, "unmount")
-    check("the shelf lists eject for unmount too, so Unmount draws it", Mounts.railMenu(share)[0].glyph, "eject")
+    check("a mounted removable volume offers Eject", Mounts.railMenu(volume).map(function (r) { return r.action }).join("|"), "eject")
+    check("and that row is named and marked", Mounts.railMenu(volume)[0].label + "/" + Mounts.railMenu(volume)[0].glyph, "Eject/eject")
+    check("a mounted network share offers Unmount then Edit", Mounts.railMenu(share).map(function (r) { return r.action }).join("|"), "unmount|edit")
+    check("Unmount stays first so Ctrl+E still unmounts", Mounts.railMenu(share)[0].label + "/" + Mounts.railMenu(share)[0].glyph, "Unmount/eject")
+    check("Edit draws the rename mark", Mounts.railMenu(share)[1].label + "/" + Mounts.railMenu(share)[1].glyph, "Edit/rename")
 
     // Every rail row that must never be offered a release, each for its own reason.
     check("the internal disk offers nothing, it is the box's own system disk", Mounts.railMenu(internal).length, 0)
     check("the Dropbox row offers nothing, it is a local folder the stock service owns", Mounts.railMenu(dropbox).length, 0)
     check("a favourite offers nothing, it is not a mount at all", Mounts.railMenu(favourite).length, 0)
     check("an unmounted volume offers nothing, there is nothing to release", Mounts.railMenu(idle).length, 0)
-    check("a bookmark nothing has mounted offers nothing", Mounts.railMenu(bookmark).length, 0)
+    check("a bookmark nothing has mounted offers Edit", Mounts.railMenu(bookmark).map(function (r) { return r.action }).join("|"), "edit")
+    check("Ctrl+E unmounts a live share and ignores a bookmark", Mounts.releaseAction(share) + "|" + Mounts.releaseAction(bookmark), "unmount|")
     check("no entry at all offers nothing rather than throwing", Mounts.railMenu(null).length, 0)
     check("an undefined entry offers nothing rather than throwing", Mounts.railMenu(undefined).length, 0)
 
@@ -289,12 +287,14 @@ function run(check) {
     // The rail menu's chosen row, resolved by key; a key that no longer names a row releases nothing.
     function rec() { var a = []; return { a: a, eject: function (i) { a.push("e" + i) }, unmount: function (i) { a.push("u" + i) } } }
     function released(action, key) {
-        var d = rec(), n = rec()
-        Mounts.release(action, key, d, n, [disk, stick], [{ label: "isos", group: "network", kind: "share", uri: "smb://x/isos/", path: "", mounted: true }])
-        return d.a.concat(n.a).join(",")
+        var d = rec(), n = rec(), edited = []
+        Mounts.release(action, key, d, n, [disk, stick], [{ label: "isos", group: "network", kind: "share", uri: "smb://x/isos/", path: "", mounted: true }],
+            { edit: function (uri, label) { edited.push(uri + " " + label) } })
+        return d.a.concat(n.a, edited).join(",")
     }
     check("eject resolves the volume's position and never the network Service", released("eject", "/dev/sda1"), "e1")
     check("unmount resolves the share's position and never the device Service", released("unmount", "smb://x/isos/"), "u0")
+    check("edit names the share rather than a Service index", released("edit", "smb://x/isos/"), "smb://x/isos/ isos")
     check("a key that no longer names a row releases nothing", released("eject", "/dev/sdz9"), "")
     check("an action that is neither release does nothing", released("forget", "/dev/sda1"), "")
 }

--- a/tests/js/mounts.js
+++ b/tests/js/mounts.js
@@ -198,7 +198,7 @@ function run(check) {
 
     check("a mounted removable volume offers Eject", Mounts.railMenu(volume).map(function (r) { return r.action }).join("|"), "eject")
     check("and that row is named and marked", Mounts.railMenu(volume)[0].label + "/" + Mounts.railMenu(volume)[0].glyph, "Eject/eject")
-    check("a mounted network share offers Unmount then Edit", Mounts.railMenu(share).map(function (r) { return r.action }).join("|"), "unmount|edit")
+    check("a mounted network share offers Unmount, Edit, Remove", Mounts.railMenu(share).map(function (r) { return r.action }).join("|"), "unmount|edit|remove")
     check("Unmount stays first so Ctrl+E still unmounts", Mounts.railMenu(share)[0].label + "/" + Mounts.railMenu(share)[0].glyph, "Unmount/eject")
     check("Edit draws the rename mark", Mounts.railMenu(share)[1].label + "/" + Mounts.railMenu(share)[1].glyph, "Edit/rename")
 
@@ -207,7 +207,7 @@ function run(check) {
     check("the Dropbox row offers nothing, it is a local folder the stock service owns", Mounts.railMenu(dropbox).length, 0)
     check("a favourite offers nothing, it is not a mount at all", Mounts.railMenu(favourite).length, 0)
     check("an unmounted volume offers nothing, there is nothing to release", Mounts.railMenu(idle).length, 0)
-    check("a bookmark nothing has mounted offers Edit", Mounts.railMenu(bookmark).map(function (r) { return r.action }).join("|"), "edit")
+    check("a bookmark nothing has mounted offers Edit then Remove", Mounts.railMenu(bookmark).map(function (r) { return r.action }).join("|"), "edit|remove")
     check("Ctrl+E unmounts a live share and ignores a bookmark", Mounts.releaseAction(share) + "|" + Mounts.releaseAction(bookmark), "unmount|")
     check("no entry at all offers nothing rather than throwing", Mounts.railMenu(null).length, 0)
     check("an undefined entry offers nothing rather than throwing", Mounts.railMenu(undefined).length, 0)
@@ -285,7 +285,7 @@ function run(check) {
     check("no rail at all answers nothing rather than throwing", Mounts.holding(null, "/x"), null)
 
     // The rail menu's chosen row, resolved by key; a key that no longer names a row releases nothing.
-    function rec() { var a = []; return { a: a, eject: function (i) { a.push("e" + i) }, unmount: function (i) { a.push("u" + i) } } }
+    function rec() { var a = []; return { a: a, eject: function (i) { a.push("e" + i) }, unmount: function (i) { a.push("u" + i) }, remove: function (i) { a.push("r" + i) } } }
     function released(action, key) {
         var d = rec(), n = rec(), edited = []
         Mounts.release(action, key, d, n, [disk, stick], [{ label: "isos", group: "network", kind: "share", uri: "smb://x/isos/", path: "", mounted: true }],

--- a/tests/js/places.js
+++ b/tests/js/places.js
@@ -132,4 +132,15 @@ function run(check) {
     check("every matching duplicate is dropped",
         Places.remove(dupes, "smb://192.168.1.10/data"),
         'file:///home/gm/Downloads Downloads\n')
+
+    var live = [{ label: "tom", uri: "sftp://tom@h/" }]
+    var saved = [{ label: "omv root", uri: "sftp://tom@h:22/" }]
+    var merged = Places.networkEntries(live, saved)
+    check("a live mount and its bookmark are one row", merged.length, 1)
+    check("the bookmark's label wins over gio's username-on-host name", merged[0].label, "omv root")
+    check("the live uri is what Unmount is handed", merged[0].uri, "sftp://tom@h/")
+    check("the collapsed row reads as mounted", merged[0].mounted, true)
+    var onlyMark = Places.networkEntries([], saved)
+    check("an unmounted bookmark keeps its own uri and label",
+          onlyMark[0].label + "|" + onlyMark[0].uri + "|" + onlyMark[0].mounted, "omv root|sftp://tom@h:22/|false")
 }

--- a/tests/js/places.js
+++ b/tests/js/places.js
@@ -89,4 +89,34 @@ function run(check) {
     check("every row is tagged as a favourite", favs[3].group + "/" + favs[3].kind, "favorite/favorite")
     check("the mark is resolved by the caller, so the rail keeps its own Icons import", favs[1].glyph, "mark:Downloads")
     check("a box with neither file still gets Home", Places.favorites("/home/gm", "", "", function () { return "m" }).length, 1)
+
+    check("replace rewrites the matched URI and label",
+        Places.replace(netFile, "smb://192.168.1.10/data", "sftp://tom@nas:22/home/tom", "omv"),
+        'file:///home/gm/Downloads Downloads\n'
+        + 'sftp://tom@nas:22/home/tom omv\n'
+        + 'smb://10.0.0.9/backups Backups\n')
+    check("a trailing-slash live uri still finds the written line",
+        Places.replace(netFile, "smb://192.168.1.10/data/", "smb://192.168.1.10/isos", "ISOs"),
+        'file:///home/gm/Downloads Downloads\n'
+        + 'smb://192.168.1.10/isos ISOs\n'
+        + 'smb://10.0.0.9/backups Backups\n')
+    check("an empty old uri appends, which is the add dialog",
+        Places.replace(netFile, "", "smb://host/share", "Share"),
+        netFile + "smb://host/share Share\n")
+    check("an unmatched old uri appends rather than dropping the edit",
+        Places.replace(netFile, "smb://missing/x", "smb://host/share", "Share"),
+        netFile + "smb://host/share Share\n")
+    check("an empty new uri is a no-op", Places.replace(netFile, "smb://192.168.1.10/data", "", "X"), netFile)
+    check("a blank label falls back to the path leaf",
+        Places.replace("", "smb://h/data", "smb://h/data", "  "), "smb://h/data data\n")
+    check("an embedded newline in the new label cannot fork a line",
+        Places.replace(netFile, "smb://192.168.1.10/data", "smb://192.168.1.10/data", "Home\nlab"),
+        'file:///home/gm/Downloads Downloads\n'
+        + 'smb://192.168.1.10/data Homelab\n'
+        + 'smb://10.0.0.9/backups Backups\n')
+    check("every matching duplicate rewrites to the new uri",
+        Places.replace(dupes, "smb://192.168.1.10/data", "sftp://nas/data", "Homelab"),
+        'sftp://nas/data Homelab\n'
+        + 'file:///home/gm/Downloads Downloads\n'
+        + 'sftp://nas/data Homelab\n')
 }

--- a/tests/js/places.js
+++ b/tests/js/places.js
@@ -143,4 +143,17 @@ function run(check) {
     var onlyMark = Places.networkEntries([], saved)
     check("an unmounted bookmark keeps its own uri and label",
           onlyMark[0].label + "|" + onlyMark[0].uri + "|" + onlyMark[0].mounted, "omv root|sftp://tom@h:22/|false")
+
+    var home = [{ label: "tom@omv ts", uri: "sftp://tom@h:22/home/tom" }]
+    var both = Places.networkEntries(live, saved.concat(home))
+    check("a second sftp path on the same host stays its own row", both.length, 2)
+    check("and reads as mounted because gio only lists the connection root",
+          both[0].mounted + "|" + both[1].label + "|" + both[1].mounted, "true|tom@omv ts|true")
+    check("Unmount of either path is handed gio's live root uri",
+          Places.coveringUri(live, home[0].uri), "sftp://tom@h/")
+    var smbLive = [{ label: "data", uri: "smb://nas/data/" }]
+    var smbMarks = [{ label: "data", uri: "smb://nas/data" }, { label: "isos", uri: "smb://nas/isos" }]
+    var smb = Places.networkEntries(smbLive, smbMarks)
+    check("an SMB share does not mark a different share on the same host mounted",
+          smb.length + "|" + smb[0].mounted + "|" + smb[1].label + "|" + smb[1].mounted, "2|true|isos|false")
 }

--- a/tests/js/places.js
+++ b/tests/js/places.js
@@ -93,7 +93,7 @@ function run(check) {
     check("replace rewrites the matched URI and label",
         Places.replace(netFile, "smb://192.168.1.10/data", "sftp://tom@nas:22/home/tom", "omv"),
         'file:///home/gm/Downloads Downloads\n'
-        + 'sftp://tom@nas:22/home/tom omv\n'
+        + 'sftp://tom@nas/home/tom omv\n'
         + 'smb://10.0.0.9/backups Backups\n')
     check("a trailing-slash live uri still finds the written line",
         Places.replace(netFile, "smb://192.168.1.10/data/", "smb://192.168.1.10/isos", "ISOs"),

--- a/tests/js/places.js
+++ b/tests/js/places.js
@@ -119,4 +119,17 @@ function run(check) {
         'sftp://nas/data Homelab\n'
         + 'file:///home/gm/Downloads Downloads\n'
         + 'sftp://nas/data Homelab\n')
+
+    check("remove drops the matched line and keeps the rest",
+        Places.remove(netFile, "smb://192.168.1.10/data"),
+        'file:///home/gm/Downloads Downloads\n'
+        + 'smb://10.0.0.9/backups Backups\n')
+    check("a trailing-slash live uri still finds the written line to drop",
+        Places.remove(netFile, "smb://192.168.1.10/data/"),
+        'file:///home/gm/Downloads Downloads\n'
+        + 'smb://10.0.0.9/backups Backups\n')
+    check("an empty uri is a no-op", Places.remove(netFile, ""), netFile)
+    check("every matching duplicate is dropped",
+        Places.remove(dupes, "smb://192.168.1.10/data"),
+        'file:///home/gm/Downloads Downloads\n')
 }

--- a/tests/js/protocols.js
+++ b/tests/js/protocols.js
@@ -77,4 +77,33 @@ function run(check) {
           Protocols.label({ label: "", host: "h", path: "/media/isos" }), "isos")
     check("falling back to the host when there is no path either",
           Protocols.label({ label: "", host: "nas", path: "/" }), "nas")
+
+    function roundtrip(form) {
+        var built = Protocols.uri(form)
+        var parsed = Protocols.parse(built)
+        return Protocols.uri(parsed)
+    }
+    check("parse inverts the SFTP URI the canvas draws",
+          roundtrip({ protocol: "SFTP", host: "username.servername.example.com", port: "22",
+                      path: "/downloads", user: "username", tls: false }),
+          "sftp://username@username.servername.example.com:22/downloads")
+    check("and the SMB domain form",
+          roundtrip({ protocol: "SMB", host: "nas", port: "445", path: "isos",
+                      user: "gm", domain: "WORKGROUP", tls: false }),
+          "smb://WORKGROUP;gm@nas:445/isos")
+    check("and NFS, which carries no credentials",
+          roundtrip({ protocol: "NFS", host: "nas", port: "2049", path: "/export", user: "gm", tls: false }),
+          "nfs://nas:2049/export")
+    check("and WebDAV with TLS on",
+          roundtrip({ protocol: "WebDAV", host: "h", port: "443", path: "/webdav", user: "u", tls: true }),
+          "davs://u@h:443/webdav")
+    check("ftp is the TLS-off twin of FTPS",
+          Protocols.parse("ftp://u@h:21/").protocol + "|" + Protocols.parse("ftp://u@h:21/").tls,
+          "FTPS|false")
+    check("a bookmark whose path is a literal tilde keeps it, gio does not expand ~",
+          Protocols.parse("sftp://tom@omv.example:22/~").path, "~")
+    check("a missing scheme is not a location", Protocols.parse("nas/share") === null, true)
+    check("an unknown scheme is refused", Protocols.parse("afp://h/share") === null, true)
+    check("a host with a non-numeric colon is refused rather than split",
+          Protocols.parse("sftp://u@[::1]/home") === null, true)
 }

--- a/tests/js/protocols.js
+++ b/tests/js/protocols.js
@@ -106,4 +106,10 @@ function run(check) {
     check("an unknown scheme is refused", Protocols.parse("afp://h/share") === null, true)
     check("a host with a non-numeric colon is refused rather than split",
           Protocols.parse("sftp://u@[::1]/home") === null, true)
+    check("an @ in the path is not stolen as a username",
+          roundtrip({ protocol: "SFTP", host: "h", port: "22", path: "inbox@2026", user: "u" }),
+          "sftp://u@h:22/inbox@2026")
+    check("and parse keeps that path and the real user",
+          Protocols.parse("sftp://u@h:22/inbox@2026").path + "|"
+          + Protocols.parse("sftp://u@h:22/inbox@2026").user, "inbox@2026|u")
 }

--- a/tests/ui.sh
+++ b/tests/ui.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Drives the real Quickshell window with omarchy-drive and asserts through the read-only IPC seam.
-# Usage: ./tests/ui.sh [cursor|terminal|open|click|menu|hidden|selection|select|colour|lifted|icons|thumbs|hashcache|stale|nosweep|oem|header|overflow|focus|preview|network|sharebrowser|unmount|eject|rename|renamelife|taildrop|grid|columns|operations|tabs ...]; no argument runs all thirty-one.
+# Usage: ./tests/ui.sh [cursor|terminal|open|click|menu|hidden|selection|select|colour|lifted|icons|thumbs|hashcache|stale|nosweep|oem|header|overflow|focus|preview|network|networkedit|sharebrowser|unmount|eject|rename|renamelife|taildrop|grid|columns|operations|tabs ...]; no argument runs all thirty-two.
 set -u
 set -o pipefail
 # Hard rule 9's guard, which owns FIXTURE_ROOT and every create and delete this suite makes.
@@ -2184,6 +2184,90 @@ case_network() {
     sandbox_remove "$fixture_home"
 }
 
+# A bookmarked SFTP URI whose path is a literal tilde does not mount (gio has no ~ expansion).
+# Edit opens the same form over that line and Save rewrites it in place.
+case_networkedit() {
+    local dir="$fixture_root/networkedit"
+    sandbox_scratch "$dir"
+    : > "$dir/0-one.txt"
+    : > "$dir/0-two.txt"
+
+    local fixture_home="$fixture_root/networkedit-home"
+    fixture_home_make "$fixture_home"
+    mkdir -p "$fixture_home/.config/gtk-3.0"
+    local bookmarks="$fixture_home/.config/gtk-3.0/bookmarks"
+    printf 'sftp://tom@omv.example:22/~ omv\n' > "$bookmarks"
+    local real_home="$HOME"
+
+    export HOME="$fixture_home"
+    launch "$dir"
+    export HOME="$real_home"
+    wait_listing 3
+    wait_rail 2
+    for _attempt in $(seq 1 100); do
+        [[ "$(ipc networkEntries)" == "omv|network|share|false" ]] && break
+        sleep 0.05
+    done
+    [[ "$(ipc networkEntries)" == "omv|network|share|false" ]] \
+        || fail "networkedit: the seeded bookmark never reached the rail, got $(ipc networkEntries)"
+
+    key -k Tab >/dev/null
+    settle
+    [[ "$(ipc focusView)" == "rail" ]] || fail "networkedit: Tab did not reach the rail"
+    # Home(0), omv(1).
+    key j >/dev/null
+    settle
+    [[ "$(ipc railCursor)" == "1" ]] || fail "networkedit: cursor did not reach omv, it is $(ipc railCursor)"
+
+    click_rail_row 1 right
+    settle
+    printf 'NETWORKEDIT menu visible=%s entries=%s glyphs=%s\n' \
+        "$(ipc contextMenuVisible)" "$(ipc contextMenuEntries)" "$(ipc contextMenuGlyphs)"
+    shot networkedit-menu
+    [[ "$(ipc contextMenuVisible)" == "true" ]] || fail "networkedit: right click opened no menu on the bookmark"
+    [[ "$(ipc contextMenuEntries)" == "Edit" ]] \
+        || fail "networkedit: the bookmark's menu is $(ipc contextMenuEntries), not one Edit row"
+    [[ "$(ipc contextMenuGlyphs)" == "rename" ]] \
+        || fail "networkedit: the Edit row draws $(ipc contextMenuGlyphs), not the rename mark"
+
+    key -k Return >/dev/null
+    settle
+    [[ "$(ipc dialogOpen)" == "true" ]] || fail "networkedit: choosing Edit did not open the dialog"
+    [[ "$(ipc networkTitle)" == "EDIT NETWORK LOCATION" ]] \
+        || fail "networkedit: the heading is $(ipc networkTitle), not EDIT NETWORK LOCATION"
+    [[ "$(ipc networkProtocol)" == "SFTP" ]] || fail "networkedit: protocol is $(ipc networkProtocol), not SFTP"
+    [[ "$(ipc networkHost)" == "omv.example" ]] || fail "networkedit: host is $(ipc networkHost)"
+    [[ "$(ipc networkUser)" == "tom" ]] || fail "networkedit: user is $(ipc networkUser)"
+    [[ "$(ipc networkPath)" == "~" ]] || fail "networkedit: path is $(ipc networkPath), not the literal tilde"
+    [[ "$(ipc networkLabel)" == "omv" ]] || fail "networkedit: label is $(ipc networkLabel)"
+    [[ "$(ipc networkUri)" == "sftp://tom@omv.example:22/~" ]] \
+        || fail "networkedit: Mounts-as is $(ipc networkUri)"
+    shot networkedit-dialog
+
+    # Host has the caret. Tab past Port onto Path, drop the tilde, type the real remote home.
+    key -k Tab >/dev/null
+    key -k Tab >/dev/null
+    key -k BackSpace >/dev/null
+    key "home/tom" >/dev/null
+    settle
+    [[ "$(ipc networkUri)" == "sftp://tom@omv.example:22/home/tom" ]] \
+        || fail "networkedit: rewriting the path left Mounts-as as $(ipc networkUri)"
+    key -k Return >/dev/null
+    settle
+    [[ "$(ipc dialogOpen)" == "false" ]] || fail "networkedit: Save did not close the dialog"
+    for _attempt in $(seq 1 100); do
+        [[ "$(ipc networkEntries)" == "omv|network|share|false" ]] && break
+        sleep 0.05
+    done
+    [[ "$(ipc networkEntries)" == "omv|network|share|false" ]] \
+        || fail "networkedit: the rail lost the row after save, got $(ipc networkEntries)"
+    [[ "$(cat "$bookmarks")" == "sftp://tom@omv.example:22/home/tom omv" ]] \
+        || fail "networkedit: bookmarks became $(cat "$bookmarks")"
+    printf 'NETWORKEDIT menu=ok prefill=ok rewrite=ok\n'
+    kill_flea
+    sandbox_remove "$fixture_home"
+}
+
 # Item 1 of Task 15 fix round 2: activating a bare smb://host/ entry lists its shares as pane
 # rows (ui/ShareBrowser.qml) instead of round 1's superseded sidebar bookmark expansion, and Enter
 # on a row mounts and opens through the exact ui/NetworkMounts.qml pipeline a bookmarked share
@@ -2405,10 +2489,10 @@ EOS
         "$(ipc contextMenuVisible)" "$(ipc contextMenuEntries)" "$(ipc contextMenuGlyphs)"
     shot unmount-menu
     [[ "$(ipc contextMenuVisible)" == "true" ]] || fail "unmount: right click opened no menu on the share"
-    [[ "$(ipc contextMenuEntries)" == "Unmount" ]] \
-        || fail "unmount: the share's menu is $(ipc contextMenuEntries), not one Unmount row"
-    [[ "$(ipc contextMenuGlyphs)" == "eject" ]] \
-        || fail "unmount: the Unmount row draws $(ipc contextMenuGlyphs), not the eject mark"
+    [[ "$(ipc contextMenuEntries)" == "Unmount|Edit" ]] \
+        || fail "unmount: the share's menu is $(ipc contextMenuEntries), not Unmount then Edit"
+    [[ "$(ipc contextMenuGlyphs)" == "eject|rename" ]] \
+        || fail "unmount: the share's glyphs are $(ipc contextMenuGlyphs), not eject then rename"
     [[ -z "$(cat "$unmount_log")" ]] || fail "unmount: opening the menu already unmounted: $(cat "$unmount_log")"
 
     # Escape closes it and still nothing has run, which is what makes the menu the confirmation.
@@ -2989,7 +3073,7 @@ cache_snapshot
 trap cleanup EXIT
 
 declare -a wanted=("$@")
-[[ ${#wanted[@]} -eq 0 ]] && wanted=(cursor terminal open click menu hidden selection select colour lifted icons thumbs hashcache stale nosweep oem header overflow focus preview network sharebrowser unmount eject rename renamelife taildrop grid columns operations tabs)
+[[ ${#wanted[@]} -eq 0 ]] && wanted=(cursor terminal open click menu hidden selection select colour lifted icons thumbs hashcache stale nosweep oem header overflow focus preview network networkedit sharebrowser unmount eject rename renamelife taildrop grid columns operations tabs)
 
 : > "$run_log"
 : > "$flea_log"

--- a/tests/ui.sh
+++ b/tests/ui.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Drives the real Quickshell window with omarchy-drive and asserts through the read-only IPC seam.
-# Usage: ./tests/ui.sh [cursor|terminal|open|click|menu|hidden|selection|select|colour|lifted|icons|thumbs|hashcache|stale|nosweep|oem|header|overflow|focus|preview|network|networkedit|sharebrowser|unmount|eject|rename|renamelife|taildrop|grid|columns|operations|tabs ...]; no argument runs all thirty-two.
+# Usage: ./tests/ui.sh [cursor|terminal|open|click|menu|hidden|selection|select|colour|lifted|icons|thumbs|hashcache|stale|nosweep|oem|header|overflow|focus|preview|network|networkedit|networkremove|sharebrowser|unmount|eject|rename|renamelife|taildrop|grid|columns|operations|tabs ...]; no argument runs all thirty-three.
 set -u
 set -o pipefail
 # Hard rule 9's guard, which owns FIXTURE_ROOT and every create and delete this suite makes.
@@ -2533,6 +2533,121 @@ EOS
     sandbox_remove "$fixture_home"
 }
 
+# Remove of a live share must not drop the bookmark if gio -u fails; an unmounted bookmark
+# is dropped immediately with no gio call.
+case_networkremove() {
+    local dir="$fixture_root/networkremove"
+    sandbox_scratch "$dir"
+    mkdir -p "$dir/bin"
+    : > "$dir/0-one.txt"
+
+    local unmount_log="$dir/unmount.log"
+    : > "$unmount_log"
+    local share_uri="smb://stubhost/stubshare/"
+    cat > "$dir/bin/gio" <<EOS
+#!/bin/sh
+case "\$1 \$2" in
+  "mount -l")
+    printf 'Mount(0): stubshare on stubhost -> $share_uri\n  Type: GDaemonMount\n'
+    exit 0
+    ;;
+  "mount -u")
+    printf 'UNMOUNT %s\n' "\$3" >> "$unmount_log"
+    exit 1
+    ;;
+esac
+exit 0
+EOS
+    chmod +x "$dir/bin/gio"
+
+    local fixture_home="$fixture_root/networkremove-home"
+    fixture_home_make "$fixture_home"
+    mkdir -p "$fixture_home/.config/gtk-3.0"
+    local bookmarks="$fixture_home/.config/gtk-3.0/bookmarks"
+    printf '%s Stub\n' "$share_uri" > "$bookmarks"
+    local real_home="$HOME" saved_path="$PATH"
+
+    export PATH="$dir/bin:$PATH"
+    export HOME="$fixture_home"
+    launch "$dir"
+    export HOME="$real_home"
+    export PATH="$saved_path"
+    wait_listing 2
+    wait_rail 2
+    for _attempt in $(seq 1 100); do
+        [[ "$(ipc networkEntries)" == "Stub|network|share|true" ]] && break
+        sleep 0.05
+    done
+    [[ "$(ipc networkEntries)" == "Stub|network|share|true" ]] \
+        || fail "networkremove: the stub mount never appeared live, got $(ipc networkEntries)"
+
+    key -k Tab >/dev/null
+    settle
+    [[ "$(ipc focusView)" == "rail" ]] || fail "networkremove: Tab did not reach the rail"
+    key j >/dev/null
+    settle
+    click_rail_row 1 right
+    settle
+    [[ "$(ipc contextMenuEntries)" == "Unmount|Edit|Remove" ]] \
+        || fail "networkremove: menu is $(ipc contextMenuEntries)"
+    key j >/dev/null
+    key j >/dev/null
+    key -k Return >/dev/null
+    wait_message "That share could not be unmounted; it may still be in use."
+    [[ "$(cat "$unmount_log")" == "UNMOUNT $share_uri" ]] \
+        || fail "networkremove: Remove did not try to unmount, log is: $(cat "$unmount_log")"
+    [[ "$(cat "$bookmarks")" == "$share_uri Stub" ]] \
+        || fail "networkremove: a failed unmount dropped the bookmark, file is $(cat "$bookmarks")"
+
+    kill_flea
+    : > "$unmount_log"
+    cat > "$dir/bin/gio" <<EOS
+#!/bin/sh
+exit 0
+EOS
+    chmod +x "$dir/bin/gio"
+    printf '%s Stub\n' "$share_uri" > "$bookmarks"
+
+    export PATH="$dir/bin:$PATH"
+    export HOME="$fixture_home"
+    launch "$dir"
+    export HOME="$real_home"
+    export PATH="$saved_path"
+    wait_listing 2
+    wait_rail 2
+    for _attempt in $(seq 1 100); do
+        [[ "$(ipc networkEntries)" == "Stub|network|share|false" ]] && break
+        sleep 0.05
+    done
+    [[ "$(ipc networkEntries)" == "Stub|network|share|false" ]] \
+        || fail "networkremove: the unmounted bookmark never appeared, got $(ipc networkEntries)"
+
+    key -k Tab >/dev/null
+    settle
+    key j >/dev/null
+    settle
+    click_rail_row 1 right
+    settle
+    [[ "$(ipc contextMenuEntries)" == "Edit|Remove" ]] \
+        || fail "networkremove: unmounted menu is $(ipc contextMenuEntries)"
+    key j >/dev/null
+    key -k Return >/dev/null
+    settle
+    for _attempt in $(seq 1 100); do
+        [[ -z "$(ipc networkEntries)" ]] && break
+        sleep 0.05
+    done
+    [[ -z "$(ipc networkEntries)" ]] \
+        || fail "networkremove: the unmounted bookmark stayed on the rail, got $(ipc networkEntries)"
+    [[ "$(cat "$bookmarks")" != *"$share_uri"* ]] \
+        || fail "networkremove: the unmounted bookmark was not dropped, file is $(cat "$bookmarks")"
+    [[ -z "$(cat "$unmount_log")" ]] || fail "networkremove: an unmounted Remove called gio -u"
+
+    printf 'NETWORKREMOVE fail-keeps-bookmark=ok idle-drops=ok\n'
+    kill_flea
+    sandbox_remove "$fixture_home"
+}
+
 # The eject half of the same menu, and the one property that must never bend: "safe to unplug" is
 # read off an lsblk listing taken after gio exits, never off gio's exit code. Both are stubbed, so
 # no real device is touched and no privilege is needed; the gio stub always exits 0, which is the
@@ -3073,7 +3188,7 @@ cache_snapshot
 trap cleanup EXIT
 
 declare -a wanted=("$@")
-[[ ${#wanted[@]} -eq 0 ]] && wanted=(cursor terminal open click menu hidden selection select colour lifted icons thumbs hashcache stale nosweep oem header overflow focus preview network networkedit sharebrowser unmount eject rename renamelife taildrop grid columns operations tabs)
+[[ ${#wanted[@]} -eq 0 ]] && wanted=(cursor terminal open click menu hidden selection select colour lifted icons thumbs hashcache stale nosweep oem header overflow focus preview network networkedit networkremove sharebrowser unmount eject rename renamelife taildrop grid columns operations tabs)
 
 : > "$run_log"
 : > "$flea_log"

--- a/tests/ui.sh
+++ b/tests/ui.sh
@@ -2225,10 +2225,10 @@ case_networkedit() {
         "$(ipc contextMenuVisible)" "$(ipc contextMenuEntries)" "$(ipc contextMenuGlyphs)"
     shot networkedit-menu
     [[ "$(ipc contextMenuVisible)" == "true" ]] || fail "networkedit: right click opened no menu on the bookmark"
-    [[ "$(ipc contextMenuEntries)" == "Edit" ]] \
-        || fail "networkedit: the bookmark's menu is $(ipc contextMenuEntries), not one Edit row"
-    [[ "$(ipc contextMenuGlyphs)" == "rename" ]] \
-        || fail "networkedit: the Edit row draws $(ipc contextMenuGlyphs), not the rename mark"
+    [[ "$(ipc contextMenuEntries)" == "Edit|Remove" ]] \
+        || fail "networkedit: the bookmark's menu is $(ipc contextMenuEntries), not Edit then Remove"
+    [[ "$(ipc contextMenuGlyphs)" == "rename|trash" ]] \
+        || fail "networkedit: the glyphs are $(ipc contextMenuGlyphs), not rename then trash"
 
     key -k Return >/dev/null
     settle
@@ -2489,10 +2489,10 @@ EOS
         "$(ipc contextMenuVisible)" "$(ipc contextMenuEntries)" "$(ipc contextMenuGlyphs)"
     shot unmount-menu
     [[ "$(ipc contextMenuVisible)" == "true" ]] || fail "unmount: right click opened no menu on the share"
-    [[ "$(ipc contextMenuEntries)" == "Unmount|Edit" ]] \
-        || fail "unmount: the share's menu is $(ipc contextMenuEntries), not Unmount then Edit"
-    [[ "$(ipc contextMenuGlyphs)" == "eject|rename" ]] \
-        || fail "unmount: the share's glyphs are $(ipc contextMenuGlyphs), not eject then rename"
+    [[ "$(ipc contextMenuEntries)" == "Unmount|Edit|Remove" ]] \
+        || fail "unmount: the share's menu is $(ipc contextMenuEntries), not Unmount, Edit, Remove"
+    [[ "$(ipc contextMenuGlyphs)" == "eject|rename|trash" ]] \
+        || fail "unmount: the share's glyphs are $(ipc contextMenuGlyphs), not eject, rename, trash"
     [[ -z "$(cat "$unmount_log")" ]] || fail "unmount: opening the menu already unmounted: $(cat "$unmount_log")"
 
     # Escape closes it and still nothing has run, which is what makes the menu the confirmation.

--- a/ui/Ipc.qml
+++ b/ui/Ipc.qml
@@ -245,6 +245,11 @@ QtObject {
         function networkPort(): string { return root.networkDialog.formPort() }
         function networkUri(): string { return root.networkDialog.formUri() }
         function networkPathLabel(): string { return root.networkDialog.formPathLabel() }
+        function networkTitle(): string { return root.networkDialog.titleText }
+        function networkHost(): string { return root.networkDialog.formHost() }
+        function networkPath(): string { return root.networkDialog.formPath() }
+        function networkUser(): string { return root.networkDialog.formUser() }
+        function networkLabel(): string { return root.networkDialog.formLabel() }
         // A protocol chip carries a label and no tree, so a test clicks its centre the way it does a row.
         function networkChipCentre(name: string): string { return root.fleaWindow.centreOf(root.networkDialog.formChip(name)) }
         function shareBrowserOpen(): bool { return root.shareBrowser.active }

--- a/ui/NetworkDialog.qml
+++ b/ui/NetworkDialog.qml
@@ -5,11 +5,12 @@ import qs.Commons
 import qs.Ui
 import "." as Flea
 import "js/Mounts.js" as Mounts
+import "js/Places.js" as Places
 import "js/Protocols.js" as Protocols
 import "js/Motion.js" as Motion
 
-// The Network group's add popup: a form over a gvfs URI, written to the same GTK bookmarks file
-// nautilus writes, plus a separate Add Dropbox action that runs the stock installer.
+// The Network group's add/edit popup: a form over a gvfs URI, written to the same GTK bookmarks
+// file nautilus writes. Add appends; Edit rewrites the line it opened on. Dropbox install is add-only.
 //
 // The form records a bookmark and mounts nothing, so it asks for a username (which the URI carries)
 // and never for a password. gio's own prompt is what asks for a secret at mount time. The canvas
@@ -21,6 +22,9 @@ Item {
     property bool opened: false
     property string statusText: ""
     property bool dropboxInstalled: false
+    // Empty while adding; the bookmark URI being rewritten while editing.
+    property string editingUri: ""
+    readonly property string titleText: root.editingUri.length > 0 ? "EDIT NETWORK LOCATION" : "ADD NETWORK LOCATION"
 
     signal closed()
     // Sidebar's own bookmarksFile FileView never watched a directory absent at its own
@@ -35,10 +39,26 @@ Item {
 
     function open() {
         root.statusText = ""
+        root.editingUri = ""
         form.reset()
         root.checkDropbox()
         root.opened = true
         // The host is the one field the form actually needs, so it takes the caret on open.
+        form.focusHost()
+    }
+
+    function openEdit(uri, label) {
+        root.statusText = ""
+        root.editingUri = uri
+        var parsed = Protocols.parse(uri)
+        if (!parsed) {
+            form.reset()
+            root.statusText = "This location could not be parsed."
+        } else {
+            form.load(parsed, label)
+        }
+        root.checkDropbox()
+        root.opened = true
         form.focusHost()
     }
 
@@ -53,17 +73,15 @@ Item {
             root.statusText = "A host is the one thing this needs; the rest is optional."
             return
         }
-        root.appendBookmark(form.uri, form.labelText())
+        root.writeBookmark(root.editingUri, form.uri, form.labelText())
         root.close()
     }
 
-    function appendBookmark(uri, label) {
+    function writeBookmark(oldUri, uri, label) {
         // Canonical form, so this line dedups against a later gio-reported mount of the same share.
         var canonical = Mounts.normalize(uri)
         var body = bookmarksWrite.text()
-        if (body.length > 0 && body.charAt(body.length - 1) !== "\n")
-            body += "\n"
-        bookmarksWrite.setText(body + canonical + " " + label + "\n")
+        bookmarksWrite.setText(Places.replace(body, oldUri, canonical, label))
         // Blocks until this write actually lands, not just until it is queued: without it,
         // Sidebar's reload() (fired by saved(), below) can race the write and read stale content.
         bookmarksWrite.waitForJob()
@@ -75,6 +93,10 @@ Item {
     function formPort() { return form.port }
     function formUri() { return form.uri }
     function formPathLabel() { return form.spec.pathLabel }
+    function formHost() { return form.host }
+    function formPath() { return form.path }
+    function formUser() { return form.user }
+    function formLabel() { return form.label }
     function formChip(name) { return form.chipFor(name) }
 
     function checkDropbox() {
@@ -174,7 +196,7 @@ Item {
                 spacing: Style.space(10)
 
                 PanelSectionHeader {
-                    text: "ADD NETWORK LOCATION"
+                    text: root.titleText
                 }
 
                 NetworkForm {
@@ -219,11 +241,16 @@ Item {
                 }
             }
 
-            PanelSeparator {}
+            PanelSeparator {
+                visible: root.editingUri.length === 0
+                height: visible ? implicitHeight : 0
+            }
 
             Column {
                 width: parent.width
                 spacing: Style.space(10)
+                visible: root.editingUri.length === 0
+                height: visible ? implicitHeight : 0
 
                 PanelSectionHeader {
                     text: "DROPBOX"

--- a/ui/NetworkForm.qml
+++ b/ui/NetworkForm.qml
@@ -109,6 +109,23 @@ Column {
         root.pick("SMB")
     }
 
+    // Fill from Protocols.parse, without pick(), so a non-default port survives rather than
+    // snapping back to the protocol's own default the way a chip click does.
+    function load(parsed, name) {
+        if (!parsed) {
+            reset()
+            return
+        }
+        root.protocol = parsed.protocol
+        root.tls = !!parsed.tls
+        portField.text = String(parsed.port || Protocols.defaultPort(parsed.protocol))
+        labelField.text = name || ""
+        hostField.text = parsed.host || ""
+        pathField.text = parsed.path || ""
+        domainField.text = parsed.domain || ""
+        userField.text = parsed.user || ""
+    }
+
     Row {
         id: chips
         spacing: Theme.spacing.hairline * 6

--- a/ui/NetworkMounts.qml
+++ b/ui/NetworkMounts.qml
@@ -42,6 +42,10 @@ Item {
     // report a second, redundant failure for the exact same mount attempt.
     property bool _mountTimedOut: false
     property string _pendingUnmountLabel: ""
+    property string _pendingUnmountUri: ""
+    // The FUSE path last opened for a share, so Unmount can leave it before gio -u (busy otherwise).
+    property string _openFuse: ""
+    property string _openFuseKey: ""
     // A re-read asked for mid-listing used to be dropped, leaving a just-mounted share to wait out
     // the poll; this remembers it instead, and mountListProcess runs it the moment the listing ends.
     property bool _pollAgain: false
@@ -84,25 +88,11 @@ Item {
         onTriggered: root.pollMounts()
     }
 
-    // Three sources, deduped on the normalized uri (see ui/js/Mounts.js "normalize"): a live gio mount wins over a bookmark for the same share even when the trailing slash differs.
+    // Three sources, deduped on the normalized uri (see ui/js/Mounts.js "normalize"): a live gio
+    // mount wins the row, the bookmark keeps the label. Places.networkEntries is that merge.
     function rebuild() {
         var home = Quickshell.env("HOME")
-        var out = []
-        var seen = {}
-        var mounts = Mounts.parseMounts(root._mountListing)
-        for (var i = 0; i < mounts.length; i++) {
-            var mkey = Mounts.normalize(mounts[i].uri)
-            if (seen[mkey]) continue
-            seen[mkey] = true
-            out.push({ path: "", label: mounts[i].label, group: "network", kind: "share", uri: mounts[i].uri, mounted: true, glyph: "server" })
-        }
-        var marks = Mounts.nonFileBookmarks(root.bookmarksText)
-        for (var j = 0; j < marks.length; j++) {
-            var bkey = Mounts.normalize(marks[j].uri)
-            if (seen[bkey]) continue
-            seen[bkey] = true
-            out.push({ path: "", label: marks[j].label, group: "network", kind: "share", uri: marks[j].uri, mounted: false, glyph: "server" })
-        }
+        var out = Places.networkEntries(Mounts.parseMounts(root._mountListing), Mounts.nonFileBookmarks(root.bookmarksText))
         if (dropboxFile.loaded) {
             out.push({ path: home + "/Dropbox", label: "Dropbox", group: "network", kind: "dropbox", uri: "", mounted: true, glyph: "" })
         }
@@ -162,9 +152,21 @@ Item {
     // instance breaks the whole window's keyboard focus" for why one was tried and reverted.
     function unmount(index) {
         var e = root.entries[index]
-        if (!e || e.kind !== "share" || !e.mounted || unmountProcess.running) return
+        if (!e || e.kind !== "share" || !e.mounted || unmountProcess.running || unmountDelay.running) return
         root._pendingUnmountLabel = e.label
-        unmountProcess.command = ["gio", "mount", "-u", e.uri]
+        root._pendingUnmountUri = e.uri
+        if (root._openFuseKey.length > 0 && Mounts.normalize(e.uri) === root._openFuseKey) {
+            root._openFuse = ""
+            root._openFuseKey = ""
+            root.opened(Quickshell.env("HOME"))
+            unmountDelay.restart()
+            return
+        }
+        root.runUnmount(e.uri)
+    }
+
+    function runUnmount(uri) {
+        unmountProcess.command = ["gio", "mount", "-u", uri]
         unmountProcess.running = true
     }
 
@@ -227,6 +229,18 @@ Item {
         }
     }
 
+    Timer {
+        id: unmountDelay
+        interval: 150
+        repeat: false
+        onTriggered: {
+            var uri = root._pendingUnmountUri
+            root._pendingUnmountUri = ""
+            if (uri.length > 0)
+                root.runUnmount(uri)
+        }
+    }
+
     Process {
         id: mountProcess
         stderr: StdioCollector { id: mountErr; waitForEnd: true; onStreamFinished: root._mountErrOutput = text }
@@ -254,7 +268,10 @@ Item {
             var body = String(infoOut.text || root._infoOutput || "")
             var line = body.split("\n").find(function (l) { return l.indexOf("local path: ") === 0 })
             if (exitCode === 0 && line) {
-                root.opened(line.substring("local path: ".length).trim())
+                var localPath = line.substring("local path: ".length).trim()
+                root._openFuse = localPath
+                root._openFuseKey = Mounts.normalize(root._pendingUri)
+                root.opened(localPath)
                 return
             }
             if (root.isBareRoot(root._pendingUri)) {

--- a/ui/NetworkMounts.qml
+++ b/ui/NetworkMounts.qml
@@ -43,6 +43,8 @@ Item {
     property bool _mountTimedOut: false
     property string _pendingUnmountLabel: ""
     property string _pendingUnmountUri: ""
+    // Set by Remove on a live share; the bookmark is dropped only after gio -u succeeds.
+    property string _pendingRemoveUri: ""
     // The FUSE path last opened for a share, so Unmount can leave it before gio -u (busy otherwise).
     property string _openFuse: ""
     property string _openFuseKey: ""
@@ -152,7 +154,8 @@ Item {
     // instance breaks the whole window's keyboard focus" for why one was tried and reverted.
     function unmount(index) {
         var e = root.entries[index]
-        if (!e || e.kind !== "share" || !e.mounted || unmountProcess.running || unmountDelay.running) return
+        if (!e || e.kind !== "share" || !e.mounted || unmountProcess.running || unmountDelay.running)
+            return false
         root._pendingUnmountLabel = e.label
         // gio lists one SFTP mount for the host; -u must be that URI, not a path on it.
         var target = Places.coveringUri(Mounts.parseMounts(root._mountListing), e.uri)
@@ -162,9 +165,10 @@ Item {
             root._openFuseKey = ""
             root.opened(Quickshell.env("HOME"))
             unmountDelay.restart()
-            return
+            return true
         }
         root.runUnmount(target)
+        return true
     }
 
     function runUnmount(uri) {
@@ -172,17 +176,25 @@ Item {
         unmountProcess.running = true
     }
 
-    // Drops the bookmark line. A live mount is unmounted too, so the row leaves the rail instead
-    // of turning into a mount-only leftover of the place the operator just deleted.
+    function dropBookmark(uri) {
+        var body = bookmarksWrite.text()
+        bookmarksWrite.setText(Places.remove(body, uri))
+        bookmarksWrite.waitForJob()
+        root.renamed()
+    }
+
+    // An unmounted bookmark is dropped immediately. A live one is unmounted first; the file is
+    // rewritten from unmountProcess.onExited only when gio succeeds, so a busy share keeps its row.
     function remove(index) {
         var e = root.entries[index]
         if (!e || e.kind !== "share") return
-        var body = bookmarksWrite.text()
-        bookmarksWrite.setText(Places.remove(body, e.uri))
-        bookmarksWrite.waitForJob()
-        root.renamed()
-        if (e.mounted)
-            root.unmount(index)
+        if (!e.mounted) {
+            root.dropBookmark(e.uri)
+            return
+        }
+        root._pendingRemoveUri = e.uri
+        if (!root.unmount(index))
+            root._pendingRemoveUri = ""
     }
 
     // Rewrites uri's own label, or appends a bookmark for it if it was only ever a live mount;
@@ -301,12 +313,18 @@ Item {
     Process {
         id: unmountProcess
         onExited: function (exitCode) {
+            var removeUri = root._pendingRemoveUri
+            root._pendingRemoveUri = ""
             root.pollMounts()
             // A success message replaces the arm prompt, which would otherwise linger, stale,
             // for up to its own 4 s clear window with nothing on screen to say it already fired.
-            root.message(exitCode === 0
-                ? "Unmounted " + root._pendingUnmountLabel + "."
-                : "That share could not be unmounted; it may still be in use.", exitCode !== 0)
+            if (exitCode === 0) {
+                if (removeUri.length > 0)
+                    root.dropBookmark(removeUri)
+                root.message("Unmounted " + root._pendingUnmountLabel + ".", false)
+                return
+            }
+            root.message("That share could not be unmounted; it may still be in use.", true)
         }
     }
 

--- a/ui/NetworkMounts.qml
+++ b/ui/NetworkMounts.qml
@@ -154,15 +154,17 @@ Item {
         var e = root.entries[index]
         if (!e || e.kind !== "share" || !e.mounted || unmountProcess.running || unmountDelay.running) return
         root._pendingUnmountLabel = e.label
-        root._pendingUnmountUri = e.uri
-        if (root._openFuseKey.length > 0 && Mounts.normalize(e.uri) === root._openFuseKey) {
+        // gio lists one SFTP mount for the host; -u must be that URI, not a path on it.
+        var target = Places.coveringUri(Mounts.parseMounts(root._mountListing), e.uri)
+        root._pendingUnmountUri = target
+        if (root._openFuseKey.length > 0 && Places.connectionKey(e.uri) === root._openFuseKey) {
             root._openFuse = ""
             root._openFuseKey = ""
             root.opened(Quickshell.env("HOME"))
             unmountDelay.restart()
             return
         }
-        root.runUnmount(e.uri)
+        root.runUnmount(target)
     }
 
     function runUnmount(uri) {
@@ -270,7 +272,7 @@ Item {
             if (exitCode === 0 && line) {
                 var localPath = line.substring("local path: ".length).trim()
                 root._openFuse = localPath
-                root._openFuseKey = Mounts.normalize(root._pendingUri)
+                root._openFuseKey = Places.connectionKey(root._pendingUri)
                 root.opened(localPath)
                 return
             }

--- a/ui/NetworkMounts.qml
+++ b/ui/NetworkMounts.qml
@@ -168,6 +168,19 @@ Item {
         unmountProcess.running = true
     }
 
+    // Drops the bookmark line. A live mount is unmounted too, so the row leaves the rail instead
+    // of turning into a mount-only leftover of the place the operator just deleted.
+    function remove(index) {
+        var e = root.entries[index]
+        if (!e || e.kind !== "share") return
+        var body = bookmarksWrite.text()
+        bookmarksWrite.setText(Places.remove(body, e.uri))
+        bookmarksWrite.waitForJob()
+        root.renamed()
+        if (e.mounted)
+            root.unmount(index)
+    }
+
     // Rewrites uri's own label, or appends a bookmark for it if it was only ever a live mount;
     // either way this is what makes the rename survive a reboot. waitForJob() blocks until the
     // write actually lands, the same fix AGENTS.md "A FileView write can race a reload" applies

--- a/ui/Sidebar.qml
+++ b/ui/Sidebar.qml
@@ -38,6 +38,7 @@ Item {
 
     signal opened(string path)
     signal addRequested()
+    signal editRequested(string uri, string label)
     signal message(string text, bool isError)
     // Bubbled straight from NetworkMounts; shell.qml opens ui/ShareBrowser.qml on this.
     signal sharesListed(string baseUri, string baseLabel, var names)
@@ -146,7 +147,9 @@ Item {
     // A chosen menu row, arriving with the row's key rather than its position; which row that
     // names is Mounts.release', so tests/js/mounts.js drives the resolution with no rail.
     function releaseChosen(action, key) {
-        Mounts.release(action, key, devices, mounts, root.deviceEntries, root.networkEntries)
+        Mounts.release(action, key, devices, mounts, root.deviceEntries, root.networkEntries, {
+            edit: function (uri, label) { root.editRequested(uri, label) }
+        })
     }
 
     Connections {

--- a/ui/js/Eject.js
+++ b/ui/js/Eject.js
@@ -122,10 +122,10 @@ function release(root, sidebar, fromRail) {
         root.message("This directory is not inside a removable volume, so there is nothing to eject.", false)
         return
     }
-    var rows = Mounts.railMenu(entry)
-    if (rows.length === 0) {
+    var action = Mounts.releaseAction(entry)
+    if (!action) {
         root.message(entry.label + " has nothing to eject or unmount.", false)
         return
     }
-    sidebar.releaseChosen(rows[0].action, Mounts.railKey(entry))
+    sidebar.releaseChosen(action, Mounts.railKey(entry))
 }

--- a/ui/js/Mounts.js
+++ b/ui/js/Mounts.js
@@ -173,6 +173,7 @@ function railMenu(entry) {
         if (entry.mounted)
             rows.push({ label: "Unmount", action: "unmount", glyph: "eject" })
         rows.push({ label: "Edit", action: "edit", glyph: "rename" })
+        rows.push({ label: "Remove", action: "remove", glyph: "trash" })
         return rows
     }
     return []
@@ -261,4 +262,6 @@ function release(action, key, devices, mounts, deviceEntries, networkEntries, ed
         mounts.unmount(share)
     if (action === "edit" && editor)
         editor.edit(networkEntries[share].uri, networkEntries[share].label)
+    if (action === "remove")
+        mounts.remove(share)
 }

--- a/ui/js/Mounts.js
+++ b/ui/js/Mounts.js
@@ -68,9 +68,26 @@ function decodePath(raw) {
     }
 }
 
-// One canonical form: every trailing slash stripped, except a bare host root, which keeps one.
+// gio mount -l omits a scheme's default port; the add form writes it. Same share either way.
+var DEFAULT_PORTS = { smb: "445", sftp: "22", ftp: "21", ftps: "21", dav: "443", davs: "443", nfs: "2049" }
+
+function stripDefaultPort(uri) {
+    var m = String(uri).match(/^([a-z][a-z0-9+.-]*):\/\//i)
+    if (!m)
+        return uri
+    var def = DEFAULT_PORTS[m[1].toLowerCase()]
+    if (!def)
+        return uri
+    var rest = uri.substring(m[0].length)
+    var at = rest.lastIndexOf("@")
+    var hostPart = at >= 0 ? rest.substring(at + 1) : rest
+    var head = at >= 0 ? uri.substring(0, m[0].length + at + 1) : m[0]
+    return head + hostPart.replace(new RegExp("^([^/]+):" + def + "(?=/|$)"), "$1")
+}
+
+// One canonical form: default ports dropped, trailing slashes stripped except a bare host root.
 function normalize(uri) {
-    var stripped = String(uri || "").replace(/\/+$/, "")
+    var stripped = stripDefaultPort(String(uri || "")).replace(/\/+$/, "")
     var bareRoot = /^[a-z][a-z0-9+.-]*:\/\/[^\/]+$/i.test(stripped)
     return bareRoot ? stripped + "/" : stripped
 }

--- a/ui/js/Mounts.js
+++ b/ui/js/Mounts.js
@@ -157,18 +157,36 @@ function sameEntry(x, y) {
 
 // Sample input: one rail entry as ui/DeviceMounts.qml and ui/NetworkMounts.qml build them,
 // {label:"128GB", group:"device", kind:"volume", device:"/dev/sda1", mounted:true}.
-// A removable volume ejects and a mounted network share unmounts; every other rail row offers
-// neither and opens no menu. The kind is read here, never re-derived: the internal disk reads as
-// mounted too, the Dropbox row is a local folder the stock service owns, and a favourite is not a
-// mount. gio's -f is offered nowhere: forcing an unmount over an open write is how data is lost.
+// A removable volume ejects and a mounted network share unmounts; a share also offers Edit so a
+// bookmark whose URI is wrong can be rewritten without leaving the rail. Every other rail row
+// offers neither and opens no menu. The kind is read here, never re-derived: the internal disk
+// reads as mounted too, the Dropbox row is a local folder the stock service owns, and a favourite
+// is not a mount. gio's -f is offered nowhere: forcing an unmount over an open write is how data
+// is lost. Unmount stays first on a live share so Ctrl+E still releases rather than opening Edit.
 function railMenu(entry) {
-    if (!entry || !entry.mounted)
+    if (!entry)
         return []
-    if (entry.group === "device" && entry.kind === "volume")
+    if (entry.group === "device" && entry.kind === "volume" && entry.mounted)
         return [{ label: "Eject", action: "eject", glyph: "eject" }]
-    if (entry.group === "network" && entry.kind === "share")
-        return [{ label: "Unmount", action: "unmount", glyph: "eject" }]
+    if (entry.group === "network" && entry.kind === "share") {
+        var rows = []
+        if (entry.mounted)
+            rows.push({ label: "Unmount", action: "unmount", glyph: "eject" })
+        rows.push({ label: "Edit", action: "edit", glyph: "rename" })
+        return rows
+    }
     return []
+}
+
+// The action Ctrl+E fires: eject or unmount, never Edit. A bookmark-only share has a menu and
+// still answers empty here, so the key cannot rewrite a URI the operator did not open a menu for.
+function releaseAction(entry) {
+    var rows = railMenu(entry)
+    for (var i = 0; i < rows.length; i++) {
+        if (rows[i].action === "eject" || rows[i].action === "unmount")
+            return rows[i].action
+    }
+    return ""
 }
 
 // The handle a chosen menu row carries back: a volume's device node, a share's uri, "" for a row
@@ -205,7 +223,7 @@ function holding(entries, dir) {
     var path = String(dir || "")
     for (var i = 0; i < list.length; i++) {
         var e = list[i]
-        if (!e.path || railMenu(e).length === 0)
+        if (!e.path || !releaseAction(e))
             continue
         if (path === e.path || path.indexOf(e.path + "/") === 0)
             return e
@@ -229,16 +247,18 @@ function raiseMenu(pane, sidebar) {
 // a five second poll, so the index the menu opened over can name a different row by now. A key
 // that no longer names a row does nothing, because the row it named has left the rail already.
 // Both Services re-check the kind themselves; this only resolves which row was meant.
-function release(action, key, devices, mounts, deviceEntries, networkEntries) {
+function release(action, key, devices, mounts, deviceEntries, networkEntries, editor) {
     if (action === "eject") {
         var volume = rowByKey(deviceEntries, key)
         if (volume >= 0)
             devices.eject(volume)
         return
     }
-    if (action === "unmount") {
-        var share = rowByKey(networkEntries, key)
-        if (share >= 0)
-            mounts.unmount(share)
-    }
+    var share = rowByKey(networkEntries, key)
+    if (share < 0)
+        return
+    if (action === "unmount")
+        mounts.unmount(share)
+    if (action === "edit" && editor)
+        editor.edit(networkEntries[share].uri, networkEntries[share].label)
 }

--- a/ui/js/Places.js
+++ b/ui/js/Places.js
@@ -62,6 +62,41 @@ function leaf(path) {
     return cut < 0 ? path : path.substring(cut + 1)
 }
 
+function taggedShare(uri, label, mounted) {
+    return { path: "", label: label, group: "network", kind: "share", uri: uri, mounted: mounted, glyph: "server" }
+}
+
+// Live mounts first, then bookmarks not already mounted. A bookmark's label wins over gio's
+// "user on host" name, so a rename survives the next poll while the share is still mounted.
+function networkEntries(mounts, marks) {
+    var labels = {}
+    var list = marks || []
+    for (var j = 0; j < list.length; j++) {
+        var k = Mounts.normalize(list[j].uri)
+        if (k.length === 0 || labels[k] !== undefined)
+            continue
+        labels[k] = list[j].label
+    }
+    var out = []
+    var seen = {}
+    var live = mounts || []
+    for (var i = 0; i < live.length; i++) {
+        var mkey = Mounts.normalize(live[i].uri)
+        if (seen[mkey])
+            continue
+        seen[mkey] = true
+        out.push(taggedShare(live[i].uri, labels[mkey] || live[i].label, true))
+    }
+    for (var n = 0; n < list.length; n++) {
+        var bkey = Mounts.normalize(list[n].uri)
+        if (seen[bkey])
+            continue
+        seen[bkey] = true
+        out.push(taggedShare(list[n].uri, list[n].label, false))
+    }
+    return out
+}
+
 // Sample input: "smb://192.168.1.10/data NAS"; see AGENTS.md "Places.relabel" for the matching, duplicate and control-character rules.
 function relabel(body, path, name) {
     // A trust boundary: an embedded newline could otherwise split one bookmark into two lines.

--- a/ui/js/Places.js
+++ b/ui/js/Places.js
@@ -121,3 +121,26 @@ function replace(body, oldUri, newUri, label) {
         out += "\n"
     return out + next + " " + trimmed + "\n"
 }
+
+// Drops every line whose uri matches, leaving the rest byte-identical. An empty uri is a no-op
+// so a Dropbox row with no bookmark cannot wipe the file.
+function remove(body, uri) {
+    var target = Mounts.normalize(uri)
+    if (target.length === 0)
+        return String(body || "")
+    var lines = String(body || "").split("\n")
+    var out = []
+    for (var i = 0; i < lines.length; i++) {
+        var line = lines[i]
+        if (line.trim().length === 0) {
+            out.push(line)
+            continue
+        }
+        var space = line.indexOf(" ")
+        var u = space < 0 ? line : line.substring(0, space)
+        if (Mounts.normalize(u) === target)
+            continue
+        out.push(line)
+    }
+    return out.join("\n")
+}

--- a/ui/js/Places.js
+++ b/ui/js/Places.js
@@ -66,8 +66,32 @@ function taggedShare(uri, label, mounted) {
     return { path: "", label: label, group: "network", kind: "share", uri: uri, mounted: mounted, glyph: "server" }
 }
 
-// Live mounts first, then bookmarks not already mounted. A bookmark's label wins over gio's
-// "user on host" name, so a rename survives the next poll while the share is still mounted.
+// gvfsd-sftp (and ftp) mounts one connection per host, not per path. SMB/NFS stay per share.
+function connectionKey(uri) {
+    var n = Mounts.normalize(uri)
+    var s = (n.match(/^([a-z][a-z0-9+.-]*)/i) || [""])[0].toLowerCase()
+    if (s !== "sftp" && s !== "ssh" && s !== "ftp" && s !== "ftps")
+        return n
+    var m = n.match(/^([a-z][a-z0-9+.-]*:\/\/[^\/]+)/i)
+    return m ? Mounts.normalize(m[1]) : n
+}
+
+function covers(liveUri, otherUri) {
+    var a = connectionKey(liveUri)
+    return a.length > 0 && a === connectionKey(otherUri)
+}
+
+function coveringUri(mounts, uri) {
+    var list = mounts || []
+    for (var i = 0; i < list.length; i++) {
+        if (covers(list[i].uri, uri))
+            return list[i].uri
+    }
+    return uri
+}
+
+// Live mounts first, then bookmarks not already shown. A bookmark's label wins over gio's
+// "user on host" name. An SFTP path on a live host is mounted even when gio only lists the root.
 function networkEntries(mounts, marks) {
     var labels = {}
     var list = marks || []
@@ -92,7 +116,14 @@ function networkEntries(mounts, marks) {
         if (seen[bkey])
             continue
         seen[bkey] = true
-        out.push(taggedShare(list[n].uri, list[n].label, false))
+        var mounted = false
+        for (var k = 0; k < live.length; k++) {
+            if (covers(live[k].uri, list[n].uri)) {
+                mounted = true
+                break
+            }
+        }
+        out.push(taggedShare(list[n].uri, list[n].label, mounted))
     }
     return out
 }

--- a/ui/js/Places.js
+++ b/ui/js/Places.js
@@ -89,3 +89,35 @@ function relabel(body, path, name) {
         out += "\n"
     return out + target + " " + trimmed + "\n"
 }
+
+// Sample input: body as relabel's, oldUri the bookmark being rewritten, newUri the form's Mounts-as
+// line. Matching is the same normalized compare relabel uses, so a live gio trailing slash still
+// finds the written line. An empty oldUri matches nothing and appends, which is the add-dialog path.
+function replace(body, oldUri, newUri, label) {
+    var trimmed = String(label || "").replace(/[\r\n]/g, "").trim()
+    var next = Mounts.normalize(newUri)
+    if (next.length === 0)
+        return String(body || "")
+    if (trimmed.length === 0)
+        trimmed = Mounts.leaf(next)
+    var target = Mounts.normalize(oldUri)
+    var lines = String(body || "").split("\n")
+    var found = false
+    for (var i = 0; i < lines.length; i++) {
+        var line = lines[i]
+        if (line.trim().length === 0)
+            continue
+        var space = line.indexOf(" ")
+        var uri = space < 0 ? line : line.substring(0, space)
+        if (target.length > 0 && Mounts.normalize(uri) === target) {
+            lines[i] = next + " " + trimmed
+            found = true
+        }
+    }
+    if (found)
+        return lines.join("\n")
+    var out = String(body || "")
+    if (out.length > 0 && out.charAt(out.length - 1) !== "\n")
+        out += "\n"
+    return out + next + " " + trimmed + "\n"
+}

--- a/ui/js/Protocols.js
+++ b/ui/js/Protocols.js
@@ -97,3 +97,74 @@ function label(form) {
 function complete(form) {
     return String(form.host || "").trim().length > 0
 }
+
+function protocolFor(schemeName) {
+    switch (String(schemeName || "").toLowerCase()) {
+    case "smb": return "SMB"
+    case "sftp": return "SFTP"
+    case "ftp":
+    case "ftps": return "FTPS"
+    case "dav":
+    case "davs": return "WebDAV"
+    case "nfs": return "NFS"
+    }
+    return ""
+}
+
+// Inverse of uri(): a bookmark line's address becomes the form fields that would rebuild it.
+// corner: a host with a colon that is not a port (IPv6 without brackets) is refused rather than
+// split, because the form has no place to round-trip that spelling.
+function parse(uri) {
+    var raw = String(uri || "").trim()
+    var m = raw.match(/^([a-z][a-z0-9+.-]*):\/\/(.*)$/i)
+    if (!m)
+        return null
+    var schemeName = m[1].toLowerCase()
+    var protocol = protocolFor(schemeName)
+    if (!protocol)
+        return null
+    var rest = m[2]
+    var user = ""
+    var domain = ""
+    var at = rest.lastIndexOf("@")
+    if (at >= 0) {
+        var creds = rest.substring(0, at)
+        rest = rest.substring(at + 1)
+        var semi = creds.indexOf(";")
+        if (semi >= 0) {
+            domain = creds.substring(0, semi)
+            user = creds.substring(semi + 1)
+        } else {
+            user = creds
+        }
+    }
+    var path = "/"
+    var slash = rest.indexOf("/")
+    if (slash >= 0) {
+        path = rest.substring(slash)
+        rest = rest.substring(0, slash)
+    }
+    var host = rest
+    var port = ""
+    var colon = rest.lastIndexOf(":")
+    if (colon >= 0) {
+        var maybePort = rest.substring(colon + 1)
+        if (!/^\d+$/.test(maybePort))
+            return null
+        host = rest.substring(0, colon)
+        port = maybePort
+    }
+    if (host.length === 0)
+        return null
+    if (port.length === 0)
+        port = String(defaultPort(protocol))
+    return {
+        protocol: protocol,
+        host: host,
+        port: port,
+        path: path === "/" ? "" : path.replace(/^\/+/, ""),
+        domain: domain,
+        user: user,
+        tls: schemeName === "davs" || schemeName === "ftps"
+    }
+}

--- a/ui/js/Protocols.js
+++ b/ui/js/Protocols.js
@@ -124,8 +124,15 @@ function parse(uri) {
     if (!protocol)
         return null
     var rest = m[2]
+    var path = "/"
+    var slash = rest.indexOf("/")
+    if (slash >= 0) {
+        path = rest.substring(slash)
+        rest = rest.substring(0, slash)
+    }
     var user = ""
     var domain = ""
+    // Authority only: an @ in the path (inbox@2026) must not be read as credentials.
     var at = rest.lastIndexOf("@")
     if (at >= 0) {
         var creds = rest.substring(0, at)
@@ -137,12 +144,6 @@ function parse(uri) {
         } else {
             user = creds
         }
-    }
-    var path = "/"
-    var slash = rest.indexOf("/")
-    if (slash >= 0) {
-        path = rest.substring(slash)
-        rest = rest.substring(0, slash)
     }
     var host = rest
     var port = ""

--- a/ui/shell.qml
+++ b/ui/shell.qml
@@ -161,6 +161,7 @@ ShellRoot {
             Connections {
                 target: pane.sidebar
                 function onAddRequested() { networkDialog.open() }
+                function onEditRequested(uri, label) { networkDialog.openEdit(uri, label) }
                 function onSharesListed(baseUri, baseLabel, names) { shareBrowser.open(baseUri, baseLabel, names) }
             }
 


### PR DESCRIPTION
A network place can be added, and `r` can relabel it, but there was no way to change the URI or drop the bookmark. On a fresh Omarchy install that showed up immediately: SFTP bookmarks were saved, one used a literal `~` (`gio` does not expand it), and fixing the line meant editing `~/.config/gtk-3.0/bookmarks` by hand.

This PR is the rail work that followed from that, not only the edit dialog.

## Edit and remove

- Right-click (or `m`) on a NETWORK share offers **Edit** and **Remove**.
- An unmounted bookmark is still reachable, so a URI that will not mount can be rewritten.
- A mounted share keeps **Unmount** first, then Edit, then Remove.
- Edit opens the existing add-location form, filled from `Protocols.parse`.
- Save rewrites that bookmark line in place via `Places.replace` (same GTK file, same normalized match `relabel` already uses).
- Remove drops the matching bookmark line. If the share is live, it also unmounts.
- Dropbox install stays on the add dialog only.
- `r` is unchanged: it still only relabels.
- Ctrl+E cannot fire Edit. It reads `Mounts.releaseAction` (eject/unmount only) instead of `railMenu()[0]`.

## Live mounts vs bookmarks (SFTP)

The add form writes `sftp://user@host:22/path`. `gio mount -l` reports the same share without the default port, so opening a saved place used to add a second, brighter row and leave the cursor on the dim bookmark. `normalize` now drops a scheme's default port on write and on compare.

Once collapsed, the live `gio` row kept gio's own name (`tom` for an SFTP session) and dropped the bookmark's, so rename wrote the file and the next poll put `tom` back. `Places.networkEntries` keeps the bookmark label on the live row.

gvfsd-sftp mounts **one connection per host**. `gio` lists `sftp://user@host/` even when the bookmark is `…/home/tom`, so a second path on that host stayed dim, and Unmount of the root failed as busy while Flea was listing `/home/tom` on the same FUSE mount. Extra SFTP/FTP paths on a live host now stay their own rows and read as mounted. Unmount sends gio the live root URI and goes Home first if any path on that connection is open. SMB/NFS stay per-share.

## Tests

- `tests/js.sh`: parse round-trips, replace/remove, rail menu, Ctrl+E, live/bookmark merge, SFTP connection coverage, SMB still per-share.
- `tests/ui.sh case_networkedit` seeds a `~` bookmark, opens Edit, rewrites the path, and asserts the bookmarks file.
- `case_unmount` expects Unmount, Edit, Remove on a live share; Return still fires Unmount.

`tests/ui.sh` was not run on the original box (`omarchy-drive` is not installed). JS suites and the file-budget hard cap passed.

## Notes

`gio` does not expand `~` in an SFTP path; use `/home/user` (or leave Path empty for the remote `/`). Hyprland also does not start `gvfsd-fuse`; without it Flea can mount over D-Bus and then fail with "no browsable folder". That daemon is a session concern, not part of this PR.