### PR TITLE
feat: identify remote-to-remote transfers

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ Large directories stay responsive: the window loads rows and requests thumbnails
 - **Three views.** List, columns and grid, with tabs and natural filename sorting.
 - **Quick Look.** Press Space for images, PDFs, text, media and archive contents.
 - **File operations.** Copy, move, rename, trash, compress and extract, with an undo journal.
+  Copies and moves between two network mounts run on that same undoable backend and are identified
+  as remote-to-remote.
 - **Network and sharing.** SMB, SFTP, FTPS, WebDAV, NFS, Dropbox and Taildrop.
 - **Desktop integration.** Default file manager, “Show in folder” and Open/Save dialogs.
 - **Your settings.** Omarchy text sizes, configurable menus and Default, Vim, Mac or Windows keys.

--- a/tests/js/harness.qml
+++ b/tests/js/harness.qml
@@ -28,6 +28,7 @@ import "places.js" as PlacesSuite
 import "protocols.js" as ProtocolsSuite
 import "railkeys.js" as RailKeysSuite
 import "recent.js" as RecentSuite
+import "remote.js" as RemoteSuite
 import "renderer.js" as RendererSuite
 import "scroll.js" as ScrollSuite
 import "search.js" as SearchSuite
@@ -70,7 +71,7 @@ Item {
             ["palette", PaletteSuite], ["pathbar", PathBarSuite], ["places", PlacesSuite],
             ["picker", PickerSuite],
             ["protocols", ProtocolsSuite], ["railkeys", RailKeysSuite],
-            ["recent", RecentSuite],
+            ["recent", RecentSuite], ["remote", RemoteSuite],
             ["renderer", RendererSuite],
             ["scroll", ScrollSuite], ["search", SearchSuite],
             ["selection", SelectionSuite], ["settings", SettingsSuite],

--- a/tests/js/ops.js
+++ b/tests/js/ops.js
@@ -11,7 +11,6 @@ function run(check) {
     check("one item is singular and two are not",
           Ops.items(1) + " / " + Ops.items(2) + " / " + Ops.items(0),
           "1 item / 2 items / 0 items")
-
     // The canvas's own line, drawn on the Operations artboard: "Copying 2 of 5, photo.heic".
     check("a copy in flight reads the way the canvas draws it",
           Ops.progressLine({ moving: false, n: 5, index: 1, name: "photo.heic" }),
@@ -22,6 +21,12 @@ function run(check) {
     check("a remote-to-remote transfer says what crosses the wire",
           Ops.progressLine({ moving: false, n: 2, index: 0, name: "photo.heic", kind: "remote-to-remote" }),
           "Copying between remote hosts 1 of 2, photo.heic")
+    check("a remote-to-remote move uses the matching verb",
+          Ops.progressLine({ moving: true, n: 2, index: 0, name: "photo.heic", kind: "remote-to-remote" }),
+          "Moving between remote hosts 1 of 2, photo.heic")
+    var pending = { pendingTransferKind: "remote-to-remote" }
+    Ops.clearPendingKind(pending, "transfer")
+    check("a transfer refused before start cannot leak its kind", pending.pendingTransferKind, "local")
     // A directory item reports no name until its first line arrives, and the count still reads.
     check("an item with no name yet still counts",
           Ops.progressLine({ moving: false, n: 2, index: 0, name: "" }),

--- a/tests/js/ops.js
+++ b/tests/js/ops.js
@@ -19,6 +19,9 @@ function run(check) {
     check("a move says so instead",
           Ops.progressLine({ moving: true, n: 5, index: 1, name: "photo.heic" }),
           "Moving 2 of 5, photo.heic")
+    check("a remote-to-remote transfer says what crosses the wire",
+          Ops.progressLine({ moving: false, n: 2, index: 0, name: "photo.heic", kind: "remote-to-remote" }),
+          "Copying between remote hosts 1 of 2, photo.heic")
     // A directory item reports no name until its first line arrives, and the count still reads.
     check("an item with no name yet still counts",
           Ops.progressLine({ moving: false, n: 2, index: 0, name: "" }),

--- a/tests/js/ops.js
+++ b/tests/js/ops.js
@@ -289,6 +289,24 @@ function run(check) {
     check("and it keeps the id the cancel button has to name",
           flight.id + " " + flight.running,
           "12 true")
+    // The wire rebuilds the transfer on every sample, so a field it forgets to name is gone from
+    // the first progress update onward. This one is the whole point of the classification: it
+    // survived `started` and vanished the moment bytes began arriving.
+    var remote = Transfer.sampled(Ops.started(13, false, 2, "remote-to-remote"), 0, "photo.heic", 1, 2)
+    check("a sample keeps the transfer remote-to-remote",
+          Ops.progressLine(remote),
+          "Copying between remote hosts 1 of 2, photo.heic")
+    check("and so does the item line that ends it",
+          Ops.progressLine(Transfer.itemDone(remote, 0, "photo.heic")),
+          "Copying between remote hosts 1 of 2, photo.heic")
+    var remoteMove = Transfer.sampled(Ops.started(14, true, 2, "remote-to-remote"), 0, "photo.heic", 1, 2)
+    check("a sampled remote move keeps its verb too",
+          Ops.progressLine(remoteMove),
+          "Moving between remote hosts 1 of 2, photo.heic")
+    check("a local transfer is still worded plainly through a sample",
+          Ops.progressLine(Transfer.sampled(Ops.started(15, false, 2), 0, "photo.heic", 1, 2)),
+          "Copying 1 of 2, photo.heic")
+
     var landed = Transfer.itemDone(flight, 8, "panel-demo.mp4")
     check("an item's own terminal line counts it whole and spends its byte sample",
           landed.done + " " + landed.bytes + " " + landed.total,

--- a/tests/js/remote.js
+++ b/tests/js/remote.js
@@ -4,8 +4,13 @@ function run(check) {
     var remote = "/run/user/1000/gvfs/sftp:host=box/home/pi"
     check("a GVFS path is remote", Remote.isRemotePath(remote), true)
     check("a local lookalike is local", Remote.isRemotePath("/tmp/gvfs/box"), false)
+    check("the mount root stops before the path inside it", Remote.remoteRoot(remote), "/run/user/1000/gvfs/sftp:host=box")
     check("two mounted endpoints are remote to remote", Remote.transferKind([remote + "/a"], "/run/user/1000/gvfs/smb-share:server=nas,share=data"), "remote-to-remote")
     check("a local source to a mount is named separately", Remote.transferKind(["/tmp/a"], remote), "local-to-remote")
+    check("a mixed batch is not mislabeled as entirely between remote hosts",
+          Remote.transferKind([remote + "/a", "/tmp/b"], "/run/user/1000/gvfs/smb-share:server=nas,share=data"), "local-to-remote")
+    check("a transfer within one mount is not described as crossing hosts",
+          Remote.transferKind([remote + "/a"], remote + "/folder"), "same-remote")
     check("a remote destination line is explicit", Remote.transferPrefix("remote-to-remote", false), "Copying between remote hosts")
     var peer = { group:"network", kind:"peer", uri:"sftp://pi@box/", health:"online", origin:"tailnet", taildrop:true, mac:"" }
     check("a Tailnet peer gets safe remote actions", Remote.menu(peer).map(function (r) { return r.action }).join("|"), "copy-address|open-ssh|taildrop-peer")

--- a/tests/js/remote.js
+++ b/tests/js/remote.js
@@ -1,0 +1,21 @@
+.import "../../ui/js/Remote.js" as Remote
+
+function run(check) {
+    var remote = "/run/user/1000/gvfs/sftp:host=box/home/pi"
+    check("a GVFS path is remote", Remote.isRemotePath(remote), true)
+    check("a local lookalike is local", Remote.isRemotePath("/tmp/gvfs/box"), false)
+    check("two mounted endpoints are remote to remote", Remote.transferKind([remote + "/a"], "/run/user/1000/gvfs/smb-share:server=nas,share=data"), "remote-to-remote")
+    check("a local source to a mount is named separately", Remote.transferKind(["/tmp/a"], remote), "local-to-remote")
+    check("a remote destination line is explicit", Remote.transferPrefix("remote-to-remote", false), "Copying between remote hosts")
+    var peer = { group:"network", kind:"peer", uri:"sftp://pi@box/", health:"online", origin:"tailnet", taildrop:true, mac:"" }
+    check("a Tailnet peer gets safe remote actions", Remote.menu(peer).map(function (r) { return r.action }).join("|"), "copy-address|open-ssh|taildrop-peer")
+    check("the terminal argv keeps the host one argument", Remote.terminalArgv(peer).join("|"), "omarchy-launch-terminal|ssh|pi@box")
+    var lan = { group:"network", kind:"discovered", uri:"sftp://lan/", health:"offline", origin:"lan", mac:"aa:bb:cc:dd:ee:ff" }
+    check("an offline LAN host offers reconnect and Wake but not SSH", Remote.menu(lan).map(function (r) { return r.action }).join("|"), "reconnect|copy-address|wake")
+    check("an offline Taildrop peer never offers a doomed send", Remote.menu({group:"network",kind:"peer",uri:"sftp://box/",health:"offline",origin:"tailnet",taildrop:true}).map(function (r) { return r.action }).join("|"), "reconnect|copy-address")
+    check("invalid MACs never offer Wake", Remote.validMac("aa:bb"), false)
+    check("a custom SSH port stays in separate argv slots", Remote.terminalArgv({uri:"sftp://pi@host:2222/"}).join("|"), "omarchy-launch-terminal|ssh|-p|2222|pi@host")
+    check("a bracketed IPv6 host becomes an SSH target without URI brackets", Remote.terminalArgv({uri:"sftp://pi@[fd7a::1]:2222/"}).join("|"), "omarchy-launch-terminal|ssh|-p|2222|pi@fd7a::1")
+    check("a hostile SSH authority is refused", Remote.terminalArgv({uri:"sftp://host;touch/"}).length, 0)
+    check("an invalid SSH port is refused", Remote.terminalArgv({uri:"sftp://host:99999/"}).length, 0)
+}

--- a/tests/ops.sh
+++ b/tests/ops.sh
@@ -157,6 +157,7 @@ await '"t":"transferdone"' || fail=1
 check "remote-to-remote copy preserves source bytes" "remote copy|remote copy" "$(cat "$remote_src/copy.txt")|$(cat "$remote_dst/copy.txt")"
 send "{\"c\":\"transfer\",\"op\":\"move\",\"paths\":[\"$remote_src/move.txt\"],\"dest\":\"$remote_dst\"}"
 for _attempt in $(seq 1 200); do [[ $(seen '"t":"transferdone"') -ge 2 ]] && break; sleep 0.05; done
+[[ $(seen '"t":"transferdone"') -ge 2 ]] || { printf 'FAIL remote move never completed\n'; fail=1; }
 check "remote-to-remote move removes the source only after landing" "no|remote move" "$([ -e "$remote_src/move.txt" ] && echo yes || echo no)|$(cat "$remote_dst/move.txt")"
 stop_backend
 

--- a/tests/ops.sh
+++ b/tests/ops.sh
@@ -145,6 +145,21 @@ check "undo put it back where it came from" "moving" "$(cat "$D/m.txt" 2>/dev/nu
 check "the destination copy is gone" "no" "$([ -e "$D/dest/m.txt" ] && echo yes || echo no)"
 stop_backend
 
+echo "--- transfers between two synthetic GVFS mount roots use the normal backend ---"
+start_backend
+mkdir -p "$D/run/user/1000/gvfs/sftp:host=source" "$D/run/user/1000/gvfs/smb-share:server=dest,share=data"
+printf 'remote copy' > "$D/run/user/1000/gvfs/sftp:host=source/copy.txt"
+printf 'remote move' > "$D/run/user/1000/gvfs/sftp:host=source/move.txt"
+remote_src="$D/run/user/1000/gvfs/sftp:host=source"
+remote_dst="$D/run/user/1000/gvfs/smb-share:server=dest,share=data"
+send "{\"c\":\"transfer\",\"op\":\"copy\",\"paths\":[\"$remote_src/copy.txt\"],\"dest\":\"$remote_dst\"}"
+await '"t":"transferdone"' || fail=1
+check "remote-to-remote copy preserves source bytes" "remote copy|remote copy" "$(cat "$remote_src/copy.txt")|$(cat "$remote_dst/copy.txt")"
+send "{\"c\":\"transfer\",\"op\":\"move\",\"paths\":[\"$remote_src/move.txt\"],\"dest\":\"$remote_dst\"}"
+for _attempt in $(seq 1 200); do [[ $(seen '"t":"transferdone"') -ge 2 ]] && break; sleep 0.05; done
+check "remote-to-remote move removes the source only after landing" "no|remote move" "$([ -e "$remote_src/move.txt" ] && echo yes || echo no)|$(cat "$remote_dst/move.txt")"
+stop_backend
+
 echo "--- one failing item is data, and the batch carries on ---"
 start_backend
 printf 'good' > "$D/good.txt"; mkdir -p "$D/dest"

--- a/ui/Pane.qml
+++ b/ui/Pane.qml
@@ -121,6 +121,7 @@ FocusScope {
     property var pathsPending: null
     // What the status bar's sticky slot is reporting, or an idle transfer; see ui/js/Ops.js.
     property var transfer: Ops.emptyTransfer()
+    property string pendingTransferKind: "local"
     // The row that is its own editor right now, or -1; ui/List.qml's delegate reads it per row.
     property int renamingIndex: -1
     // Set by a pointer-committed rename so the reply reveals nothing; ui/js/Nav.js clears it.

--- a/ui/PaneWire.qml
+++ b/ui/PaneWire.qml
@@ -224,7 +224,8 @@ Item {
         // The verb comes off the wire, never off the clipboard: paste spends a cut before this line
         // arrives, and a Dropbox move never touches the clipboard at all.
         function onTransferStarted(id, n, moving) {
-            pane.transfer = Ops.started(id, moving, n)
+            pane.transfer = Ops.started(id, moving, n, pane.pendingTransferKind)
+            pane.pendingTransferKind = "local"
             pane.sticky(Ops.progressLine(pane.transfer))
         }
 

--- a/ui/PaneWire.qml
+++ b/ui/PaneWire.qml
@@ -322,6 +322,9 @@ Item {
         function onFailed(where, input, message, mode) {
             // A listing that failed cannot seat the row a peeked right click asked for, so its menu intent dies here.
             pane.pendingMenu = false
+            // A refused transfer leaves its classification behind, and the next
+            // one is then labelled with the kind of the one that never ran.
+            Ops.clearPendingKind(pane, where)
             var text = Errors.sentence(where, message)
             // A refused sort changes nothing in the backend, so it changes nothing here: a notice in the
             // plain role, never the error role, which is for a listing that stopped being true.

--- a/ui/js/Ops.js
+++ b/ui/js/Ops.js
@@ -14,7 +14,7 @@ function emptyTransfer() {
     return { id: 0, moving: false, n: 0, index: 0, name: "", running: false,
              done: 0, bytes: 0, total: 0, kind: "local" }
 }
-
+function clearPendingKind(pane, where) { if (where === "transfer") pane.pendingTransferKind = "local" }
 // "1 item" or "4 items", so no caller builds a plural by hand.
 function items(n) {
     return n + (n === 1 ? " item" : " items")

--- a/ui/js/Ops.js
+++ b/ui/js/Ops.js
@@ -3,17 +3,16 @@
 .import "Archive.js" as Archive
 .import "Convert.js" as Convert
 .import "Transfer.js" as Transfer
-
+.import "Remote.js" as Remote
 // The clipboard is entirely client-side: the backend knows about a transfer, never about a pending paste.
 function emptyClipboard() {
     return { paths: [], moving: false }
 }
-
 // What the status bar and the card are tracking while a transfer runs; id is what a cancel names.
 // done, bytes and total are the card's bar: the items already finished, and the one in flight.
 function emptyTransfer() {
     return { id: 0, moving: false, n: 0, index: 0, name: "", running: false,
-             done: 0, bytes: 0, total: 0 }
+             done: 0, bytes: 0, total: 0, kind: "local" }
 }
 
 // "1 item" or "4 items", so no caller builds a plural by hand.
@@ -24,17 +23,19 @@ function items(n) {
 // A finished operation names its own reversal, which is why none of them needs a confirmation step.
 var UNDO_HINT = " · z undoes"
 
-function started(id, moving, n) {
+function started(id, moving, n, kind) {
     return { id: id, moving: moving, n: n, index: 0, name: "", running: true,
-             done: 0, bytes: 0, total: 0 }
+             done: 0, bytes: 0, total: 0, kind: kind || "local" }
 }
 
 // The canvas's own line: "Copying 2 of 5, photo.heic". The count comes from the card's own
 // headline so the bar and the card can never word the same operation two different ways.
 function progressLine(t) {
-    return t.name.length > 0 ? Transfer.head(t) + ", " + t.name : Transfer.head(t)
+    var head = Transfer.head(t)
+    if (t.kind === "remote-to-remote")
+        head = Remote.transferPrefix(t.kind, t.moving) + " " + (t.index + 1) + " of " + t.n
+    return t.name.length > 0 ? head + ", " + t.name : head
 }
-
 function transferDone(t, ok, failed, cancelled) {
     if (cancelled) {
         return ok > 0 ? "Cancelled after " + items(ok) + UNDO_HINT : "Cancelled."
@@ -188,13 +189,13 @@ function paste(pane) {
         pane.message("There is nothing to paste; y copies and x cuts.", false)
         return
     }
+    pane.pendingTransferKind = Remote.transferKind(clip.paths, pane.path)
     pane.backend.send({ c: "transfer", op: clip.moving ? "move" : "copy", paths: clip.paths, dest: pane.path })
     // A cut is spent by its paste; a copy stays on the clipboard so it can be pasted again.
     if (clip.moving) {
         pane.clipboard = emptyClipboard()
     }
 }
-
 function undo(pane) {
     pane.backend.undo()
 }

--- a/ui/js/Remote.js
+++ b/ui/js/Remote.js
@@ -1,0 +1,76 @@
+.pragma library
+
+function isRemotePath(path) {
+    return /^\/run\/user\/\d+\/gvfs\//.test(String(path || ""))
+}
+
+function transferKind(paths, destination) {
+    if (!isRemotePath(destination))
+        return "local"
+    var list = paths || []
+    for (var i = 0; i < list.length; i++) {
+        if (isRemotePath(list[i]))
+            return "remote-to-remote"
+    }
+    return "local-to-remote"
+}
+
+function transferPrefix(kind, moving) {
+    var verb = moving ? "Moving" : "Copying"
+    return kind === "remote-to-remote" ? verb + " between remote hosts" : verb
+}
+
+function menu(entry) {
+    if (!entry || entry.group !== "network" || entry.kind === "dropbox" || entry.kind === "status")
+        return []
+    var rows = []
+    if (entry.mounted)
+        rows.push(item("Unmount", "unmount", "eject"))
+    if (entry.health === "failed" || entry.health === "offline")
+        rows.push(item("Reconnect", "reconnect", "refresh-cw"))
+    rows.push(item("Copy address", "copy-address", "file-text"))
+    if (sshTarget(entry.uri).length > 0 && entry.health !== "offline")
+        rows.push(item("Open terminal over SSH", "open-ssh", "terminal"))
+    if (entry.taildrop && entry.health === "online")
+        rows.push(item("Send with Taildrop", "taildrop-peer", "network"))
+    if (entry.origin === "lan" && validMac(entry.mac))
+        rows.push(item("Wake", "wake", "power"))
+    if (entry.kind !== "peer" && entry.kind !== "discovered") {
+        rows.push(item("Edit", "edit", "rename"))
+        rows.push(item("Remove", "remove", "trash"))
+    }
+    return rows
+}
+
+function item(label, action, glyph) { return { label: label, action: action, glyph: glyph } }
+
+function sshTarget(uri) {
+    var spec = sshSpec(uri)
+    return spec ? spec.target : ""
+}
+
+function terminalArgv(entry) {
+    var spec = sshSpec(entry && entry.uri)
+    if (!spec)
+        return []
+    var out = ["omarchy-launch-terminal", "ssh"]
+    if (spec.port.length > 0)
+        out = out.concat(["-p", spec.port])
+    out.push(spec.target)
+    return out
+}
+
+function sshSpec(uri) {
+    var m = String(uri || "").match(/^(?:sftp|ssh):\/\/((?:[A-Za-z0-9._%-]+@)?)(\[[0-9A-Fa-f:%._-]+\]|[A-Za-z0-9._-]+)(?::(\d+))?(?:\/.*)?$/i)
+    if (!m)
+        return null
+    var port = m[3] || ""
+    if (port.length > 0 && (Number(port) < 1 || Number(port) > 65535))
+        return null
+    var host = m[2].charAt(0) === "[" ? m[2].slice(1, -1) : m[2]
+    return { target: m[1] + host, port: port }
+}
+
+function validMac(value) {
+    return /^[0-9a-f]{2}(?::[0-9a-f]{2}){5}$/i.test(String(value || ""))
+}

--- a/ui/js/Remote.js
+++ b/ui/js/Remote.js
@@ -1,18 +1,29 @@
 .pragma library
 
 function isRemotePath(path) {
-    return /^\/run\/user\/\d+\/gvfs\//.test(String(path || ""))
+    return remoteRoot(path).length > 0
+}
+
+function remoteRoot(path) {
+    var match = String(path || "").match(/^(\/run\/user\/\d+\/gvfs\/[^\/]+)(?:\/|$)/)
+    return match ? match[1] : ""
 }
 
 function transferKind(paths, destination) {
-    if (!isRemotePath(destination))
+    var destinationRoot = remoteRoot(destination)
+    if (destinationRoot.length === 0)
         return "local"
     var list = paths || []
+    if (list.length === 0)
+        return "local-to-remote"
     for (var i = 0; i < list.length; i++) {
-        if (isRemotePath(list[i]))
-            return "remote-to-remote"
+        var sourceRoot = remoteRoot(list[i])
+        if (sourceRoot.length === 0)
+            return "local-to-remote"
+        if (sourceRoot === destinationRoot)
+            return "same-remote"
     }
-    return "local-to-remote"
+    return "remote-to-remote"
 }
 
 function transferPrefix(kind, moving) {

--- a/ui/js/Transfer.js
+++ b/ui/js/Transfer.js
@@ -7,15 +7,19 @@
 
 // The byte sample for the item in flight. done is the count already finished, so it stays where it
 // was: a sample fills the item in, it does not complete it.
+//
+// Every field is restated here rather than copied, so a field added to the transfer is dropped the
+// moment the first sample lands unless it is named. `kind` was: the transfer started as
+// remote-to-remote, and reverted to generic wording on its own first progress update.
 function sampled(t, index, name, bytes, total) {
     return { id: t.id, moving: t.moving, n: t.n, index: index, name: name, running: t.running,
-             done: index, bytes: bytes, total: total }
+             done: index, bytes: bytes, total: total, kind: t.kind }
 }
 
 // That item's own terminal line: it counts whole from here, and its byte sample is spent.
 function itemDone(t, index, name) {
     return { id: t.id, moving: t.moving, n: t.n, index: index, name: name, running: t.running,
-             done: index + 1, bytes: 0, total: 0 }
+             done: index + 1, bytes: 0, total: 0, kind: t.kind }
 }
 
 // The card's headline, the count with no name in it: the card gives the name a row of its own, and


### PR DESCRIPTION
## What changes

- detects when every source and the destination are under distinct GVFS mount roots
- labels those operations as `Copying between remote hosts` or `Moving between remote hosts`
- keeps mixed local/remote batches and same-mount operations under generic progress wording
- keeps the existing backend, cancellation, partial-file cleanup, and undo behavior unchanged

## Why

Remote-to-remote transfers already use Flea's normal backend through their GVFS paths, but the progress line presented them as ordinary local work. The explicit label makes the network path and its likely latency clear without adding a second transfer implementation.

## Review fixes

- require distinct remote roots before applying the remote-to-remote label
- clear pending transfer classification when a transfer is refused before it starts
- cover both copy and move wording
- fail the shell integration test if the move never completes

## Verification

- [x] `./tests/run-all.sh` — 10 suites, 0 failed
- [x] `./tests/js.sh` — 1,173 checks, 0 failed
- [x] `./tests/ops.sh` — synthetic SFTP-to-SMB copy and move, including source retention/removal
- [x] mixed local/remote and same-mount batches are not mislabeled
- [x] existing failure, no-clobber, cancellation, and undo tests remain green
- [x] `./tools/flea-qmllint-gate` — 0 regressions
- [x] `./tools/flea-file-budget`
- [x] `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for identifying transfers between two remote GVFS mounts as remote-to-remote operations.
  * Remote-to-remote copy and move progress now shows the transfer direction, item count, and filename.
  * Transfers between files on the same remote mount are recognized separately.

* **Bug Fixes**
  * Prevented failed transfers from leaving stale transfer status that could affect subsequent operations.
  * Improved handling of mixed local and remote file selections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->