### PR TITLE
fix: open the GUI for bare terminal launches

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -349,17 +349,17 @@ booleans, `want_tui` and `want_gui`, not an enum: there are four modes total, ea
 exactly once, and a type nobody matches on twice would be ceremony.
 
 `--tui` and `--gui` are mutually exclusive; giving both is a usage error naming the conflict,
-never a coin flip. With neither flag, the choice is `interactive`: both stdin and stdout must
-be a real terminal, not just one, so that a pipeline never receives the terminal interface.
-`flea | head` gives stdin a tty and stdout a pipe, so `interactive` is false and the window
-branch runs; what the rule prevents is the terminal interface writing escape codes into that
-pipe, which is exactly what the `--tui` refusal below it says. `--tui` without a terminal on
-both handles exits 2; `--gui` without `WAYLAND_DISPLAY` or `DISPLAY` refuses rather than
+never a coin flip. With neither flag the window is the default, including when both handles are
+a terminal, because the terminal interface is reserved but not built and a bare invocation must
+open the product that exists. `--tui` is the only route to that reserved interface. It requires
+both stdin and stdout to be a real terminal, not just one, so a future implementation cannot write
+escape codes into a pipeline. `flea | head` gives stdin a tty and stdout a pipe and an explicit
+`--tui` therefore refuses. `--gui` without `WAYLAND_DISPLAY` or `DISPLAY` refuses rather than
 trying and failing inside `qs`.
 
-Telling that `&&` apart from an `||` needs a tty on exactly one handle and no suite here has
-a pty, so that distinction is untested; the no-flag case in `./tests/modes.sh` pins only
-which branch the default takes.
+`./tests/modes.sh` checks both no-flag shapes: redirected handles exercise the launcher path and
+`script` from the hard `util-linux` dependency gives the child a real pty on both handles, pinning
+the terminal invocation that used to fall into the unbuilt interface.
 
 `paths::ui_dir()` finds the UI the same way `FLEA_BIN` finds the backend binary (see "Where
 the backend binary comes from" below): `FLEA_UI` first, then the packaged

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -380,8 +380,7 @@ huge pages" below for what it is worth and what it cost.
 - `main.rs` dispatches on argv: `--backend` runs the command loop, `--prewarm <path>
   <first> <dest>` writes the prewarm file, `--open <path>` hands one file to the desktop's
   handler, `--default [off]` claims or releases the OS-level default, and anything else
-  picks the terminal interface or the window by the `--tui`/`--gui` flags and the tty
-  state, see "Modes".
+  opens the window unless explicit `--tui` requests the terminal interface, see "Modes".
 - `paths.rs` resolves the UI directory and whether a display is available.
 - `gui.rs` execs `qs` against the resolved UI directory.
 - `thp.rs` the one `prctl(PR_SET_THP_DISABLE)` declaration, `disable()` and `enable()`.

--- a/src/main.rs
+++ b/src/main.rs
@@ -121,11 +121,10 @@ fn main() {
         None => (start, None),
     };
 
-    // Both handles must be a tty, so a pipeline never receives the terminal interface.
+    // The window is the default until the terminal interface exists. Keep the tty check on an
+    // explicit --tui so a future implementation cannot write escape codes into a pipeline.
     let interactive = std::io::stdin().is_terminal() && std::io::stdout().is_terminal();
-    let tui = if want_tui { true } else if want_gui { false } else { interactive };
-
-    if tui {
+    if want_tui {
         if !interactive {
             eprintln!("flea: the terminal interface needs a terminal on stdin and stdout");
             exit(2);

--- a/src/main.rs
+++ b/src/main.rs
@@ -121,8 +121,7 @@ fn main() {
         None => (start, None),
     };
 
-    // The window is the default until the terminal interface exists. Keep the tty check on an
-    // explicit --tui so a future implementation cannot write escape codes into a pipeline.
+    // Keep the tty check on explicit --tui so a future implementation cannot write escape codes into a pipeline.
     let interactive = std::io::stdin().is_terminal() && std::io::stdout().is_terminal();
     if want_tui {
         if !interactive {

--- a/tests/modes.sh
+++ b/tests/modes.sh
@@ -42,6 +42,11 @@ check "missing qs carries no errno" "0" "$(echo "$out" | grep -c 'os error')"
 out=$(env -u WAYLAND_DISPLAY -u DISPLAY $BIN . 2>&1 </dev/null)
 check "no flag defaults to the window" "1" "$(echo "$out" | grep -c 'no graphical session')"
 
+# A shell gives the child a tty on both handles. Bare flea still means the product that exists,
+# not the reserved terminal interface; script comes from Flea's hard util-linux dependency.
+out=$(env -u WAYLAND_DISPLAY -u DISPLAY script -qec "$BIN ." /dev/null 2>&1)
+check "no flag at a terminal defaults to the window" "1" "$(echo "$out" | grep -c 'no graphical session')"
+
 # --tui with no tty must refuse rather than write escape codes into a pipe.
 out=$($BIN --tui 2>&1 </dev/null | cat)
 check "--tui without a tty refuses" "1" "$(echo "$out" | grep -c 'needs a terminal')"

--- a/tests/modes.sh
+++ b/tests/modes.sh
@@ -62,8 +62,7 @@ check "missing qs carries no errno" "0" "$(echo "$out" | grep -c 'os error')"
 out=$(env -u WAYLAND_DISPLAY -u DISPLAY $BIN . 2>&1 </dev/null)
 check "no flag defaults to the window" "1" "$(echo "$out" | grep -c 'no graphical session')"
 
-# A shell gives the child a tty on both handles. Bare flea still means the product that exists,
-# not the reserved terminal interface; script comes from Flea's hard util-linux dependency.
+# A shell PTY proves bare flea still means the product that exists, not the reserved terminal interface.
 out=$(env -u WAYLAND_DISPLAY -u DISPLAY script -qec "$BIN ." /dev/null 2>&1)
 check "no flag at a terminal defaults to the window" "1" "$(echo "$out" | grep -c 'no graphical session')"
 


### PR DESCRIPTION
## What was wrong

Running `flea` from a terminal inferred the reserved TUI and exited because that interface is not built. That made the first command shown after installation fail instead of opening Flea.

## Fix

- make the GUI the default for a bare invocation, including from a real terminal
- retain explicit `--tui` terminal validation
- add a real-PTY regression test
- update the mode contract documentation

## Verification

- [x] clean `cargo build` and `cargo build --release`, zero warnings
- [x] clean `cargo test` and `cargo test --release`: 338 passed in each profile
- [x] `FLEA_FIXTURE_ROOT=/tmp/flea-sandbox ./tests/modes.sh`
- [x] `./tools/flea-qmllint-gate`: 0 regressions
- [x] `./tools/flea-file-budget`: hard budgets pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Changes**
  - The window interface is now the default when no mode flag is provided, including when launched from a terminal.
  - The terminal interface requires an explicit `--tui` flag and refuses to run when input or output is piped.
  - Window launches require a non-empty `WAYLAND_DISPLAY` or `DISPLAY` environment variable.

- **Tests**
  - Expanded coverage for mode selection across terminal and redirected-handle scenarios, including display environment checks.

- **Documentation**
  - Updated mode-selection guidance and testing notes to reflect the new behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->