### PR TITLE
l enters a directory or previews a file

### DIFF
--- a/README.md
+++ b/README.md
@@ -444,6 +444,7 @@ and the application cannot disagree.
 | `g`, `G` | First or last row |
 | Ctrl-d, Ctrl-u | Half a viewport |
 | `h`, Backspace, Ctrl-Up | Parent directory |
+| `l` | Browse forward: enter a directory, preview a file, page a PDF, or activate a rail/share row; unused in media |
 | Return, Enter, Ctrl-Down | Open a directory, or open a file with the desktop's handler |
 | Space | Quick Look, and close it |
 | Left, Right | Page a PDF, or seek in media |

--- a/keys.toml
+++ b/keys.toml
@@ -326,8 +326,7 @@ action = "zoomIn"
 char = "e"
 action = "expand"
 
-# The page pair. h keeps "parent" while browsing and turns a PDF page back when a preview is open.
-# l is the forward of that pair: page forward in a PDF, otherwise enter a directory or preview a file.
+# The page pair: h goes back in a PDF or to the parent while browsing; l goes forward, enters a directory, or previews a file.
 [[text]]
 char = "l"
 action = "pageForward"
@@ -356,6 +355,11 @@ label = "move"
 keys = "enter"
 action = "open"
 label = "open"
+
+[[sheet]]
+keys = "l"
+action = "pageForward"
+label = "browse forward"
 
 [[sheet]]
 keys = "space"

--- a/keys.toml
+++ b/keys.toml
@@ -326,8 +326,8 @@ action = "zoomIn"
 char = "e"
 action = "expand"
 
-# The page pair. h keeps "parent" above, because that is what it means while browsing, and turns a
-# page back only once a PDF preview is open; l means nothing anywhere else, so it stays type-ahead.
+# The page pair. h keeps "parent" while browsing and turns a PDF page back when a preview is open.
+# l is the forward of that pair: page forward in a PDF, otherwise enter a directory or preview a file.
 [[text]]
 char = "l"
 action = "pageForward"

--- a/tests/js/focus-forward.js
+++ b/tests/js/focus-forward.js
@@ -1,0 +1,114 @@
+.import "../../ui/js/Focus.js" as Focus
+
+function closed() {
+    return { active: false, isMedia: false, isPdf: false }
+}
+
+function pdfOpen() {
+    return { active: true, isMedia: false, isPdf: true }
+}
+
+function mediaOpen() {
+    return { active: true, isMedia: true, isPdf: false }
+}
+
+function lKey() {
+    return { key: Qt.Key_L, text: "l", modifiers: Qt.NoModifier }
+}
+
+// rowFor records its only input so browse-forward cannot grow beyond Pane's held viewport.
+function pane(row, view) {
+    var p = {
+        cursorIndex: 37,
+        focusView: view ? view : "list",
+        viewMode: "list",
+        searchMode: "",
+        preview: closed(),
+        shareBrowser: { active: false },
+        rowsRead: [],
+        rowFor: function (index) { p.rowsRead.push(index); return row }
+    }
+    return p
+}
+
+function handlePane(row) {
+    var p = pane(row)
+    p.filterTyping = false
+    p.inputAt = 0
+    p.rowsAt = 0
+    p.trashArmedAt = 0
+    p.shown = null
+    p.said = ""
+    p.renameEditor = function () { return null }
+    p.message = function (text) { p.said = text }
+    return p
+}
+
+function sidebar() {
+    return { renameEditor: function () { return null } }
+}
+
+function pdfPreview() {
+    return {
+        active: true,
+        isMedia: false,
+        isPdf: true,
+        page: 0,
+        revealStrip: function () {},
+        turnPage: function (delta) { this.page += delta }
+    }
+}
+
+function run(check) {
+    var l = lKey()
+
+    var directory = pane({ d: true, t: false, i: "folder" })
+    check("l enters the directory under the cursor", Focus.lookup(l, directory), "open")
+    check("directory lookup reads only the held cursor row", directory.rowsRead.join(","), "37")
+
+    var extensionlessSymlinkDirectory = pane({ d: false, p: 0o120777, i: "folder", t: false })
+    check("l enters an extensionless symlink to a directory", Focus.lookup(l, extensionlessSymlinkDirectory), "open")
+    check("extensionless symlink lookup reads only the held cursor row", extensionlessSymlinkDirectory.rowsRead.join(","), "37")
+
+    var thumbnailableSymlinkDirectory = pane({ d: false, p: 0o120777, i: "folder", t: true })
+    check("l enters a thumbnailable symlink to a directory", Focus.lookup(l, thumbnailableSymlinkDirectory), "open")
+    check("thumbnailable symlink lookup reads only the held cursor row", thumbnailableSymlinkDirectory.rowsRead.join(","), "37")
+
+    var file = pane({ d: false, p: 0o100644, i: "folder", t: false })
+    check("l previews an ordinary file even with a folder icon", Focus.lookup(l, file), "preview")
+    check("file lookup reads only the held cursor row", file.rowsRead.join(","), "37")
+
+    var empty = pane(null)
+    check("l is silent without a held cursor row", Focus.lookup(l, empty), "")
+    check("empty lookup still asks only for the held cursor row", empty.rowsRead.join(","), "37")
+
+    var unloaded = handlePane(null)
+    check("l on an unloaded row is consumed without a filter hint",
+          Focus.handleKey(l, unloaded, sidebar()) + "|" + unloaded.said, "true|")
+    check("unloaded handling still asks only for the held cursor row", unloaded.rowsRead.join(","), "37")
+
+    var rail = pane(null, "rail")
+    check("l activates the selected rail row", Focus.lookup(l, rail), "open")
+    check("rail lookup does not inspect the hidden listing", rail.rowsRead.length, 0)
+
+    var share = pane({ d: false })
+    share.shareBrowser.active = true
+    check("l activates the selected share", Focus.lookup(l, share), "open")
+    check("share lookup does not inspect the hidden listing", share.rowsRead.length, 0)
+
+    var pdf = pane(null)
+    pdf.preview = pdfOpen()
+    check("l pages an open PDF forward", Focus.lookup(l, pdf), "pageForward")
+    check("PDF lookup does not inspect the hidden listing", pdf.rowsRead.length, 0)
+
+    var reader = pdfPreview()
+    Focus.previewAct("pageForward", { preview: reader })
+    Focus.previewAct("pageForward", { preview: reader })
+    Focus.previewAct("parent", { preview: reader })
+    check("l advances the PDF and h retreats it", reader.page, 1)
+
+    var media = pane(null)
+    media.preview = mediaOpen()
+    check("l stays silent over media", Focus.lookup(l, media), "")
+    check("media lookup does not inspect the hidden listing", media.rowsRead.length, 0)
+}

