### PR TITLE
fix: reject empty display environment values

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -354,8 +354,8 @@ be a real terminal, not just one, so that a pipeline never receives the terminal
 `flea | head` gives stdin a tty and stdout a pipe, so `interactive` is false and the window
 branch runs; what the rule prevents is the terminal interface writing escape codes into that
 pipe, which is exactly what the `--tui` refusal below it says. `--tui` without a terminal on
-both handles exits 2; `--gui` without `WAYLAND_DISPLAY` or `DISPLAY` refuses rather than
-trying and failing inside `qs`.
+both handles exits 2; `--gui` without a non-empty `WAYLAND_DISPLAY` or `DISPLAY` refuses
+rather than trying and failing inside `qs`.
 
 Telling that `&&` apart from an `||` needs a tty on exactly one handle and no suite here has
 a pty, so that distinction is untested; the no-flag case in `./tests/modes.sh` pins only

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -30,7 +30,9 @@ pub fn ui_dir() -> Option<PathBuf> {
 }
 
 pub fn has_display() -> bool {
-    std::env::var_os("WAYLAND_DISPLAY").is_some() || std::env::var_os("DISPLAY").is_some()
+    ["WAYLAND_DISPLAY", "DISPLAY"]
+        .iter()
+        .any(|name| std::env::var_os(name).map_or(false, |value| !value.is_empty()))
 }
 
 // Decodes %XX triplets in a file:// URI path; a malformed triplet passes through as literal text.

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -32,7 +32,7 @@ pub fn ui_dir() -> Option<PathBuf> {
 pub fn has_display() -> bool {
     ["WAYLAND_DISPLAY", "DISPLAY"]
         .iter()
-        .any(|name| std::env::var_os(name).map_or(false, |value| !value.is_empty()))
+        .any(|name| std::env::var_os(name).is_some_and(|value| !value.is_empty()))
 }
 
 // Decodes %XX triplets in a file:// URI path; a malformed triplet passes through as literal text.

--- a/tests/modes.sh
+++ b/tests/modes.sh
@@ -33,6 +33,11 @@ check "--version wins over another mode" "$want" "$out"
 out=$(env -u WAYLAND_DISPLAY -u DISPLAY $BIN --gui 2>&1 </dev/null)
 check "no display refuses" "1" "$(echo "$out" | grep -c 'no graphical session')"
 
+# An exported-but-empty display is absent too. It must not reach qs and turn the precise refusal
+# above into a generic shell-start failure.
+out=$(env WAYLAND_DISPLAY= DISPLAY= PATH=/nonexistent-flea-test-path $BIN --gui 2>&1 </dev/null)
+check "an empty display refuses" "1" "$(echo "$out" | grep -c 'no graphical session')"
+
 # qs missing from PATH is what a bad launcher or .desktop install hits; no errno may leak.
 out=$(env WAYLAND_DISPLAY=flea-modes-test-display PATH=/nonexistent-flea-test-path $BIN --gui 2>&1 </dev/null)
 check "missing qs is elided" "1" "$(echo "$out" | grep -c 'could not start the shell')"

--- a/tests/modes.sh
+++ b/tests/modes.sh
@@ -33,10 +33,25 @@ check "--version wins over another mode" "$want" "$out"
 out=$(env -u WAYLAND_DISPLAY -u DISPLAY $BIN --gui 2>&1 </dev/null)
 check "no display refuses" "1" "$(echo "$out" | grep -c 'no graphical session')"
 
-# An exported-but-empty display is absent too. It must not reach qs and turn the precise refusal
-# above into a generic shell-start failure.
+# An exported-but-empty display is absent and must not reach qs.
 out=$(env WAYLAND_DISPLAY= DISPLAY= PATH=/nonexistent-flea-test-path $BIN --gui 2>&1 </dev/null)
 check "an empty display refuses" "1" "$(echo "$out" | grep -c 'no graphical session')"
+out=$(env -u DISPLAY WAYLAND_DISPLAY= PATH=/nonexistent-flea-test-path $BIN --gui 2>&1 </dev/null)
+check "an empty WAYLAND_DISPLAY alone refuses" "1" "$(echo "$out" | grep -c 'no graphical session')"
+out=$(env -u WAYLAND_DISPLAY DISPLAY= PATH=/nonexistent-flea-test-path $BIN --gui 2>&1 </dev/null)
+check "an empty DISPLAY alone refuses" "1" "$(echo "$out" | grep -c 'no graphical session')"
+
+# Each display variable independently permits launch, and an empty peer must not mask it.
+out=$(env -u DISPLAY WAYLAND_DISPLAY=flea-modes-test-display PATH=/nonexistent-flea-test-path $BIN --gui 2>&1 </dev/null)
+check "a non-empty WAYLAND_DISPLAY is accepted" "1" "$(echo "$out" | grep -c 'could not start the shell')"
+out=$(env -u WAYLAND_DISPLAY DISPLAY=:99 PATH=/nonexistent-flea-test-path $BIN --gui 2>&1 </dev/null)
+check "a non-empty DISPLAY is accepted" "1" "$(echo "$out" | grep -c 'could not start the shell')"
+out=$(env WAYLAND_DISPLAY= DISPLAY=:99 PATH=/nonexistent-flea-test-path $BIN --gui 2>&1 </dev/null)
+check "an empty WAYLAND_DISPLAY does not mask DISPLAY" "1" "$(echo "$out" | grep -c 'could not start the shell')"
+out=$(env WAYLAND_DISPLAY=flea-modes-test-display DISPLAY= PATH=/nonexistent-flea-test-path $BIN --gui 2>&1 </dev/null)
+check "an empty DISPLAY does not mask WAYLAND_DISPLAY" "1" "$(echo "$out" | grep -c 'could not start the shell')"
+out=$(env WAYLAND_DISPLAY=flea-modes-test-display DISPLAY=:99 PATH=/nonexistent-flea-test-path $BIN --gui 2>&1 </dev/null)
+check "two non-empty displays are accepted" "1" "$(echo "$out" | grep -c 'could not start the shell')"
 
 # qs missing from PATH is what a bad launcher or .desktop install hits; no errno may leak.
 out=$(env WAYLAND_DISPLAY=flea-modes-test-display PATH=/nonexistent-flea-test-path $BIN --gui 2>&1 </dev/null)


### PR DESCRIPTION
## What was wrong

An exported-but-empty `WAYLAND_DISPLAY` or `DISPLAY` was treated as a graphical session. Flea then reached `qs` and returned a generic shell-start failure instead of its precise no-display error.

## Fix

Require at least one display variable to contain a value and pin the empty-variable case in the launcher integration tests.

## Verification

- [x] clean debug and release builds, zero warnings
- [x] 338 debug and 338 release tests passed
- [x] `FLEA_FIXTURE_ROOT=/tmp/flea-sandbox ./tests/modes.sh`
- [x] QML lint and file-budget gates pass
- [x] `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved graphical session detection by treating empty display environment values as unavailable.
  - The `--gui` mode now correctly refuses to start when no valid graphical display is configured, providing the appropriate message.
  - A non-empty display value now permits `--gui` to proceed, even if the other display variable is empty or unavailable.

- **Tests**
  - Added coverage for empty and non-empty display variables to verify consistent refusal and acceptance behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->