### PR TITLE
test: skip unavailable optional 7z format

### DIFF
--- a/tests/archive.sh
+++ b/tests/archive.sh
@@ -57,7 +57,16 @@ check "and the convert tool is reported" "1" "$(printf '%s' "$formats" | grep -c
 echo "  $formats"
 stop_backend
 
-for format in tar.zst zip 7z; do
+# tar.zst and zip come from the required libarchive toolchain. 7z is advertised only when the
+# optional 7zip executable is installed, so exercise it exactly when the live backend offers it.
+round_trip_formats="tar.zst zip"
+if printf '%s' "$formats" | grep -q '"7z"'; then
+  round_trip_formats="$round_trip_formats 7z"
+else
+  echo "--- 7z is unavailable; optional round trip skipped ---"
+fi
+
+for format in $round_trip_formats; do
   echo "--- compress and extract $format ---"
   start_backend
   send "{\"c\":\"archive\",\"op\":\"compress\",\"paths\":[\"$D/src/a.txt\",\"$D/src/sub\"],\"dest\":\"$D/out.$format\",\"format\":\"$format\"}"

--- a/tests/archive.sh
+++ b/tests/archive.sh
@@ -57,9 +57,16 @@ check "and the convert tool is reported" "1" "$(printf '%s' "$formats" | grep -c
 echo "  $formats"
 stop_backend
 
+seven_zip_installed=0
+if command -v 7z >/dev/null 2>&1; then
+  seven_zip_installed=1
+fi
+seven_zip_advertised=$(printf '%s' "$formats" | grep -c '"7z"')
+check "7z availability matches the advertised format" "$seven_zip_installed" "$seven_zip_advertised"
+
 # tar.zst and zip are required; exercise optional 7z exactly when the live backend offers it.
 round_trip_formats="tar.zst zip"
-if printf '%s' "$formats" | grep -q '"7z"'; then
+if [ "$seven_zip_advertised" = 1 ]; then
   round_trip_formats="$round_trip_formats 7z"
 else
   echo "--- 7z is unavailable; optional round trip skipped ---"

--- a/tests/archive.sh
+++ b/tests/archive.sh
@@ -57,8 +57,7 @@ check "and the convert tool is reported" "1" "$(printf '%s' "$formats" | grep -c
 echo "  $formats"
 stop_backend
 
-# tar.zst and zip come from the required libarchive toolchain. 7z is advertised only when the
-# optional 7zip executable is installed, so exercise it exactly when the live backend offers it.
+# tar.zst and zip are required; exercise optional 7z exactly when the live backend offers it.
 round_trip_formats="tar.zst zip"
 if printf '%s' "$formats" | grep -q '"7z"'; then
   round_trip_formats="$round_trip_formats 7z"


### PR DESCRIPTION
## What was wrong

The archive suite always exercised 7z even when the optional `7zip` package was absent and Flea correctly omitted 7z from its runtime format list. That made a supported dependency configuration report a false test failure.

## Fix

Derive the optional 7z round trip from the backend's live `formats` response while keeping required tar.zst and zip coverage unconditional.

## Verification

- [x] reproduced on a system without `7zip`
- [x] `FLEA_FIXTURE_ROOT=/tmp/flea-sandbox ./tests/archive.sh`: all checks passed
- [x] `bash -n tests/archive.sh`
- [x] file-budget gate and `git diff --check` pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated archive testing to use the formats advertised by the live backend.
  * Added detection for 7z availability and skips 7z round-trip tests when unsupported or unavailable.
  * Continues testing tar.zst and ZIP archive round trips.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->