--- a/tests/js/focus.js
+++ b/tests/js/focus.js
@@ -72,19 +72,6 @@ function key(code, text, modifiers) {
     return { key: code, text: text, modifiers: modifiers }
 }
 
-// Focus.previewAct is the other half: the gate above decides what reaches it, this records what it
-// then does to the preview. Only the members the PDF cases touch are stubbed.
-function pdfPreview() {
-    return {
-        active: true,
-        isMedia: false,
-        isPdf: true,
-        page: 0,
-        revealStrip: function () {},
-        turnPage: function (delta) { this.page += delta }
-    }
-}
-
 // Only the members the escape case reads. Search.cancel and Pane.escapePressed both record rather
 // than act, because what is being checked is the order they are reached in.
 function escaper(query, retreated) {
@@ -114,36 +101,19 @@ function run(check) {
     check("plus zooms an open PDF", Focus.lookup(plus, pane(pdfOpen())), "zoomIn")
 
     // The three are silent everywhere else, so none of them acts while the list has the keys.
-    check("e minus plus are discarded while browsing",
-          Focus.lookup(e, pane(closed())) + Focus.lookup(minus, pane(closed())) + Focus.lookup(plus, pane(closed())), "")
-    check("e and minus are discarded over a media preview",
-          Focus.lookup(e, pane(mediaOpen())) + Focus.lookup(minus, pane(mediaOpen())), "")
+    check("e is discarded while browsing", Focus.lookup(e, pane(closed())), "")
+    check("minus is discarded while browsing", Focus.lookup(minus, pane(closed())), "")
+    check("plus is discarded while browsing", Focus.lookup(plus, pane(closed())), "")
+    check("e is discarded over a media preview", Focus.lookup(e, pane(mediaOpen())), "")
+    check("minus is discarded over a media preview", Focus.lookup(minus, pane(mediaOpen())), "")
 
     // Left and Right now serve two previews, and must still serve the grid and nothing else.
     check("left turns a PDF page", Focus.lookup(left, pane(pdfOpen())), "seekBack")
     check("right turns a PDF page", Focus.lookup(right, pane(pdfOpen())), "seekForward")
     check("left still seeks media", Focus.lookup(left, pane(mediaOpen())), "seekBack")
-    check("left is discarded in the list and steps a grid tile",
-          Focus.lookup(left, pane(closed())) + "|" + Focus.lookup(left, pane(closed(), "grid"))
-          + "|" + Focus.lookup(right, pane(closed(), "grid")), "|cursorLeft|cursorRight")
-
-    // h and l are the PDF page pair; l is also browse-forward when no PDF is open.
-    var h = key(Qt.Key_H, "h", none)
-    var l = key(Qt.Key_L, "l", none)
-    check("l turns a page in an open PDF", Focus.lookup(l, pane(pdfOpen())), "pageForward")
-    var d = pane(closed()); d.rowFor = function () { return { d: true } }
-    var f = pane(closed()); f.rowFor = function () { return { d: false } }
-    check("l opens a directory and previews a file while browsing",
-          Focus.lookup(l, d) + "|" + Focus.lookup(l, f), "open|preview")
-    check("l is discarded over a media preview", Focus.lookup(l, pane(mediaOpen())), "")
-    check("h still means parent, in the list and over a PDF both",
-          Focus.lookup(h, pane(closed())) + "|" + Focus.lookup(h, pane(pdfOpen())), "parent|parent")
-
-    var reader = pdfPreview()
-    Focus.previewAct("pageForward", { preview: reader })
-    Focus.previewAct("pageForward", { preview: reader })
-    Focus.previewAct("parent", { preview: reader })
-    check("l turns the page forward and h turns it back", reader.page, 1)
+    check("left is discarded in the list", Focus.lookup(left, pane(closed())), "")
+    check("left still steps a grid tile", Focus.lookup(left, pane(closed(), "grid")), "cursorLeft")
+    check("right still steps a grid tile", Focus.lookup(right, pane(closed(), "grid")), "cursorRight")
 
     // Nothing in keys.toml is bound ahead of its feature now: lookup hands both actions through
     // and handleKey routes each above the views, so neither answers with a sentence any more.

--- a/tests/js/focus.js
+++ b/tests/js/focus.js
@@ -114,27 +114,27 @@ function run(check) {
     check("plus zooms an open PDF", Focus.lookup(plus, pane(pdfOpen())), "zoomIn")
 
     // The three are silent everywhere else, so none of them acts while the list has the keys.
-    check("e is discarded while browsing", Focus.lookup(e, pane(closed())), "")
-    check("minus is discarded while browsing", Focus.lookup(minus, pane(closed())), "")
-    check("plus is discarded while browsing", Focus.lookup(plus, pane(closed())), "")
-    check("e is discarded over a media preview", Focus.lookup(e, pane(mediaOpen())), "")
-    check("minus is discarded over a media preview", Focus.lookup(minus, pane(mediaOpen())), "")
+    check("e minus plus are discarded while browsing",
+          Focus.lookup(e, pane(closed())) + Focus.lookup(minus, pane(closed())) + Focus.lookup(plus, pane(closed())), "")
+    check("e and minus are discarded over a media preview",
+          Focus.lookup(e, pane(mediaOpen())) + Focus.lookup(minus, pane(mediaOpen())), "")
 
     // Left and Right now serve two previews, and must still serve the grid and nothing else.
     check("left turns a PDF page", Focus.lookup(left, pane(pdfOpen())), "seekBack")
     check("right turns a PDF page", Focus.lookup(right, pane(pdfOpen())), "seekForward")
     check("left still seeks media", Focus.lookup(left, pane(mediaOpen())), "seekBack")
-    check("left is discarded in the list", Focus.lookup(left, pane(closed())), "")
-    check("left still steps a grid tile", Focus.lookup(left, pane(closed(), "grid")), "cursorLeft")
-    check("right still steps a grid tile", Focus.lookup(right, pane(closed(), "grid")), "cursorRight")
+    check("left is discarded in the list and steps a grid tile",
+          Focus.lookup(left, pane(closed())) + "|" + Focus.lookup(left, pane(closed(), "grid"))
+          + "|" + Focus.lookup(right, pane(closed(), "grid")), "|cursorLeft|cursorRight")
 
-    // h and l are the PDF page pair. l was unbound and h fell through previewAct's switch, so
-    // neither ever turned a page while the chevrons and the arrows both did.
+    // h and l are the PDF page pair; l is also browse-forward when no PDF is open.
     var h = key(Qt.Key_H, "h", none)
     var l = key(Qt.Key_L, "l", none)
     check("l turns a page in an open PDF", Focus.lookup(l, pane(pdfOpen())), "pageForward")
-    check("l is discarded while browsing, so it does nothing outside a PDF",
-          Focus.lookup(l, pane(closed())), "")
+    var d = pane(closed()); d.rowFor = function () { return { d: true } }
+    var f = pane(closed()); f.rowFor = function () { return { d: false } }
+    check("l opens a directory and previews a file while browsing",
+          Focus.lookup(l, d) + "|" + Focus.lookup(l, f), "open|preview")
     check("l is discarded over a media preview", Focus.lookup(l, pane(mediaOpen())), "")
     check("h still means parent, in the list and over a PDF both",
           Focus.lookup(h, pane(closed())) + "|" + Focus.lookup(h, pane(pdfOpen())), "parent|parent")

--- a/tests/js/harness.qml
+++ b/tests/js/harness.qml
@@ -9,6 +9,7 @@ import "errors.js" as ErrorsSuite
 import "facts.js" as FactsSuite
 import "filter.js" as FilterSuite
 import "focus.js" as FocusSuite
+import "focus-forward.js" as FocusForwardSuite
 import "format.js" as FormatSuite
 import "icons.js" as IconsSuite
 import "keymap.js" as KeymapSuite
@@ -49,7 +50,8 @@ Item {
             ["dirsizes", DirSizesSuite], ["drag", DragSuite], ["dst", DstSuite],
             ["edmonton", DstSuite],
             ["errors", ErrorsSuite], ["facts", FactsSuite], ["filter", FilterSuite],
-            ["focus", FocusSuite], ["format", FormatSuite], ["icons", IconsSuite],
+            ["focus", FocusSuite], ["focus-forward", FocusForwardSuite],
+            ["format", FormatSuite], ["icons", IconsSuite],
             ["keymap", KeymapSuite], ["match", MatchSuite], ["menu", MenuSuite],
             ["mounts", MountsSuite], ["nav", NavSuite], ["ops", OpsSuite],
             ["palette", PaletteSuite], ["pathbar", PathBarSuite], ["places", PlacesSuite],

--- a/tests/js/keymap.js
+++ b/tests/js/keymap.js
@@ -104,7 +104,7 @@ function run(check) {
           Keymap.SHEET.map(sheetAction).join("|"),
           Keymap.SHEET.map(function (row) { return row.action }).join("|"))
     check("the sheet is not empty, so the check above has a denominator",
-          Keymap.SHEET.length, 24)
+          Keymap.SHEET.length, 25)
     // A chord shares the row of the key it doubles, so every caret token must resolve to that row's
     // own action, or the sheet advertises a chord bound to something else.
     check("every chord the sheet draws is bound to the action of its own row",
@@ -116,6 +116,8 @@ function run(check) {
           Keymap.SHEET.filter(function (r) { return r.keys === "/" }).length, 1)
     check("and the sheet draws m, so eject and unmount are not mouse-only affordances",
           Keymap.SHEET.filter(function (r) { return r.keys === "m" }).length, 1)
+    check("and the sheet draws l, so browse-forward is discoverable",
+          Keymap.SHEET.filter(function (r) { return r.keys === "l" && r.action === "pageForward" }).length, 1)
 }
 
 // The three caps that name a key rather than printing one; everything else on the sheet is the

--- a/tests/ui.sh
+++ b/tests/ui.sh
@@ -1891,8 +1891,8 @@ PYEOF
     [[ -s "$dir/clip.mp4" ]] || fail "ffmpeg produced no clip.mp4"
     # Space on a pdf answered "This file cannot be previewed" until kindOf gained its branch, on a
     # type the preview column had rendered all along, so this row is what guards that branch.
-    magick \( -size 400x560 xc:white -fill black -draw "rectangle 40,40 120,80" \) \
-           \( -size 400x560 xc:white -fill black -draw "rectangle 40,40 360,520" \) \
+    magick \( -size 400x560 xc:white -fill black -font Liberation-Sans -pointsize 40 -annotate +40+80 'PAGEONE' \) \
+           \( -size 400x560 xc:white -fill black -font Liberation-Sans -pointsize 40 -annotate +40+80 'PAGETWO' \) \
            "$dir/manual.pdf"
     [[ -s "$dir/manual.pdf" ]] || fail "magick produced no manual.pdf"
 
@@ -2042,6 +2042,12 @@ PYEOF
         || fail "preview: manual.pdf classified as $(ipc previewKind), not pdf"
     [[ "$(ipc previewState)" == "pdf" ]] \
         || fail "preview: the pdf overlay reports $(ipc previewState), so it fell through to the refusal"
+    [[ "$(ipc previewPdfPage)" == "0" ]] || fail "preview: manual.pdf opened on page $(ipc previewPdfPage), not page 0"
+    key l >/dev/null
+    omarchy-drive wait ipc -p "$flea_ui" flea previewPdfPage 1 --timeout 10 >/dev/null \
+        || fail "preview: l left manual.pdf on page $(ipc previewPdfPage), not page 1"
+    omarchy-drive wait ocr flea PAGETWO --timeout 10 >/dev/null \
+        || fail "preview: l advanced manual.pdf state but left page 1 painted"
     shot preview-pdf
     key -k Escape >/dev/null
     settle

--- a/tests/ui.sh
+++ b/tests/ui.sh
@@ -641,11 +641,42 @@ case_open() {
     # Measured row order: bin, subdir, broken, linkdir, linkfile, opened.log, target.txt.
     wait_listing 7
 
-    # A symlink to a file resolves and opens its target, and the listing does not move.
-    key -k Down >/dev/null
-    key -k Down >/dev/null
-    key -k Down >/dev/null
-    key -k Down >/dev/null
+    # Bare l enters a real directory and stays silent when its empty listing has no row.
+    seek_row_named subdir
+    key l >/dev/null
+    wait_path "$dir/subdir"
+    omarchy-drive wait ipc -p "$flea_ui" flea state empty --timeout 10 >/dev/null \
+        || fail "open: subdir never reached its empty listing, state is $(ipc state)"
+    [[ ! -s "$opened" ]] || fail "l on a directory handed $(cat "$opened") to xdg-open"
+    [[ -z "$(ipc lastMessage)" ]] || fail "open: entering the empty subdir said $(ipc lastMessage)"
+    key l >/dev/null
+    settle
+    [[ -z "$(ipc lastMessage)" ]] || fail "open: l on an empty directory said $(ipc lastMessage)"
+    key q >/dev/null
+    settle
+    [[ "$(ipc lastMessage)" == "Press / to filter this listing by name." ]] \
+        || fail "open: unbound q said $(ipc lastMessage), so the empty-row l check has no negative control"
+
+    # Bare l enters a symlink to a directory without handing it to xdg-open.
+    key -k Backspace >/dev/null
+    wait_path "$dir"
+    seek_row_named linkdir
+    key l >/dev/null
+    wait_path "$dir/linkdir"
+    [[ ! -s "$opened" ]] || fail "l on a symlink directory handed $(cat "$opened") to xdg-open"
+
+    # Return on a symlink to a directory keeps its existing navigation and opener coverage.
+    key -k Backspace >/dev/null
+    wait_path "$dir"
+    seek_row_named linkdir
+    key -k Return >/dev/null
+    wait_path "$dir/linkdir"
+    [[ ! -s "$opened" ]] || fail "Enter on a symlink directory handed $(cat "$opened") to xdg-open"
+
+    # Return on a symlink to a file still resolves and opens its target.
+    key -k Backspace >/dev/null
+    wait_path "$dir"
+    seek_row_named linkfile
     settle
     [[ "$(ipc rowAt "$(ipc cursor)")" == "linkfile|"* ]] || fail "the cursor is on $(ipc rowAt "$(ipc cursor)"), not linkfile"
     key -k Return >/dev/null
@@ -658,18 +689,7 @@ case_open() {
     grep -q "^OPENED $dir/target.txt$" "$opened" || fail "Enter on a symlink did not open its target"
     [[ "$(ipc path)" == "$dir" ]] || fail "Enter on a file left the directory for $(ipc path)"
 
-    # A symlink to a directory navigates rather than launching another file manager.
-    key -k Up >/dev/null
-    settle
-    [[ "$(ipc rowAt "$(ipc cursor)")" == "linkdir|"* ]] || fail "the cursor is on $(ipc rowAt "$(ipc cursor)"), not linkdir"
-    key -k Return >/dev/null
-    omarchy-drive wait ipc -p "$flea_ui" flea path "$dir/linkdir" --timeout 10 >/dev/null \
-        || fail "Enter on a symlink to a directory left the path at $(ipc path)"
-    [[ "$(grep -c OPENED "$opened")" == "1" ]] || fail "a directory was handed to xdg-open"
-
     # A broken symlink is one sentence and nothing else.
-    key -k Backspace >/dev/null
-    omarchy-drive wait ipc -p "$flea_ui" flea path "$dir" --timeout 10 >/dev/null
     key g >/dev/null
     key -k Down >/dev/null
     key -k Down >/dev/null
@@ -1912,8 +1932,10 @@ PYEOF
     settle
     [[ "$(ipc previewOpen)" == "false" ]] || fail "preview: escape did not close the preview after the negative control"
 
-    open_row sample.txt
-    [[ "$(ipc previewOpen)" == "true" ]] || fail "preview: space on sample.txt did not open a preview"
+    goto_row "$(row_index_of sample.txt)"
+    key l >/dev/null
+    settle
+    [[ "$(ipc previewOpen)" == "true" ]] || fail "preview: l on sample.txt did not open a preview"
     [[ "$(ipc previewKind)" == "text" ]] || fail "preview: sample.txt classified as $(ipc previewKind), not text"
     shot preview-text
     # Task 22 repurposes Space for play/pause only on a MEDIA preview; text keeps the old binding.
@@ -1954,6 +1976,14 @@ PYEOF
     key -k space >/dev/null
     wait_preview_state paused
     [[ "$(ipc previewOpen)" == "true" ]] || fail "preview: space paused tone.wav but also closed the preview"
+    pos_before=$(ipc previewPosition)
+    key l >/dev/null
+    settle
+    pos_after=$(ipc previewPosition)
+    [[ "$(ipc previewOpen)" == "true" ]] || fail "preview: l closed the paused audio preview"
+    [[ "$(ipc previewState)" == "paused" ]] || fail "preview: l changed paused audio to $(ipc previewState)"
+    [[ "$pos_after" == "$pos_before" ]] \
+        || fail "preview: l moved paused audio, before=$pos_before after=$pos_after"
     key -k space >/dev/null
     wait_preview_state playing
 
@@ -2295,7 +2325,7 @@ EOS
     [[ "$(ipc networkEntries)" == "StubNAS|network|share|false" ]] \
         || fail "sharebrowser: the stub NAS bookmark did not appear, got $(ipc networkEntries)"
 
-    # Tab to the rail and Enter the bare-root entry: it lists shares, it does not open anything.
+    # Tab to the rail and l the bare-root entry: it lists shares, it does not open anything.
     key -k Tab >/dev/null
     settle
     [[ "$(ipc focusView)" == "rail" ]] || fail "sharebrowser: Tab did not reach the rail"
@@ -2303,12 +2333,12 @@ EOS
     key j >/dev/null
     settle
     [[ "$(ipc railCursor)" == "1" ]] || fail "sharebrowser: expected the rail cursor on StubNAS, got $(ipc railCursor)"
-    key -k Return >/dev/null
+    key l >/dev/null
     for _attempt in $(seq 1 100); do
         [[ "$(ipc shareBrowserOpen)" == "true" ]] && break
         sleep 0.05
     done
-    [[ "$(ipc shareBrowserOpen)" == "true" ]] || fail "sharebrowser: Enter on the bare root never opened the overlay"
+    [[ "$(ipc shareBrowserOpen)" == "true" ]] || fail "sharebrowser: l on the bare root never opened the overlay"
     [[ "$(ipc shareBrowserEntries)" == "$(printf 'share1\nshare2')" ]] \
         || fail "sharebrowser: the overlay's own shares over IPC are wrong: $(ipc shareBrowserEntries)"
     [[ "$(ipc path)" == "$dir" ]] || fail "sharebrowser: listing the shares navigated away from $dir"
@@ -2329,39 +2359,34 @@ EOS
     settle
     [[ "$(ipc cursor)" == "1" ]] || fail "sharebrowser: keyboard nav is dead after Escape, cursor is $(ipc cursor)"
 
-    # Enter on a share mounts it and opens its resolved path, the same pipeline a bookmarked share uses.
-    key -k Tab >/dev/null
-    settle
-    key -k Return >/dev/null
+    # Pointer-opened overlay leaves list focus underneath, so l must route through the active overlay.
+    click_rail_row 1 left
     for _attempt in $(seq 1 100); do
         [[ "$(ipc shareBrowserOpen)" == "true" ]] && break
         sleep 0.05
     done
-    [[ "$(ipc shareBrowserOpen)" == "true" ]] || fail "sharebrowser: reactivating StubNAS did not reopen the overlay"
+    [[ "$(ipc shareBrowserOpen)" == "true" ]] || fail "sharebrowser: pointer reactivation of StubNAS did not reopen the overlay"
+    [[ "$(ipc focusView)" == "list" ]] || fail "sharebrowser: pointer activation moved focus to $(ipc focusView)"
     [[ "$(ipc shareBrowserCursor)" == "0" ]] || fail "sharebrowser: the overlay did not reset its cursor to 0, got $(ipc shareBrowserCursor)"
-    key -k Return >/dev/null
+    key l >/dev/null
     for _attempt in $(seq 1 100); do
         [[ "$(ipc path)" == "$share1_dir" ]] && break
         sleep 0.05
     done
-    [[ "$(ipc path)" == "$share1_dir" ]] || fail "sharebrowser: Enter on share1 never opened $share1_dir, path is $(ipc path)"
+    [[ "$(ipc path)" == "$share1_dir" ]] || fail "sharebrowser: l on share1 never opened $share1_dir, path is $(ipc path)"
     [[ "$(ipc shareBrowserOpen)" == "false" ]] || fail "sharebrowser: opening share1 did not close the overlay"
     [[ "$(ipc total)" == "1" ]] || fail "sharebrowser: share1's own listing did not load, total is $(ipc total)"
     shot sharebrowser-opened-share1
 
-    # gio's own "already mounted" quirk must still resolve to an open, not a false failure.
-    # No Tab here: opening share1 never touched focusView, so it is already "rail" from the
-    # earlier Tab in this same phase; pressing Tab again would wrongly hand focus to the list.
-    [[ "$(ipc focusView)" == "rail" ]] || fail "sharebrowser: expected focus still on the rail after opening share1, got $(ipc focusView)"
-    key g >/dev/null
-    key j >/dev/null
-    settle
-    key -k Return >/dev/null
+    # Pointer reopens the overlay over list focus; retained Return drives the already-mounted share.
+    [[ "$(ipc focusView)" == "list" ]] || fail "sharebrowser: opening share1 moved focus to $(ipc focusView)"
+    click_rail_row 1 left
     for _attempt in $(seq 1 100); do
         [[ "$(ipc shareBrowserOpen)" == "true" ]] && break
         sleep 0.05
     done
-    [[ "$(ipc shareBrowserOpen)" == "true" ]] || fail "sharebrowser: reactivating StubNAS a second time did not reopen the overlay"
+    [[ "$(ipc shareBrowserOpen)" == "true" ]] || fail "sharebrowser: second pointer reactivation of StubNAS did not reopen the overlay"
+    [[ "$(ipc focusView)" == "list" ]] || fail "sharebrowser: second pointer activation moved focus to $(ipc focusView)"
     key j >/dev/null
     settle
     [[ "$(ipc shareBrowserCursor)" == "1" ]] || fail "sharebrowser: cursor did not move to share2, got $(ipc shareBrowserCursor)"

--- a/tests/ui.sh
+++ b/tests/ui.sh
@@ -269,7 +269,7 @@ assert_theme() {
     done
     loaded=$(ipc themeLoaded 2>/dev/null || true)
     [[ "$loaded" == "true" ]] || fail "themeLoaded is '$loaded', not true, so this window has no parsed palette"
-    [[ "$seen" == "$real_foreground" ]] \
+    [[ "${seen,,}" == "${real_foreground,,}" ]] \
         || fail "this window paints foreground '$seen', not the live theme's $real_foreground, so no shot or colour claim from it is real"
 }
 

--- a/tools/flea-acceptance
+++ b/tools/flea-acceptance
@@ -5,7 +5,7 @@
 #
 #   docs/protocol.md      every request the wire accepts
 #   keys.toml             every action the key table binds
-#   ui/ContextMenu.qml    every context menu entry
+#   ui/js/Menu.js         every context menu entry
 #   canvas.json           every artboard the design defines
 #   keys.toml [[pointer]]  every click the pointer contract declares
 #   tests/*.sh            every suite, and whether anything executable names it
@@ -47,7 +47,7 @@ BIN=${BIN:-$REPO/target/release/flea}
 # reports a smaller checklist as a complete one.
 for cand in "${CANVAS:-}" \
             "$REPO/../flea-canvas/canvas.json" \
-            "$HOME/Documents/claude/omarchy/docs/superpowers/specs/assets/flea-canvas/canvas.json"; do
+            "$HOME/Documents/claude/omarchy/docs/reference/flea-canvas/canvas.json"; do
   [ -n "$cand" ] && [ -f "$cand" ] && { CANVAS=$cand; break; }
 done
 SB="$FIXTURE_ROOT/flea-acceptance-$$"
@@ -106,9 +106,9 @@ derive_digit_actions() {
   done
 }
 
-# Sample input, ui/ContextMenu.qml: '{ label: "Rename", action: "rename", glyph: "rename" }'
+# Sample input, ui/js/Menu.js: 'out.push({ label: "Rename", action: "rename", glyph: "rename" })'
 derive_menu_actions() {
-  sed -n 's/.*action: "\([a-zA-Z][a-zA-Z]*\)".*/\1/p' "$REPO/ui/ContextMenu.qml" | LC_ALL=C sort -u
+  sed -n 's/.*action: "\([a-zA-Z][a-zA-Z]*\)".*/\1/p' "$REPO/ui/js/Menu.js" | LC_ALL=C sort -u
 }
 
 # Sample input, canvas.json: '      "file": "FleaWindow.dc.html",'
@@ -338,7 +338,7 @@ echo
 mapfile -t KEY_ACTIONS < <(derive_key_actions)
 require_list "key actions from keys.toml" "${#KEY_ACTIONS[@]}"
 mapfile -t MENU_ACTIONS < <(derive_menu_actions)
-require_list "menu actions from ui/ContextMenu.qml" "${#MENU_ACTIONS[@]}"
+require_list "menu actions from ui/js/Menu.js" "${#MENU_ACTIONS[@]}"
 mapfile -t ARTBOARDS < <(derive_artboards)
 require_list "artboards from canvas.json" "${#ARTBOARDS[@]}"
 mapfile -t SIDEBAR_KINDS < <(derive_sidebar_kinds)
@@ -358,7 +358,7 @@ else
     skip key "$a" "bound in keys.toml; --drive presses it on a real window"
   done
   for a in "${MENU_ACTIONS[@]}"; do
-    skip menu "$a" "an entry in ui/ContextMenu.qml; --drive chooses it on a real window"
+    skip menu "$a" "an entry in ui/js/Menu.js; --drive chooses it on a real window"
   done
   # Read line by line: a chord's name carries spaces, and a $( ) loop split "SUPER + C" into three
   # items and reported twenty-six of them where there are ten.

--- a/tools/flea-acceptance-drive
+++ b/tools/flea-acceptance-drive
@@ -1155,7 +1155,7 @@ keycase_pageForward() {
        return 2 ;;
   esac
   k "$@"
-  omarchy-drive wait ipc -p "$UI" flea previewPdfPage 1 --timeout 10 >/dev/null \
+  omarchy-drive wait ipc -p "$REPO/ui" flea previewPdfPage 1 --timeout 10 >/dev/null \
     || { WHY="the PDF page stayed at $(ipc previewPdfPage) after the chord"; return 1; }
   omarchy-drive wait ocr flea PAGETWO --timeout 10 >/dev/null 2>&1 \
     || { WHY="the preview still does not show the second page after the chord"; return 1; }

--- a/tools/flea-acceptance-drive
+++ b/tools/flea-acceptance-drive
@@ -1138,8 +1138,7 @@ keycase_seek() {
 keycase_seekBack()    { keycase_seek back "$@"; }
 keycase_seekForward() { keycase_seek forward "$@"; }
 
-# The PDF page is the one preview state no IPC reader answers, so the page itself is read off the
-# screen. The fixture's pages carry one distinct word each for exactly this.
+# The fixture gives each page a distinct word, so both state and paint must advance.
 keycase_pageForward() {
   local before after
   reset_state || return 1
@@ -1156,6 +1155,8 @@ keycase_pageForward() {
        return 2 ;;
   esac
   k "$@"
+  omarchy-drive wait ipc -p "$UI" flea previewPdfPage 1 --timeout 10 >/dev/null \
+    || { WHY="the PDF page stayed at $(ipc previewPdfPage) after the chord"; return 1; }
   sleep 2
   after=$(omarchy-drive ocr flea 2>/dev/null)
   case $after in

--- a/tools/flea-acceptance-drive
+++ b/tools/flea-acceptance-drive
@@ -293,9 +293,9 @@ drive_fixture_build() {
     magick -size 320x200 gradient:'#0e1112-#b38956' "$DRIVE_FIXTURE/b-image.png" 2>/dev/null && HAVE_IMAGE=1
     # Each page in its own parentheses, or magick draws one annotation onto every page. The pages
     # carry different text because the page turn is asserted by reading the page back off the screen.
-    magick \( -size 400x560 xc:white -fill black -pointsize 40 -annotate +40+80 'PAGEONE' \) \
-           \( -size 400x560 xc:white -fill black -pointsize 40 -annotate +40+80 'PAGETWO' \) \
-           \( -size 400x560 xc:white -fill black -pointsize 40 -annotate +40+80 'PAGETHREE' \) \
+    magick \( -size 400x560 xc:white -fill black -font Liberation-Sans -pointsize 40 -annotate +40+80 'PAGEONE' \) \
+           \( -size 400x560 xc:white -fill black -font Liberation-Sans -pointsize 40 -annotate +40+80 'PAGETWO' \) \
+           \( -size 400x560 xc:white -fill black -font Liberation-Sans -pointsize 40 -annotate +40+80 'PAGETHREE' \) \
            "$DRIVE_FIXTURE/c-doc.pdf" 2>/dev/null && HAVE_PDF=1
   fi
   if command -v ffmpeg >/dev/null; then
@@ -1140,7 +1140,7 @@ keycase_seekForward() { keycase_seek forward "$@"; }
 
 # The fixture gives each page a distinct word, so both state and paint must advance.
 keycase_pageForward() {
-  local before after
+  local before
   reset_state || return 1
   [ "$HAVE_PDF" = 1 ] || { WHY="no PDF fixture, magick is not on this box"; return 1; }
   seek_row_named c-doc.pdf || return 1
@@ -1157,13 +1157,8 @@ keycase_pageForward() {
   k "$@"
   omarchy-drive wait ipc -p "$UI" flea previewPdfPage 1 --timeout 10 >/dev/null \
     || { WHY="the PDF page stayed at $(ipc previewPdfPage) after the chord"; return 1; }
-  sleep 2
-  after=$(omarchy-drive ocr flea 2>/dev/null)
-  case $after in
-    *PAGETWO*) return 0 ;;
-  esac
-  WHY="the preview still does not show the second page after the chord"
-  return 1
+  omarchy-drive wait ocr flea PAGETWO --timeout 10 >/dev/null 2>&1 \
+    || { WHY="the preview still does not show the second page after the chord"; return 1; }
 }
 
 # ---- the key runner ---------------------------------------------------------------------------------

--- a/tools/flea-acceptance-drive
+++ b/tools/flea-acceptance-drive
@@ -1233,16 +1233,16 @@ menu_row_for() {
   esac
 }
 
-# The label an entry draws, derived from ui/ContextMenu.qml so a renamed row is followed rather than
+# The label an entry draws, derived from ui/js/Menu.js so a renamed row is followed rather than
 # missed. Sample input: '        out.push({ label: "Rename", action: "rename", glyph: "rename" })'
 derive_menu_labels() {
-  sed -n 's/.*label: "\([^"]*\)", action: "\([a-zA-Z][a-zA-Z]*\)".*/\2 \1/p' "$REPO/ui/ContextMenu.qml"
+  sed -n 's/.*label: "\([^"]*\)", action: "\([a-zA-Z][a-zA-Z]*\)".*/\2 \1/p' "$REPO/ui/js/Menu.js"
 }
 
 # The one entry whose label is a ternary rather than a literal, so it needs its own reader.
-# Sample input: '            label: root.showHidden ? "Hide hidden files" : "Show hidden files",'
+# Sample input: '        label: showHidden ? "Hide hidden files" : "Show hidden files",'
 derive_menu_toggle_labels() {
-  sed -n 's/.*label: root.showHidden ? "\([^"]*\)" : "\([^"]*\)".*/\1\n\2/p' "$REPO/ui/ContextMenu.qml"
+  sed -n 's/.*label: showHidden ? "\([^"]*\)" : "\([^"]*\)".*/\1\n\2/p' "$REPO/ui/js/Menu.js"
 }
 
 # Steps the menu cursor onto the row carrying one of the given labels and returns its index, using
@@ -1279,7 +1279,7 @@ menu_open_on() {
   k "${menuc[@]}"; settle
   [ "$(ipc contextMenuVisible)" = true ] || { WHY="the menu did not open on $row"; return 1; }
   labels=$(menu_labels_for "$action")
-  [ -n "$labels" ] || { WHY="no label for this entry could be derived from ui/ContextMenu.qml"; return 1; }
+  [ -n "$labels" ] || { WHY="no label for this entry could be derived from ui/js/Menu.js"; return 1; }
   menu_seek_label "$labels" >/dev/null
 }
 
@@ -1431,7 +1431,7 @@ drive_menu_action() {
       return ;;
   esac
   if ! declare -F "menucase_$action" >/dev/null; then
-    skip menu "$action" "an entry in ui/ContextMenu.qml, and this battery has no driver for it yet"
+    skip menu "$action" "an entry in ui/js/Menu.js, and this battery has no driver for it yet"
     return
   fi
   WHY=""

--- a/ui/Ipc.qml
+++ b/ui/Ipc.qml
@@ -98,6 +98,7 @@ QtObject {
         function previewStripVisible(): bool { return root.pane.preview.stripVisible }
         // A 0.25 zoom step and an expand flag are not legible off a screenshot, so the seam is the
         // only honest answer for either; "" means no PDF is loaded, which is not zoom 1 or false.
+        function previewPdfPage(): int { var p = root.pane.preview.pdfItem; return p ? p.page : -1 }
         function previewPdfZoom(): string { var p = root.pane.preview.pdfItem; return p ? String(p.zoom) : "" }
         function previewExpanded(): string { var p = root.pane.preview.pdfItem; return p ? String(p.expanded) : "" }
         function rowNameColor(i: int): string {

--- a/ui/js/Focus.js
+++ b/ui/js/Focus.js
@@ -1,7 +1,7 @@
 .pragma library
-
 .import "Eject.js" as Eject
 .import "Filter.js" as Filter
+.import "Format.js" as Format
 .import "Keymap.js" as Keymap
 .import "Mounts.js" as Mounts
 .import "Ops.js" as Ops
@@ -53,10 +53,10 @@ function lookup(event, root) {
     if (action === "pageForward") {
         if (root.preview.active)
             return root.preview.isPdf ? action : ""
-        if (root.focusView === RAIL)
+        if (root.shareBrowser.active || root.focusView === RAIL)
             return "open"
         var row = root.rowFor(root.cursorIndex)
-        return row && row.d ? "open" : (row ? "preview" : "")
+        return row && (row.d || (Format.isSymlink(row.p) && row.i === "folder")) ? "open" : (row ? "preview" : "")
     }
     // reveal only means something on a search result, so o is discarded everywhere else.
     if (action === "reveal" && root.searchMode !== Search.RESULTS)
@@ -265,8 +265,8 @@ function handleKey(event, root, sidebar) {
         root.railAct(action)
         return true
     }
-    if (action.length > 0) {
-        root.act(action)
+    if (action.length > 0 || Keymap.lookup(event.key, event.text, event.modifiers).length > 0) {
+        if (action.length > 0) root.act(action)
         return true
     }
     // An unbound printable key used to jump to a name, which only half worked because most letters

--- a/ui/js/Focus.js
+++ b/ui/js/Focus.js
@@ -47,10 +47,17 @@ function lookup(event, root) {
             return action === "seekBack" ? "cursorLeft" : "cursorRight"
         return ""
     }
-    // The PDF viewer's own four. Minus, plus, e and l mean nothing anywhere else, so they stay
-    // silent rather than reaching act()'s "not built yet" while browsing.
-    if (action === "zoomOut" || action === "zoomIn" || action === "expand" || action === "pageForward")
+    // Minus, plus and e mean nothing outside a PDF. l is h's forward: page, else enter or preview.
+    if (action === "zoomOut" || action === "zoomIn" || action === "expand")
         return (root.preview.active && root.preview.isPdf) ? action : ""
+    if (action === "pageForward") {
+        if (root.preview.active)
+            return root.preview.isPdf ? action : ""
+        if (root.focusView === RAIL)
+            return "open"
+        var row = root.rowFor(root.cursorIndex)
+        return row && row.d ? "open" : (row ? "preview" : "")
+    }
     // reveal only means something on a search result, so o is discarded everywhere else.
     if (action === "reveal" && root.searchMode !== Search.RESULTS)
         return ""

--- a/ui/js/Keymap.js
+++ b/ui/js/Keymap.js
@@ -96,6 +96,7 @@ function lookup(key, text, modifiers) {
 var SHEET = [
     { keys: "j k", action: "cursorDown", label: "move" },
     { keys: "enter", action: "open", label: "open" },
+    { keys: "l", action: "pageForward", label: "browse forward" },
     { keys: "space", action: "preview", label: "preview" },
     { keys: "/", action: "filter", label: "filter" },
     { keys: "f", action: "search", label: "find in subtree" },


### PR DESCRIPTION
`h` is parent while browsing. `l` was PDF page-forward only, and after type-ahead was removed it became the leftover-letter hint (`Press / to filter…`). The pair stopped at going back.

With no PDF open, `l` is now the forward of `h`:

- **Directory** under the cursor → enter it (same as Enter)
- **File** → preview (same as Space)
- **PDF preview** → next page (unchanged)
- **Media preview** → still ignored, so it does not fight Space for play/pause
- **Rail** → open the highlighted place

This is the ranger/yazi `hl` pair, not a change to `/`, Space, or Enter.

## Tests

`tests/js.sh` covers PDF paging, directory open, file preview, and media still discarding `l`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the `l` key as a forward-browsing shortcut.
  - Use `l` to enter directories, preview files, activate rail or share-browser items, and advance PDF pages.
  - The shortcut remains inactive for media and empty rows.

- **Documentation**
  - Updated the keyboard reference and keymap descriptions to document `l` and clarify backward/forward browsing behavior.

- **Bug Fixes**
  - Improved handling of forward-browsing actions across directories, files, symlinks, PDFs, and share-browser entries.

- **Tests**
  - Added and expanded coverage for forward browsing, PDF paging, symlinks, empty directories, and media behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->