### PR TITLE
feat: discover and manage LAN and tailnet hosts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3621,3 +3621,18 @@ key press fires a compositor bind, so `omarchy-drive hotkey --global super w` is
 on the ACTIVE window, so assert the active window is the one the run launched before sending it, and
 never call `hl.dsp.window.close()` with no argument: it returns `ok` rather than printing a signature
 and acts on whatever is active, which may be a window you did not open.
+
+### Editing a network place rewrites the bookmark line, not just its label
+
+`r` on a NETWORK row still only relabels. The URI itself is edited through the same dialog Add
+uses: right-click (or `m`) on a share, **Edit**, which fills `ui/NetworkForm.qml` from
+`Protocols.parse` and Save writes through `Places.replace`. An unmounted bookmark's menu is Edit
+alone, so a URI that will not mount (the operator's real `sftp://user@host:22/~`; gio does not
+expand `~`) can still be rewritten. A mounted share keeps **Unmount** first so Ctrl+E still
+releases; `Mounts.releaseAction` is what Ctrl+E reads, never `railMenu()[0]`, because Edit is a
+menu row and not a release.
+
+`Places.replace(body, oldUri, newUri, label)` is the write: normalized match like `relabel`, every
+duplicate rewritten, control characters stripped from the label, an empty old URI appends (Add).
+`tests/js/places.js`, `tests/js/protocols.js`, `tests/js/mounts.js` and `tests/ui.sh case_networkedit`
+hold it.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3634,5 +3634,6 @@ menu row and not a release.
 
 `Places.replace(body, oldUri, newUri, label)` is the write: normalized match like `relabel`, every
 duplicate rewritten, control characters stripped from the label, an empty old URI appends (Add).
-`tests/js/places.js`, `tests/js/protocols.js`, `tests/js/mounts.js` and `tests/ui.sh case_networkedit`
-hold it.
+`Places.remove(body, uri)` drops matching lines. Remove on a live share also unmounts, so the row
+leaves instead of becoming a mount-only leftover. `tests/js/places.js`, `tests/js/protocols.js`,
+`tests/js/mounts.js` and `tests/ui.sh case_networkedit` hold it.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3513,6 +3513,12 @@ session) and drop the bookmark's, so `r` rewrote the file and the next poll put 
 `Places.networkEntries` keeps the bookmark label on the live row. Unmount of a share whose FUSE
 path is the current listing goes Home first; otherwise gio refuses as busy.
 
+gvfsd-sftp mounts one connection per host: `gio mount -l` lists `sftp://user@host/` even when the
+bookmark is `sftp://user@host/home/tom`. A second path on that host now stays its own rail row and
+reads as mounted. Unmount sends gio the live root URI, and leaving Home is keyed on the connection
+not the path, so a listing inside `/home/tom` no longer keeps the root "in use". SMB/NFS stay
+per-share: a live `smb://nas/data` does not light `smb://nas/isos`.
+
 ### The rail menu, tested with a stubbed gio and a stubbed lsblk
 
 `tests/ui.sh case_unmount` and `case_eject` drive the rail menu through the real window.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3646,6 +3646,9 @@ menu row and not a release.
 
 `Places.replace(body, oldUri, newUri, label)` is the write: normalized match like `relabel`, every
 duplicate rewritten, control characters stripped from the label, an empty old URI appends (Add).
-`Places.remove(body, uri)` drops matching lines. Remove on a live share also unmounts, so the row
-leaves instead of becoming a mount-only leftover. `tests/js/places.js`, `tests/js/protocols.js`,
-`tests/js/mounts.js` and `tests/ui.sh case_networkedit` hold it.
+`Places.remove(body, uri)` drops matching lines. An unmounted bookmark is dropped immediately. A
+live one is unmounted first and the file is rewritten only from `unmountProcess.onExited` when
+gio succeeds, so a busy share keeps its row. `Protocols.parse` splits the path off before it
+looks for `@`, so a path like `inbox@2026` is not stolen as a username. `tests/js/places.js`,
+`tests/js/protocols.js`, `tests/js/mounts.js`, `tests/ui.sh case_networkedit` and
+`case_networkremove` hold it.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3652,3 +3652,39 @@ gio succeeds, so a busy share keeps its row. `Protocols.parse` splits the path o
 looks for `@`, so a path like `inbox@2026` is not stolen as a username. `tests/js/places.js`,
 `tests/js/protocols.js`, `tests/js/mounts.js`, `tests/ui.sh case_networkedit` and
 `case_networkremove` hold it.
+
+### Network discovery is transport-aware, not a Tailscale filesystem
+
+`ui/NetworkRail.qml` composes four independent concerns: `NetworkDiscovery` discovers, `NetworkHistory`
+persists successful recents and saved Wake metadata, `NetworkMounts` owns GIO, and `NetworkActions`
+runs host-side actions. `Sidebar` renders their merged rows and owns none of their processes.
+
+Tailscale is only private reachability and identity. `tailscale status --json` contributes peer names,
+addresses, online state, and Taildrop capability; a row still opens through an ordinary GIO protocol,
+defaulting to SFTP. LAN discovery is the same model over bounded `avahi-browse -artp` output for SSH,
+SMB, NFS, and WebDAV. Missing, failed, malformed, empty, and timed-out discovery never disables a
+manual GTK bookmark or a live GIO mount. `FLEA_DISABLE_NETWORK_DISCOVERY=1` is the hermetic UI-test seam.
+
+All discovery and GIO listing children have deadlines. A timed-out `gio mount -l` preserves the last
+good rail; a timed-out `gio list` reports the bare server as failed. Health is metadata, with a live
+mount authoritative over transient states. Metadata from multiple identities must combine: an older
+recent cannot shadow a fresh online/Taildrop state or a saved LAN MAC.
+
+Quick Connect turns shorthand into an explicit URI before saving: `user@host:/path` and bare hosts are
+SFTP, `host/share` is SMB, and an explicit supported scheme wins. Embedded passwords, raw query tokens,
+fragments, newlines, and unknown schemes are rejected. Structured editing stays available underneath.
+
+`~/.config/flea-network-recents.json` is written by FileView with atomic writes. It holds at most eight
+successful connections plus separate Wake profiles, never passwords, query strings, fragments, or
+control characters. Editing an identity removes the old profile; clearing its MAC removes Wake rather
+than leaving stale capability behind.
+
+Remote actions remain argv-direct. SSH ports occupy their own `-p` argv slot, clipboard and Wake report
+success only from `Process.onExited`, and no recovery row runs `sudo`, starts `tailscaled`, or changes
+authentication. Wake is the internal `flea --wake <mac>` mode: Rust validates the MAC, builds six FF
+bytes plus sixteen MAC copies, and broadcasts the 102-byte packet to UDP port 9.
+
+Two `/run/user/<uid>/gvfs` endpoints are labelled remote-to-remote, but deliberately reuse the normal
+copy/move backend. That preserves its existing no-clobber, cancellation, partial-file, and undo rules.
+`tests/network-services.sh` is the windowless Quickshell process harness; pure parsing lives under
+`tests/js`, and `tests/ops.sh` drives copies and moves between two synthetic mounted-root shapes.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3590,6 +3590,17 @@ reachable while a device is misbehaving. The `_streamPending` interlock is relea
 rather than in the timer, because a collector whose stream was cut off may never finish it and
 `poll()` refuses on that flag alone.
 
+**Every reusable Process starts with an empty fallback.** `StdioCollector.text` and the parallel
+`_...Output` value exist because `Process.onExited` can race the collector property update, but the
+fallback is ordinary component state and survives the next command. Before this rule, a quiet
+second run could reuse the first run's bytes: an empty `gio mount -l` retained a disconnected
+share, empty `gio info` reopened the previous share's local path, an empty server listing repeated
+another server's names, a failed mount with no stderr inherited "already mounted", empty `lsblk`
+retained removed devices, and empty Tailscale status retained old Taildrop targets. Each start
+function now clears only its own fallback after refusing any overlapping run and before setting
+`Process.running`. `tests/process-output.sh` poisons all six values, starts all six real Process
+objects, and requires every reset synchronously; removing any one reset makes the suite red.
+
 ### Closing the window quits the backend, and a copy in flight is cancelled
 
 `ui/shell.qml` answers `Quickshell.onLastWindowClosed` with `backend.quit()` and signals its own pid

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3508,6 +3508,11 @@ returning whatever form their own source actually carries; only the write path a
 comparison were ever the places two spellings needed to agree. `tests/js/mounts.js` proves a
 trailing slash, a default sftp port, and a bare root all collapse, and a non-default port does not.
 
+Once collapsed, the live `gio mount -l` row used to keep gio's own label ("tom" for an SFTP
+session) and drop the bookmark's, so `r` rewrote the file and the next poll put "tom" back.
+`Places.networkEntries` keeps the bookmark label on the live row. Unmount of a share whose FUSE
+path is the current listing goes Home first; otherwise gio refuses as busy.
+
 ### The rail menu, tested with a stubbed gio and a stubbed lsblk
 
 `tests/ui.sh case_unmount` and `case_eject` drive the rail menu through the real window.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3496,16 +3496,17 @@ with its own trailing slash; nothing forced the two to agree, so `smb://h/data` 
 `smb://h/data/` (gio's own report of the same share once mounted) compared unequal everywhere a
 uri was used as a dedup key, and could show as two rows for one share. `ui/js/Mounts.js` gained
 `normalize(uri)`: every trailing slash is stripped, except a bare server root (nothing left but
-`scheme://host`), which keeps exactly one, the shape `gio` itself needs to parse it back. Applied
-in two places, per the ruling ("apply it... on write and on compare"): `ui/NetworkDialog.qml`'s
-`appendBookmark()` writes the normalized form rather than the raw typed string, and
-`ui/NetworkMounts.qml`'s `rebuild()` dedups live mounts against bookmarks using normalized keys
-rather than the raw `uri` fields, so a live mount (gio's trailing-slash form) and a bookmark (now
-also normalized, but an old hand-edited line might not be) still collapse to one row. `parseMounts()`
-and `nonFileBookmarks()` themselves are left returning whatever form their own source actually
-carries; only the write path and the dedup comparison were ever the places two spellings needed to
-agree. `tests/js/mounts.js` proves `normalize("smb://h/data") === normalize("smb://h/data/")` and
-that a bare root normalizes to its one-trailing-slash form regardless of how it was typed.
+`scheme://host`), which keeps exactly one, the shape `gio` itself needs to parse it back. A scheme's
+default port is dropped too: the add form writes `sftp://user@host:22/path` and `gio mount -l`
+reports `sftp://user@host/path`, which used to show as two rail rows (a dim bookmark the cursor
+stayed on, and a brighter live mount of the same share). Applied in two places, per the ruling
+("apply it... on write and on compare"): `ui/NetworkDialog.qml`'s write path uses the normalized
+form rather than the raw typed string, and `ui/NetworkMounts.qml`'s `rebuild()` dedups live mounts
+against bookmarks using normalized keys rather than the raw `uri` fields, so a live mount and a
+bookmark still collapse to one row. `parseMounts()` and `nonFileBookmarks()` themselves are left
+returning whatever form their own source actually carries; only the write path and the dedup
+comparison were ever the places two spellings needed to agree. `tests/js/mounts.js` proves a
+trailing slash, a default sftp port, and a bare root all collapse, and a non-default port does not.
 
 ### The rail menu, tested with a stubbed gio and a stubbed lsblk
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2533,8 +2533,16 @@ already is, so the loop stays the only writer of stdout.
 **Every write creates its target exclusively, and this is the module's whole safety story.** A file copy
 opens with `create_new`, a directory copy and a `mkdir` use `create_dir`, a symlink copy uses `symlink`, and a rename
 or a move uses `renameat2` with `RENAME_NOREPLACE`. None of them can destroy a file that is already
-there, and none has a check-then-write window another process can slip through. `std::fs::rename`
-silently replaces its target on Unix and is never used here.
+there. The one compatibility path is a directory on a mount identified exactly as `fuse.rclone` in
+`/proc/self/mountinfo`: rclone 1.75 returns `EINVAL` for `RENAME_NOREPLACE` even though its ordinary
+directory rename works. `renamecompat.rs` then checks the target for Flea's stable collision message
+and uses `std::fs::rename`; safety at the race boundary comes from rclone's own `operations.DirMove`,
+whose interface refuses an existing destination. This exception is never used for a file—rclone's
+file move deliberately accepts an object to overwrite—or on another filesystem. Mountinfo's escaped
+mount point is decoded and the deepest enclosing mount wins, so a nested non-rclone mount cannot
+inherit the exception. The parser, scope, successful fallback, and occupied-target refusal have Rust
+tests; the original failure and both outcomes were also reproduced through the real backend on the
+operator's `~/google` mount.
 
 **The journal records only what an operation created or moved.** `undo.rs`'s `Step` has exactly four
 shapes: `Moved` (rename back), `Created` (remove it), `MadeDir` (remove it while it is still empty, because

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -13,7 +13,9 @@ makedepends=('cargo')
 optdepends=('libarchive: archive listing and extraction'
             '7zip: 7z archive support'
             'imagemagick: image conversion'
-            'tailscale: Taildrop sharing')
+            'avahi: zero-configuration LAN discovery'
+            'tailscale: tailnet discovery and Taildrop sharing'
+            'wl-clipboard: copy network addresses')
 # The release profile strips, so a debug package would have nothing to hold.
 options=('!debug')
 # Empty on purpose: with no source array makepkg builds from $startdir, so a clone is the source.

--- a/README.md
+++ b/README.md
@@ -45,9 +45,10 @@ preference and not a file of the package's: run `flea --default off` first, or s
 rather track it. Building from a clone still works too, and is what the repository's own `PKGBUILD`
 is for: `git clone https://github.com/thisisgm/flea.git && cd flea && makepkg -si`.
 
-Four optional packages each unlock one feature and nothing else: `libarchive` for archive listing
-and extraction, `7zip` for `.7z` archives, `imagemagick` for image conversion, and `tailscale` for
-Taildrop sharing.
+Optional packages each unlock one feature and nothing else: `libarchive` for archive listing and
+extraction, `7zip` for `.7z` archives, `imagemagick` for image conversion, `avahi` for automatic
+LAN discovery, `tailscale` for tailnet discovery and Taildrop, and `wl-clipboard` for copying a
+network address.
 
 [`docs/install.md`](docs/install.md) has the rest: what lands on disk, what `flea --default` writes
 and how to undo it by hand, and how the package proves itself.
@@ -323,10 +324,14 @@ the name is one typed word away.
 - **File operations with an undo journal.** Copy, cut, paste, trash, rename, duplicate,
   compress, extract and convert, each reversible with `z`. Copies and moves between two GVFS
   network mounts use that same cancellable, undoable backend and identify the remote-to-remote path.
-- **Network and cloud in the rail.** SMB and NFS mounts through `gio`, Taildrop to a peer,
-  and Dropbox as a first-class destination. Local disks and removable volumes group below them
-  under DEVICES, which the screenshots here crop away rather than retouch: that row is labelled
-  with the machine's own hostname.
+- **Network and cloud in the rail.** SFTP, SMB, NFS, FTPS, and WebDAV mount through `gio`.
+  Flea discovers Avahi services on the LAN and machines on your tailnet, while keeping Tailscale
+  as the private route rather than pretending it is a filesystem. Quick Connect accepts forms
+  such as `nas/photos` and `pi@box:/home/pi`; successful connections become bounded recents.
+  The row menu can reconnect, unmount, copy an address, open SSH, send with Taildrop, or wake a
+  saved LAN machine. Copies between two GVFS mounts use the normal cancellable transfer backend.
+  Dropbox remains a first-class destination. Local disks and removable volumes group below them
+  under DEVICES, which the screenshots here crop away rather than retouch.
 - **A path bar and directory tabs.** `:` or `Ctrl+L` types a path, with Tab completion over the
   directories one level down; `t`, `w` and `1` to `9` open, close and switch up to nine tabs in
   one window, and only one listing is ever live.
@@ -405,6 +410,7 @@ flea --gui [path]          # force the window
 flea --tui [path]          # force the terminal interface (not built yet)
 flea --select <uri|path>   # open the containing directory with that entry selected
 flea --default [off]       # become the desktop's default file manager, or stop being it
+flea --wake <mac>          # internal Wake-on-LAN action used by the network rail
 ```
 
 `--tui` and `--gui` are mutually exclusive. With neither given, `flea` opens the terminal

--- a/README.md
+++ b/README.md
@@ -321,7 +321,8 @@ the name is one typed word away.
 - **Thumbnailing is mandatory-sandboxed.** Without `bwrap` and `prlimit` on `PATH` the job
   is refused rather than run unconfined.
 - **File operations with an undo journal.** Copy, cut, paste, trash, rename, duplicate,
-  compress, extract and convert, each reversible with `z`.
+  compress, extract and convert, each reversible with `z`. Copies and moves between two GVFS
+  network mounts use that same cancellable, undoable backend and identify the remote-to-remote path.
 - **Network and cloud in the rail.** SMB and NFS mounts through `gio`, Taildrop to a peer,
   and Dropbox as a first-class destination. Local disks and removable volumes group below them
   under DEVICES, which the screenshots here crop away rather than retouch: that row is labelled

--- a/TODOLIST.md
+++ b/TODOLIST.md
@@ -1,0 +1,144 @@
+# Network tricks delivery checklist
+
+This branch is stacked on upstream PR #21. Tailscale is treated as a private routed network,
+never as a filesystem protocol: Flea discovers peers through Tailscale, then reaches their files
+through SFTP, SMB, NFS, or WebDAV.
+
+## Completion rules
+
+- [x] Do not check an implementation item until its named automated test exists and passes.
+- [x] For every command-driven feature, cover failure, empty, malformed, unavailable, and timeout cases where the command can produce them.
+- [x] Keep every Rust/QML file under 400 lines and every JavaScript file under 300 lines.
+- [x] Run the complete runnable test matrix once, fix every product regression, then run it again.
+- [x] Record both clean verification passes below; one pass cannot satisfy both boxes.
+
+## 1. Tailscale peer discovery
+
+- [x] Parse all usable non-relay peers, including offline peers, without conflating Taildrop eligibility.
+- [x] Add discovered peer rows to NETWORK with online/offline state and stable identity.
+- [x] Open a peer through a chosen file protocol, defaulting to SFTP rather than inventing a Tailscale filesystem.
+- [x] Tests: `tests/js/tailnet.js`, `tests/js/places.js`, and `tests/network-services.sh`.
+
+## 2. Zero-configuration LAN discovery
+
+- [x] Parse bounded `avahi-browse -artp` output for SSH, SMB, NFS, and WebDAV services.
+- [x] Deduplicate discovered services against bookmarks and live mounts.
+- [x] Keep discovery optional: absent, malformed, failed, or timed-out Avahi must leave manual mounts working.
+- [x] Tests: `tests/js/discovery.js`, `tests/js/places.js`, and `tests/network-services.sh`.
+
+## 3. Quick Connect
+
+- [x] Parse `user@host:/path`, `host:/path`, `host/share`, full URIs, IPv4, and IPv6 safely.
+- [x] Show the normalized URI before saving and never guess SMB when an explicit scheme exists.
+- [x] Wire Quick Connect into the existing network dialog without weakening the structured form.
+- [x] Tests: `tests/js/quickconnect.js`, protocol tests, and the updated `tests/ui.sh network` case.
+
+## 4. Favorites and recent connections
+
+- [x] Keep GTK network bookmarks as favorites and add a bounded, deduplicated recent-success list.
+- [x] A failed attempt must not become recent; a successful open must move one connection to the front.
+- [x] Persist recents atomically without storing passwords, tokens, or embedded URI secrets.
+- [x] Tests: `tests/js/recents.js` and FileView persistence in `tests/network-services.sh`.
+
+## 5. Connection health
+
+- [x] Represent discovered/bookmarked peers as online, offline, unknown, connecting, mounted, or failed.
+- [x] Preserve the last good rail during a timed-out poll and expose a precise status sentence.
+- [x] Bound every discovery/health process; no dead host may freeze the rail.
+- [x] Tests: health-state units and wedged Quickshell processes in `tests/network-services.sh`.
+
+## 6. Remote context actions
+
+- [x] Add Copy address, Open terminal over SSH, Send with Taildrop when eligible, Reconnect, and Unmount.
+- [x] Gate actions by capability and state; a row must never offer an action that cannot run.
+- [x] Keep argv boundaries intact for hostile labels, hosts, users, ports, and paths.
+- [x] Tests: `tests/js/remote.js`, `tests/js/mounts.js`, and stubbed commands in `tests/network-services.sh`.
+
+## 7. Wake-on-LAN
+
+- [x] Validate and normalize MAC addresses before any packet is sent.
+- [x] Send the canonical magic packet without a shell and report success/failure precisely.
+- [x] Offer Wake only to saved LAN entries carrying a valid MAC; never to Tailscale-only peers.
+- [x] Tests: Rust packet/validation tests, `tests/modes.sh`, and the non-network stub in `tests/network-services.sh`.
+
+## 8. Remote-to-remote transfers
+
+- [x] Recognize when source and destination are mounted remote paths while reusing the existing copy/move backend.
+- [x] Make the transfer explicit in status/progress text and preserve cancel/partial-file guarantees.
+- [x] Prove copy and move between two synthetic mounted roots; the shared backend's failure and cancellation tests remain authoritative.
+- [x] Tests: `tests/ops.sh`, Rust copy/move failure/cancel tests, and `tests/js/remote.js`/`tests/js/ops.js`.
+
+## 9. Tailscale troubleshooting
+
+- [x] Distinguish CLI missing, daemon stopped, logged out, no peers, and ready.
+- [x] Show recovery guidance without executing privileged or authentication-changing commands.
+- [x] Keep ordinary LAN/GIO connections available in every Tailscale failure state.
+- [x] Tests: `tests/js/tailnet.js` plus stubbed CLI process coverage for every state.
+
+## Verification pass 1
+
+- [x] `cargo clean && cargo build && cargo build --release && cargo test && cargo test --release`
+- [x] `./tests/run-all.sh` — 13 suites, 0 failed; final pushed head has 1,270 JS/QML checks.
+- [ ] `tests/ui.sh network networkedit sharebrowser unmount taildrop` — blocked locally because `omarchy-drive` is not installed; the real GUI loads and the process-level network harness passes.
+- [x] `./tools/flea-qmllint-gate`
+- [x] `./tools/flea-file-budget`
+- [x] `git diff --check`
+- [x] Real GUI instantiation: `flea --gui /tmp` reached `Configuration Loaded` and stayed healthy until the deliberate timeout.
+
+## Bug-fix interval
+
+- [x] Bracketed IPv6 was rejected by the inherited protocol parser; covered in `tests/js/protocols.js`.
+- [x] A stale Wake profile survived URI edits or clearing the MAC; covered in `tests/js/recents.js`.
+- [x] A mounted discovered row offered Unmount but the service rejected its kind; the guard now follows capability.
+- [x] Clipboard and Wake reported success before their child exited; success/failure is covered in `tests/network-services.sh`.
+- [x] Recent rows shadowed fresh discovery health, Taildrop, or Wake metadata; covered in `tests/js/places.js`.
+- [x] Delayed unmount cleared its URI before health cleanup; the pending identity now survives through `onExited`.
+- [x] Bare-server share listing could hang forever; a wedged `gio list` is covered in `tests/network-services.sh`.
+- [x] Explicit/shorthand Quick Connect could persist query tokens or fragments; covered in `tests/js/quickconnect.js`.
+- [x] IPv6 copy-address text lost one bracket and custom SSH ports were unusable; covered in place/action tests.
+- [x] The repository fixture/dependency failures were environmental, not product regressions: tests passed with namespace access, optional `7zip`, and the documented guarded media fixture.
+
+## Verification pass 2
+
+- [x] Repeat the clean four-profile Rust warning gate — 345 tests per profile, zero warnings.
+- [x] Repeat `./tests/run-all.sh` from fresh fixtures — 13 suites, 0 failed; final pushed head has 1,270 JS/QML checks.
+- [x] Repeat the process-level network cases from fresh stubs/fixtures; repeat real GUI loading.
+
+## Pointer scrolling follow-up
+
+- [x] Reproduce the slow default Qt wheel behavior and adopt the existing PR #16 four-times policy calibrated against Chromium.
+- [x] Use one shared vertical-scroll policy for list, grid, Miller columns, sidebar, text preview, and PDF preview.
+- [x] Preserve smooth touchpad pixels, discrete wheel-line preferences, hard bounds, pointer taps, and drag ownership.
+- [x] Let wheel input propagate at a scroll boundary instead of trapping nested views.
+- [x] Add deterministic unit coverage for pixel deltas, wheel notches, direction, multiplier, empty input, and both bounds.
+- [x] Add structural coverage proving all nine shipped vertical scroll surfaces use the shared policy exactly once.
+- [x] Run the complete runnable test matrix twice after the scrolling fix, plus QML lint, file budgets, and diff checks.
+- [x] Record the pointer-driver gap: `omarchy-drive` is neither installed, packaged, nor published under that name; `tests/scroll.sh`, two real Wayland loads, and process-level QML are the available substitutes.
+- [x] Split and push: scrolling follow-up `stappmus/flea#1`, remote transfers `thisisgm/flea#31`, reusable-process fix `thisisgm/flea#33`, and stacked network productivity `thisisgm/flea#32`; merge the follow-up into #16 first, then #16/#21/#31/#33 in any order, followed by #32.
+- [x] Repeat QML lint, file-budget, and whitespace gates.
+- [ ] Repeat pointer-driven `tests/ui.sh` cases when `omarchy-drive` is available.
+
+## Follow-up adversarial audit
+
+- [x] Trace every reusable QML `Process` and its collector fallback across consecutive runs.
+- [x] Reproduce stale raw output crossing six command boundaries: network mount stderr, share info,
+      server rows, mount polling, device polling, and Taildrop status.
+- [x] Clear each fallback only after its overlap guard and immediately before starting the process.
+- [x] Add `tests/process-output.sh`; poison all six fallbacks and exercise the real QML Process objects.
+- [x] Mutation-test the guard: deleting one reset makes the new suite fail.
+- [x] Run the independent main-based branch twice — 11 suites, 0 failures, 1,153 JS/QML checks.
+- [x] Carry the exact fix into the stacked network branch — 13 suites, 0 failures, 1,270 checks.
+- [x] Push independent PR #33 and update stacked PR #32's dependency record.
+
+## rclone directory-rename follow-up
+
+- [x] Reproduce New Folder creating its directory in `~/google` and the automatic rename failing with `EINVAL`.
+- [x] Confirm the mount is `fuse.rclone`, `RENAME_NOREPLACE` is the rejected operation, and ordinary directory rename succeeds.
+- [x] Keep atomic no-clobber rename everywhere except real directories on exactly `fuse.rclone`.
+- [x] Preserve collision refusal, exclude files and symlinks, and use the deepest decoded mountinfo entry.
+- [x] Add unit coverage for mount parsing, successful fallback, occupied destinations, and excluded scopes.
+- [x] Verify the fixed backend against the real `~/google` mount for both success and collision safety.
+- [x] Run clean debug/release builds and tests — 345 tests per profile on the combined branch.
+- [x] Run the full 13-suite harness twice — 0 failures and 1,270 JS/QML checks per pass.
+- [x] Push independent PR #35 and carry its exact commit into stacked PR #32.
+- [x] Point the existing `~/bin/flea` wrapper at the tested branch's matching binary and QML tree; verify a real Wayland launch reaches `Configuration Loaded`.

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -44,6 +44,7 @@ pub mod copyfile;
 pub mod ops;
 pub mod opsdispatch;
 pub mod opsreq;
+mod renamecompat;
 pub mod trash;
 pub mod undo;
 // Test-only: hard rule 9's sandbox root, so no destructive test names a path outside one.

--- a/src/backend/ops.rs
+++ b/src/backend/ops.rs
@@ -1,46 +1,24 @@
 // Rename, duplicate and mkdir: the three operations that answer once, with no started or progress split.
 use crate::backend::copyfile::{copy_any, Progress};
+use crate::backend::renamecompat;
 use crate::backend::undo::Step;
 use crate::error::{from_io, FleaError};
-use std::ffi::CString;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::AtomicBool;
 
-// renameat2's dirfd argument meaning "relative to the current directory"; both paths here are absolute, so it is never consulted.
-const AT_FDCWD: i32 = -100;
-// RENAME_NOREPLACE: fail with EEXIST rather than silently destroying whatever is already at the target.
-const RENAME_NOREPLACE: u32 = 1;
 // How many " copy N" names duplicate will try before giving up rather than looping forever.
 const NAME_TRIES: usize = 999;
 // The default a nameless mkdir starts from, then "New Folder 2" and up while the name is taken.
 const NEW_FOLDER: &str = "New Folder";
-
-// std has no wrapper for the flag that makes rename refuse to clobber, so the syscall is declared here rather than taking a crate.
-extern "C" {
-    fn renameat2(olddirfd: i32, oldpath: *const i8, newdirfd: i32, newpath: *const i8, flags: u32) -> i32;
-}
 
 // A name from the client is a trust boundary: anything with a separator would move the file out of its own directory.
 pub fn valid_name(name: &str) -> bool {
     !name.is_empty() && name != "." && name != ".." && !name.contains('/') && !name.contains('\0')
 }
 
-// Rename that refuses to overwrite. std::fs::rename silently replaces the target on Unix, which for a file manager is unrecoverable data loss.
+// Rename that refuses to overwrite. std::fs::rename alone can replace a target on Unix.
 pub fn rename_noreplace(from: &Path, to: &Path) -> Result<(), FleaError> {
-    let (c_from, c_to) = match (path_c(from), path_c(to)) {
-        (Some(a), Some(b)) => (a, b),
-        // corner: a path with an interior NUL cannot reach a syscall, and no listing can produce one.
-        _ => return Err(named("rename", to, "path contains an interior NUL")),
-    };
-    let rc = unsafe { renameat2(AT_FDCWD, c_from.as_ptr(), AT_FDCWD, c_to.as_ptr(), RENAME_NOREPLACE) };
-    if rc == 0 {
-        return Ok(());
-    }
-    Err(from_io("rename", &to.to_string_lossy(), &std::io::Error::last_os_error()))
-}
-
-fn path_c(p: &Path) -> Option<CString> {
-    CString::new(p.as_os_str().as_encoded_bytes()).ok()
+    renamecompat::rename_noreplace(from, to).map_err(|e| from_io("rename", &to.to_string_lossy(), &e))
 }
 
 fn named(where_: &str, path: &Path, msg: &str) -> FleaError {

--- a/src/backend/renamecompat.rs
+++ b/src/backend/renamecompat.rs
@@ -1,0 +1,189 @@
+// Linux's atomic no-clobber rename, plus the one compatibility exception this product has measured.
+use std::ffi::{CString, OsString};
+use std::io;
+use std::os::unix::ffi::OsStringExt;
+use std::path::{Path, PathBuf};
+
+// Both paths passed here are absolute, so renameat2 never consults AT_FDCWD.
+const AT_FDCWD: i32 = -100;
+const RENAME_NOREPLACE: u32 = 1;
+const EINVAL: i32 = 22;
+const EEXIST: i32 = 17;
+
+extern "C" {
+    fn renameat2(
+        olddirfd: i32,
+        oldpath: *const i8,
+        newdirfd: i32,
+        newpath: *const i8,
+        flags: u32,
+    ) -> i32;
+}
+
+// rclone's FUSE server rejects RENAME_NOREPLACE with EINVAL, but its ordinary directory rename
+// calls operations.DirMove, whose contract refuses an existing destination. Files are excluded:
+// rclone's file move deliberately accepts a destination object to overwrite.
+pub fn rename_noreplace(from: &Path, to: &Path) -> io::Result<()> {
+    let c_from = path_c(from)?;
+    let c_to = path_c(to)?;
+    let rc = unsafe {
+        renameat2(
+            AT_FDCWD,
+            c_from.as_ptr(),
+            AT_FDCWD,
+            c_to.as_ptr(),
+            RENAME_NOREPLACE,
+        )
+    };
+    if rc == 0 {
+        return Ok(());
+    }
+    let error = io::Error::last_os_error();
+    if error.raw_os_error() == Some(EINVAL) {
+        if let Ok(body) = std::fs::read_to_string("/proc/self/mountinfo") {
+            if let Some(result) = rclone_directory_fallback(from, to, &body) {
+                return result;
+            }
+        }
+    }
+    Err(error)
+}
+
+fn rclone_directory_fallback(from: &Path, to: &Path, mountinfo: &str) -> Option<io::Result<()>> {
+    match from.symlink_metadata() {
+        Ok(meta) if meta.file_type().is_dir() => {}
+        Ok(_) => return None,
+        Err(e) => return Some(Err(e)),
+    }
+    if mount_type_in(from, mountinfo).as_deref() != Some("fuse.rclone") {
+        return None;
+    }
+    // Preserve Flea's stable collision result before entering the compatibility operation. If a
+    // destination arrives after this check, rclone's DirMove performs the authoritative refusal.
+    match to.symlink_metadata() {
+        Ok(_) => return Some(Err(io::Error::from_raw_os_error(EEXIST))),
+        Err(e) if e.kind() == io::ErrorKind::NotFound => {}
+        Err(e) => return Some(Err(e)),
+    }
+    Some(std::fs::rename(from, to))
+}
+
+fn path_c(path: &Path) -> io::Result<CString> {
+    CString::new(path.as_os_str().as_encoded_bytes())
+        .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "path contains an interior NUL"))
+}
+
+// The longest enclosing mount wins. mountinfo escapes whitespace and backslashes as octal bytes.
+fn mount_type_in(path: &Path, body: &str) -> Option<String> {
+    let mut best: Option<(usize, String)> = None;
+    for line in body.lines() {
+        let fields: Vec<&str> = line.split_whitespace().collect();
+        let split = match fields.iter().position(|field| *field == "-") {
+            Some(value) => value,
+            None => continue,
+        };
+        if fields.len() <= split + 1 || fields.len() < 5 {
+            continue;
+        }
+        let mount = PathBuf::from(OsString::from_vec(unescape(fields[4])));
+        if !path.starts_with(&mount) {
+            continue;
+        }
+        let depth = mount.components().count();
+        if best.as_ref().map(|(old, _)| depth >= *old).unwrap_or(true) {
+            best = Some((depth, fields[split + 1].to_string()));
+        }
+    }
+    best.map(|(_, kind)| kind)
+}
+
+fn unescape(field: &str) -> Vec<u8> {
+    let bytes = field.as_bytes();
+    let mut out = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'\\'
+            && i + 3 < bytes.len()
+            && bytes[i + 1..=i + 3]
+                .iter()
+                .all(|b| (b'0'..=b'7').contains(b))
+        {
+            out.push((bytes[i + 1] - b'0') * 64 + (bytes[i + 2] - b'0') * 8 + bytes[i + 3] - b'0');
+            i += 4;
+        } else {
+            out.push(bytes[i]);
+            i += 1;
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::backend::testdir::TestDir;
+
+    #[test]
+    fn deepest_mount_identifies_rclone_and_decodes_its_path() {
+        let info = "1 0 8:1 / / rw - ext4 /dev/a rw\n\
+                    2 1 0:9 / /home/pi/My\\040Drive rw - fuse.rclone remote: rw\n\
+                    3 2 0:10 / /home/pi/My\\040Drive/nested rw - tmpfs tmpfs rw\n";
+        assert_eq!(
+            mount_type_in(Path::new("/home/pi/My Drive/file"), info).as_deref(),
+            Some("fuse.rclone")
+        );
+        assert_eq!(
+            mount_type_in(Path::new("/home/pi/My Drive/nested/file"), info).as_deref(),
+            Some("tmpfs")
+        );
+        assert_eq!(
+            mount_type_in(Path::new("/elsewhere"), info).as_deref(),
+            Some("ext4")
+        );
+    }
+
+    #[test]
+    fn malformed_mountinfo_is_ignored() {
+        assert_eq!(mount_type_in(Path::new("/home/pi"), "junk\n"), None);
+    }
+
+    #[test]
+    fn rclone_directory_fallback_renames_without_replacing() {
+        let d = TestDir::new("rclonerename");
+        let source = d.dir("source");
+        let target = d.join("renamed");
+        let info = format!(
+            "1 0 0:1 / {} rw - fuse.rclone remote: rw\n",
+            d.path().display()
+        );
+        rclone_directory_fallback(&source, &target, &info)
+            .expect("the rclone directory path is eligible")
+            .expect("ordinary rclone directory rename");
+        assert!(!source.exists());
+        assert!(target.is_dir());
+
+        let source = d.dir("another");
+        let occupied = d.dir("occupied");
+        let error = rclone_directory_fallback(&source, &occupied, &info)
+            .expect("rclone directory")
+            .expect_err("an existing target must never be replaced");
+        assert_eq!(error.raw_os_error(), Some(EEXIST));
+        assert!(source.is_dir());
+        assert!(occupied.is_dir());
+    }
+
+    #[test]
+    fn fallback_is_never_used_for_files_or_other_filesystems() {
+        let d = TestDir::new("rclonerenamescope");
+        let file = d.file("file", "body");
+        let target = d.join("target");
+        let rclone = format!(
+            "1 0 0:1 / {} rw - fuse.rclone remote: rw\n",
+            d.path().display()
+        );
+        let ext4 = format!("1 0 8:1 / {} rw - ext4 /dev/a rw\n", d.path().display());
+        assert!(rclone_directory_fallback(&file, &target, &rclone).is_none());
+        assert!(rclone_directory_fallback(d.path(), &target, &ext4).is_none());
+        assert_eq!(std::fs::read_to_string(file).unwrap(), "body");
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ mod open;
 mod paths;
 mod thp;
 mod userfile;
+mod wol;
 
 use crate::backend::proto::error_line;
 use std::io::IsTerminal;
@@ -64,6 +65,17 @@ fn main() {
     // flea --open <path>
     if args.len() == 3 && args[1] == "--open" {
         exit(open::open(&args[2]));
+    }
+
+    // flea --wake <mac>: internal GUI action, kept argv-direct so a hostile value never reaches a shell.
+    if args.len() == 3 && args[1] == "--wake" {
+        match wol::wake(&args[2]) {
+            Ok(()) => exit(0),
+            Err(message) => {
+                eprintln!("flea: {message}");
+                exit(1);
+            }
+        }
     }
 
     // flea --default [off]: the one per-user step pacman cannot own, see docs/install.md.

--- a/src/wol.rs
+++ b/src/wol.rs
@@ -1,0 +1,65 @@
+use std::net::UdpSocket;
+
+const MAGIC_LEN: usize = 6 + 16 * 6;
+
+pub fn normalize_mac(raw: &str) -> Result<[u8; 6], String> {
+    let compact: String = raw.chars().filter(|c| *c != ':' && *c != '-').collect();
+    if compact.len() != 12 || !compact.bytes().all(|b| b.is_ascii_hexdigit()) {
+        return Err("Wake needs a MAC address like aa:bb:cc:dd:ee:ff".to_string());
+    }
+    let mut mac = [0u8; 6];
+    for (i, byte) in mac.iter_mut().enumerate() {
+        *byte = u8::from_str_radix(&compact[i * 2..i * 2 + 2], 16)
+            .map_err(|_| "Wake needs a valid hexadecimal MAC address".to_string())?;
+    }
+    Ok(mac)
+}
+
+pub fn magic_packet(mac: [u8; 6]) -> [u8; MAGIC_LEN] {
+    let mut packet = [0u8; MAGIC_LEN];
+    packet[..6].fill(0xff);
+    for chunk in packet[6..].chunks_exact_mut(6) {
+        chunk.copy_from_slice(&mac);
+    }
+    packet
+}
+
+pub fn wake(raw: &str) -> Result<(), String> {
+    let mac = normalize_mac(raw)?;
+    let socket = UdpSocket::bind("0.0.0.0:0").map_err(|e| format!("could not open a Wake socket: {e}"))?;
+    socket.set_broadcast(true).map_err(|e| format!("could not enable broadcast: {e}"))?;
+    socket.send_to(&magic_packet(mac), "255.255.255.255:9")
+        .map_err(|e| format!("could not send the Wake packet: {e}"))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accepts_colon_dash_and_compact_mac_addresses() {
+        let want = [0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff];
+        assert_eq!(normalize_mac("aa:bb:cc:dd:ee:ff").unwrap(), want);
+        assert_eq!(normalize_mac("AA-BB-CC-DD-EE-FF").unwrap(), want);
+        assert_eq!(normalize_mac("aabbccddeeff").unwrap(), want);
+    }
+
+    #[test]
+    fn rejects_wrong_length_non_hex_and_unrecognised_separators() {
+        assert!(normalize_mac("aa:bb").is_err());
+        assert!(normalize_mac("gg:bb:cc:dd:ee:ff").is_err());
+        assert!(normalize_mac("aa.bb.cc.dd.ee.ff").is_err());
+    }
+
+    #[test]
+    fn a_magic_packet_has_six_ff_bytes_then_sixteen_mac_copies() {
+        let mac = [0, 1, 2, 3, 4, 5];
+        let packet = magic_packet(mac);
+        assert_eq!(packet.len(), 102);
+        assert_eq!(&packet[..6], &[0xff; 6]);
+        for chunk in packet[6..].chunks_exact(6) {
+            assert_eq!(chunk, mac);
+        }
+    }
+}

--- a/tests/js/discovery.js
+++ b/tests/js/discovery.js
@@ -1,0 +1,21 @@
+.import "../../ui/js/Discovery.js" as Discovery
+
+function run(check) {
+    var body = [
+        '=;eth0;IPv4;Office\\032SSH;_ssh._tcp;local;workstation.local;192.168.1.8;22;"mac=aa:bb:cc:dd:ee:ff"',
+        '=;eth0;IPv6;IPv6 SSH;_ssh._tcp;local;;fe80::1;22;',
+        '=;eth0;IPv4;NAS;_smb._tcp;local;nas.local;192.168.1.9;445;',
+        '=;eth0;IPv4;Secure Docs;_webdavs._tcp;local;docs.local;192.168.1.10;8443;',
+        '+;eth0;IPv4;Unresolved;_ssh._tcp;local',
+        '=;eth0;IPv4;Ignored;_printer._tcp;local;print.local;192.168.1.11;631;',
+        '=;eth0;IPv4;Bad;_ssh._tcp;local;bad host;192.168.1.12;22;'
+    ].join('\n')
+    var rows = Discovery.parse(body)
+    check("only supported resolved services survive", rows.length, 4)
+    check("Avahi decimal escapes decode", rows.map(function (r) { return r.label }).indexOf("Office SSH") >= 0, true)
+    check("default ports normalize away", rows.filter(function (r) { return r.label === "NAS" })[0].uri, "smb://nas.local/")
+    check("non-default ports survive", rows.filter(function (r) { return r.label === "Secure Docs" })[0].uri, "davs://docs.local:8443/")
+    check("IPv6 is bracketed", rows.filter(function (r) { return r.uri.indexOf("fe80") >= 0 })[0].uri, "sftp://[fe80::1]/")
+    check("a TXT MAC is normalized for Wake", rows.filter(function (r) { return r.label === "Office SSH" })[0].mac, "aa:bb:cc:dd:ee:ff")
+    check("empty and malformed discovery are harmless", Discovery.parse("garbage\n").length, 0)
+}

--- a/tests/js/focus.js
+++ b/tests/js/focus.js
@@ -2,7 +2,6 @@
 
 // Focus.lookup is where a key is discarded for being meaningless in the current state, and a wrong
 // gate there is silent: the key simply does nothing, and no suite but this one would notice.
-
 function pane(preview, viewMode) {
     return {
         focusView: "list",

--- a/tests/js/harness.qml
+++ b/tests/js/harness.qml
@@ -20,6 +20,7 @@ import "palette.js" as PaletteSuite
 import "pathbar.js" as PathBarSuite
 import "places.js" as PlacesSuite
 import "protocols.js" as ProtocolsSuite
+import "remote.js" as RemoteSuite
 import "scale.js" as ScaleSuite
 import "search.js" as SearchSuite
 import "selection.js" as SelectionSuite
@@ -64,6 +65,7 @@ Item {
         PathBarSuite.run(check)
         PlacesSuite.run(check)
         ProtocolsSuite.run(check)
+        RemoteSuite.run(check)
         ScaleSuite.run(check)
         SearchSuite.run(check)
         SelectionSuite.run(check)

--- a/tests/js/harness.qml
+++ b/tests/js/harness.qml
@@ -3,6 +3,7 @@ import "archive.js" as ArchiveSuite
 import "columns.js" as ColumnsSuite
 import "contrast.js" as ContrastSuite
 import "dirsizes.js" as DirSizesSuite
+import "discovery.js" as DiscoverySuite
 import "drag.js" as DragSuite
 import "errors.js" as ErrorsSuite
 import "facts.js" as FactsSuite
@@ -20,12 +21,15 @@ import "palette.js" as PaletteSuite
 import "pathbar.js" as PathBarSuite
 import "places.js" as PlacesSuite
 import "protocols.js" as ProtocolsSuite
+import "quickconnect.js" as QuickConnectSuite
+import "recents.js" as RecentsSuite
 import "remote.js" as RemoteSuite
 import "scale.js" as ScaleSuite
 import "search.js" as SearchSuite
 import "selection.js" as SelectionSuite
 import "sort.js" as SortSuite
 import "taildrop.js" as TaildropSuite
+import "tailnet.js" as TailnetSuite
 import "trash.js" as TrashSuite
 import "tap.js" as TapSuite
 import "tabs.js" as TabsSuite
@@ -48,6 +52,7 @@ Item {
         ColumnsSuite.run(check)
         ContrastSuite.run(check)
         DirSizesSuite.run(check)
+        DiscoverySuite.run(check)
         DragSuite.run(check)
         ErrorsSuite.run(check)
         FactsSuite.run(check)
@@ -65,12 +70,15 @@ Item {
         PathBarSuite.run(check)
         PlacesSuite.run(check)
         ProtocolsSuite.run(check)
+        QuickConnectSuite.run(check)
+        RecentsSuite.run(check)
         RemoteSuite.run(check)
         ScaleSuite.run(check)
         SearchSuite.run(check)
         SelectionSuite.run(check)
         SortSuite.run(check)
         TaildropSuite.run(check)
+        TailnetSuite.run(check)
         TrashSuite.run(check)
         TapSuite.run(check)
         TabsSuite.run(check)

--- a/tests/js/menu.js
+++ b/tests/js/menu.js
@@ -48,6 +48,14 @@ function run(check) {
           Menu.clamp(-40, railMenu, pane), 0)
     check("a frame taller than the pane pins to the near edge, which is where its tail is cut",
           Menu.clamp(700, 1200, pane), 0)
+    check("a tall menu is bounded to the viewport instead of cutting off its tail",
+          Menu.boundedExtent(1200, pane), 800)
+    check("an ordinary flyout opens on the right",
+          Menu.adjacentX(100, 240, 240, pane), 340)
+    check("a flyout near the far edge opens wholly on the left",
+          Menu.adjacentX(560, 240, 240, pane), 320)
+    check("a flyout wider than the viewport still pins to the near edge",
+          Menu.adjacentX(0, 240, 1200, pane), 0)
 }
 
 // ui/js/Menu.js listingEntries: the listing's rows, built from the pane's state in one object.

--- a/tests/js/mounts.js
+++ b/tests/js/mounts.js
@@ -48,13 +48,13 @@ function run(check) {
     var bareRoot = 'smb://192.168.1.10/\n'
     check("a bare server root with no label falls back to the host", Mounts.nonFileBookmarks(bareRoot)[0].label, "192.168.1.10")
 
-    // Item 4: one canonical form, so a share dedupes against itself regardless of who typed the slash.
+    // Item 4: one canonical form, so a share dedupes against itself regardless of slash or default port.
     check("a share uri normalizes its trailing slash away", Mounts.normalize("smb://h/data/"), "smb://h/data")
-    check("a share uri with no trailing slash is already canonical", Mounts.normalize("smb://h/data"), "smb://h/data")
-    check("smb://h/data and smb://h/data/ cannot coexist as two rows", Mounts.normalize("smb://h/data") === Mounts.normalize("smb://h/data/"), true)
-    check("a bare server root keeps its one trailing slash", Mounts.normalize("smb://h/"), "smb://h/")
-    check("a bare server root typed with no slash still canonicalizes to one", Mounts.normalize("smb://h"), "smb://h/")
+    check("a bare server root keeps one trailing slash either way", Mounts.normalize("smb://h/") + "|" + Mounts.normalize("smb://h"), "smb://h/|smb://h/")
     check("two different shares stay distinct after normalizing", Mounts.normalize("smb://h/data/") === Mounts.normalize("smb://h/other/"), false)
+    check("the form's default sftp port is the same share gio reports without one", Mounts.normalize("sftp://tom@h:22/home/tom"), "sftp://tom@h/home/tom")
+    check("a default port on a bare root still keeps the slash", Mounts.normalize("sftp://tom@h:22/"), "sftp://tom@h/")
+    check("a non-default port is kept", Mounts.normalize("sftp://tom@h:2222/home"), "sftp://tom@h:2222/home")
 
     // Real lsblk --json output, captured on the box with a USB stick plugged in (2026-09-02).
     // ui/DeviceMounts.qml feeds this exact command's stdout to parseDevices on the rail's own clock.

--- a/tests/js/mounts.js
+++ b/tests/js/mounts.js
@@ -196,21 +196,19 @@ function run(check) {
     var dropbox = { label: "Dropbox", group: "network", kind: "dropbox", uri: "", mounted: true }
     var favourite = { label: "Home", group: "favorite", kind: "favorite", path: "/home/user" }
 
-    check("a mounted removable volume offers one row", Mounts.railMenu(volume).length, 1)
-    check("and that row is Eject", Mounts.railMenu(volume)[0].label, "Eject")
-    check("the Eject row carries the eject action", Mounts.railMenu(volume)[0].action, "eject")
-    check("the Eject row draws the eject mark", Mounts.railMenu(volume)[0].glyph, "eject")
-    check("a mounted network share offers one row", Mounts.railMenu(share).length, 1)
-    check("and that row is Unmount", Mounts.railMenu(share)[0].label, "Unmount")
-    check("the Unmount row carries the unmount action", Mounts.railMenu(share)[0].action, "unmount")
-    check("the shelf lists eject for unmount too, so Unmount draws it", Mounts.railMenu(share)[0].glyph, "eject")
+    check("a mounted removable volume offers Eject", Mounts.railMenu(volume).map(function (r) { return r.action }).join("|"), "eject")
+    check("and that row is named and marked", Mounts.railMenu(volume)[0].label + "/" + Mounts.railMenu(volume)[0].glyph, "Eject/eject")
+    check("a mounted network share offers Unmount then Edit", Mounts.railMenu(share).map(function (r) { return r.action }).join("|"), "unmount|edit")
+    check("Unmount stays first so Ctrl+E still unmounts", Mounts.railMenu(share)[0].label + "/" + Mounts.railMenu(share)[0].glyph, "Unmount/eject")
+    check("Edit draws the rename mark", Mounts.railMenu(share)[1].label + "/" + Mounts.railMenu(share)[1].glyph, "Edit/rename")
 
     // Every rail row that must never be offered a release, each for its own reason.
     check("the internal disk offers nothing, it is the box's own system disk", Mounts.railMenu(internal).length, 0)
     check("the Dropbox row offers nothing, it is a local folder the stock service owns", Mounts.railMenu(dropbox).length, 0)
     check("a favourite offers nothing, it is not a mount at all", Mounts.railMenu(favourite).length, 0)
     check("an unmounted volume offers nothing, there is nothing to release", Mounts.railMenu(idle).length, 0)
-    check("a bookmark nothing has mounted offers nothing", Mounts.railMenu(bookmark).length, 0)
+    check("a bookmark nothing has mounted offers Edit", Mounts.railMenu(bookmark).map(function (r) { return r.action }).join("|"), "edit")
+    check("Ctrl+E unmounts a live share and ignores a bookmark", Mounts.releaseAction(share) + "|" + Mounts.releaseAction(bookmark), "unmount|")
     check("no entry at all offers nothing rather than throwing", Mounts.railMenu(null).length, 0)
     check("an undefined entry offers nothing rather than throwing", Mounts.railMenu(undefined).length, 0)
 
@@ -289,12 +287,14 @@ function run(check) {
     // The rail menu's chosen row, resolved by key; a key that no longer names a row releases nothing.
     function rec() { var a = []; return { a: a, eject: function (i) { a.push("e" + i) }, unmount: function (i) { a.push("u" + i) } } }
     function released(action, key) {
-        var d = rec(), n = rec()
-        Mounts.release(action, key, d, n, [disk, stick], [{ label: "isos", group: "network", kind: "share", uri: "smb://x/isos/", path: "", mounted: true }])
-        return d.a.concat(n.a).join(",")
+        var d = rec(), n = rec(), edited = []
+        Mounts.release(action, key, d, n, [disk, stick], [{ label: "isos", group: "network", kind: "share", uri: "smb://x/isos/", path: "", mounted: true }],
+            { edit: function (uri, label) { edited.push(uri + " " + label) } })
+        return d.a.concat(n.a, edited).join(",")
     }
     check("eject resolves the volume's position and never the network Service", released("eject", "/dev/sda1"), "e1")
     check("unmount resolves the share's position and never the device Service", released("unmount", "smb://x/isos/"), "u0")
+    check("edit names the share rather than a Service index", released("edit", "smb://x/isos/"), "smb://x/isos/ isos")
     check("a key that no longer names a row releases nothing", released("eject", "/dev/sdz9"), "")
     check("an action that is neither release does nothing", released("forget", "/dev/sda1"), "")
 }

--- a/tests/js/mounts.js
+++ b/tests/js/mounts.js
@@ -185,9 +185,6 @@ function run(check) {
     check("a vanished device names nothing", Eject.blockers(gone, "/dev/sda1").join(","), "")
     check("garbage names nothing", Eject.blockers("not json", "/dev/sda1").join(","), "")
 
-    // The rail's own context menu. Which release a row offers is decided from the kind the rail
-    // already tagged: parseDevices above tags a removable volume "volume" off lsblk's RM flag and
-    // the box's own disk "disk", and ui/NetworkMounts.qml tags a gvfs share "share".
     var volume = { label: "128GB", group: "device", kind: "volume", device: "/dev/sda1", mounted: true }
     var idle = { label: "128GB", group: "device", kind: "volume", device: "/dev/sda1", mounted: false }
     var internal = { label: "nvme0n1", group: "device", kind: "disk", device: "/dev/nvme0n1", mounted: true }
@@ -198,29 +195,25 @@ function run(check) {
 
     check("a mounted removable volume offers Eject", Mounts.railMenu(volume).map(function (r) { return r.action }).join("|"), "eject")
     check("and that row is named and marked", Mounts.railMenu(volume)[0].label + "/" + Mounts.railMenu(volume)[0].glyph, "Eject/eject")
-    check("a mounted network share offers Unmount, Edit, Remove", Mounts.railMenu(share).map(function (r) { return r.action }).join("|"), "unmount|edit|remove")
+    check("a mounted network share offers Unmount, Copy address, Edit, Remove", Mounts.railMenu(share).map(function (r) { return r.action }).join("|"), "unmount|copy-address|edit|remove")
     check("Unmount stays first so Ctrl+E still unmounts", Mounts.railMenu(share)[0].label + "/" + Mounts.railMenu(share)[0].glyph, "Unmount/eject")
-    check("Edit draws the rename mark", Mounts.railMenu(share)[1].label + "/" + Mounts.railMenu(share)[1].glyph, "Edit/rename")
+    check("Edit draws the rename mark", Mounts.railMenu(share)[2].label + "/" + Mounts.railMenu(share)[2].glyph, "Edit/rename")
 
-    // Every rail row that must never be offered a release, each for its own reason.
     check("the internal disk offers nothing, it is the box's own system disk", Mounts.railMenu(internal).length, 0)
     check("the Dropbox row offers nothing, it is a local folder the stock service owns", Mounts.railMenu(dropbox).length, 0)
     check("a favourite offers nothing, it is not a mount at all", Mounts.railMenu(favourite).length, 0)
     check("an unmounted volume offers nothing, there is nothing to release", Mounts.railMenu(idle).length, 0)
-    check("a bookmark nothing has mounted offers Edit then Remove", Mounts.railMenu(bookmark).map(function (r) { return r.action }).join("|"), "edit|remove")
+    check("a bookmark nothing has mounted offers Copy address, Edit, Remove", Mounts.railMenu(bookmark).map(function (r) { return r.action }).join("|"), "copy-address|edit|remove")
     check("Ctrl+E unmounts a live share and ignores a bookmark", Mounts.releaseAction(share) + "|" + Mounts.releaseAction(bookmark), "unmount|")
     check("no entry at all offers nothing rather than throwing", Mounts.railMenu(null).length, 0)
     check("an undefined entry offers nothing rather than throwing", Mounts.railMenu(undefined).length, 0)
 
-    // The safety property as one check: eject reaches exactly one kind of row and no other.
     var never = [idle, internal, dropbox, favourite, bookmark, share, null, undefined]
     check("no row but a mounted removable volume is ever offered eject",
           never.some(function (e) {
               return Mounts.railMenu(e).some(function (r) { return r.action === "eject" })
           }), false)
 
-    // The key a chosen row carries back: the rail rebuilds on a five second poll, so an index taken
-    // when the menu opened can name a different row by the time a row inside it is chosen.
     check("a volume's key is its device node", Mounts.railKey(volume), "/dev/sda1")
     check("a share's key is its uri", Mounts.railKey(share), "smb://example.com/isos/")
     check("the internal disk has no key", Mounts.railKey(internal), "")
@@ -288,13 +281,19 @@ function run(check) {
     function rec() { var a = []; return { a: a, eject: function (i) { a.push("e" + i) }, unmount: function (i) { a.push("u" + i) }, remove: function (i) { a.push("r" + i) } } }
     function released(action, key) {
         var d = rec(), n = rec(), edited = []
-        Mounts.release(action, key, d, n, [disk, stick], [{ label: "isos", group: "network", kind: "share", uri: "smb://x/isos/", path: "", mounted: true }],
-            { edit: function (uri, label) { edited.push(uri + " " + label) } })
+        var entry = { label: "isos", group: "network", kind: "share", uri: "smb://x/isos/", path: "", mounted: true, peerId: "peer", mac: "aa:bb:cc:dd:ee:ff" }
+        Mounts.release(action, key, d, n, [disk, stick], [entry], {
+            edit: function (uri, label) { edited.push(uri + " " + label) }, copyAddress: function (e) { edited.push("copy " + e.uri) },
+            openSsh: function (e) { edited.push("ssh " + e.uri) }, taildrop: function (id) { edited.push("taildrop " + id) }, wake: function (e) { edited.push("wake " + e.mac) }
+        })
         return d.a.concat(n.a, edited).join(",")
     }
     check("eject resolves the volume's position and never the network Service", released("eject", "/dev/sda1"), "e1")
     check("unmount resolves the share's position and never the device Service", released("unmount", "smb://x/isos/"), "u0")
     check("edit names the share rather than a Service index", released("edit", "smb://x/isos/"), "smb://x/isos/ isos")
+    check("copy address carries the resolved row", released("copy-address", "smb://x/isos/"), "copy smb://x/isos/")
+    check("Taildrop carries a stable peer id", released("taildrop-peer", "smb://x/isos/"), "taildrop peer")
+    check("Wake carries the row's validated metadata", released("wake", "smb://x/isos/"), "wake aa:bb:cc:dd:ee:ff")
     check("a key that no longer names a row releases nothing", released("eject", "/dev/sdz9"), "")
     check("an action that is neither release does nothing", released("forget", "/dev/sda1"), "")
 }

--- a/tests/js/mounts.js
+++ b/tests/js/mounts.js
@@ -198,7 +198,7 @@ function run(check) {
 
     check("a mounted removable volume offers Eject", Mounts.railMenu(volume).map(function (r) { return r.action }).join("|"), "eject")
     check("and that row is named and marked", Mounts.railMenu(volume)[0].label + "/" + Mounts.railMenu(volume)[0].glyph, "Eject/eject")
-    check("a mounted network share offers Unmount then Edit", Mounts.railMenu(share).map(function (r) { return r.action }).join("|"), "unmount|edit")
+    check("a mounted network share offers Unmount, Edit, Remove", Mounts.railMenu(share).map(function (r) { return r.action }).join("|"), "unmount|edit|remove")
     check("Unmount stays first so Ctrl+E still unmounts", Mounts.railMenu(share)[0].label + "/" + Mounts.railMenu(share)[0].glyph, "Unmount/eject")
     check("Edit draws the rename mark", Mounts.railMenu(share)[1].label + "/" + Mounts.railMenu(share)[1].glyph, "Edit/rename")
 
@@ -207,7 +207,7 @@ function run(check) {
     check("the Dropbox row offers nothing, it is a local folder the stock service owns", Mounts.railMenu(dropbox).length, 0)
     check("a favourite offers nothing, it is not a mount at all", Mounts.railMenu(favourite).length, 0)
     check("an unmounted volume offers nothing, there is nothing to release", Mounts.railMenu(idle).length, 0)
-    check("a bookmark nothing has mounted offers Edit", Mounts.railMenu(bookmark).map(function (r) { return r.action }).join("|"), "edit")
+    check("a bookmark nothing has mounted offers Edit then Remove", Mounts.railMenu(bookmark).map(function (r) { return r.action }).join("|"), "edit|remove")
     check("Ctrl+E unmounts a live share and ignores a bookmark", Mounts.releaseAction(share) + "|" + Mounts.releaseAction(bookmark), "unmount|")
     check("no entry at all offers nothing rather than throwing", Mounts.railMenu(null).length, 0)
     check("an undefined entry offers nothing rather than throwing", Mounts.railMenu(undefined).length, 0)
@@ -285,7 +285,7 @@ function run(check) {
     check("no rail at all answers nothing rather than throwing", Mounts.holding(null, "/x"), null)
 
     // The rail menu's chosen row, resolved by key; a key that no longer names a row releases nothing.
-    function rec() { var a = []; return { a: a, eject: function (i) { a.push("e" + i) }, unmount: function (i) { a.push("u" + i) } } }
+    function rec() { var a = []; return { a: a, eject: function (i) { a.push("e" + i) }, unmount: function (i) { a.push("u" + i) }, remove: function (i) { a.push("r" + i) } } }
     function released(action, key) {
         var d = rec(), n = rec(), edited = []
         Mounts.release(action, key, d, n, [disk, stick], [{ label: "isos", group: "network", kind: "share", uri: "smb://x/isos/", path: "", mounted: true }],

--- a/tests/js/ops.js
+++ b/tests/js/ops.js
@@ -11,7 +11,6 @@ function run(check) {
     check("one item is singular and two are not",
           Ops.items(1) + " / " + Ops.items(2) + " / " + Ops.items(0),
           "1 item / 2 items / 0 items")
-
     // The canvas's own line, drawn on the Operations artboard: "Copying 2 of 5, photo.heic".
     check("a copy in flight reads the way the canvas draws it",
           Ops.progressLine({ moving: false, n: 5, index: 1, name: "photo.heic" }),
@@ -22,6 +21,12 @@ function run(check) {
     check("a remote-to-remote transfer says what crosses the wire",
           Ops.progressLine({ moving: false, n: 2, index: 0, name: "photo.heic", kind: "remote-to-remote" }),
           "Copying between remote hosts 1 of 2, photo.heic")
+    check("a remote-to-remote move uses the matching verb",
+          Ops.progressLine({ moving: true, n: 2, index: 0, name: "photo.heic", kind: "remote-to-remote" }),
+          "Moving between remote hosts 1 of 2, photo.heic")
+    var pending = { pendingTransferKind: "remote-to-remote" }
+    Ops.clearPendingKind(pending, "transfer")
+    check("a transfer refused before start cannot leak its kind", pending.pendingTransferKind, "local")
     // A directory item reports no name until its first line arrives, and the count still reads.
     check("an item with no name yet still counts",
           Ops.progressLine({ moving: false, n: 2, index: 0, name: "" }),

--- a/tests/js/ops.js
+++ b/tests/js/ops.js
@@ -19,6 +19,9 @@ function run(check) {
     check("a move says so instead",
           Ops.progressLine({ moving: true, n: 5, index: 1, name: "photo.heic" }),
           "Moving 2 of 5, photo.heic")
+    check("a remote-to-remote transfer says what crosses the wire",
+          Ops.progressLine({ moving: false, n: 2, index: 0, name: "photo.heic", kind: "remote-to-remote" }),
+          "Copying between remote hosts 1 of 2, photo.heic")
     // A directory item reports no name until its first line arrives, and the count still reads.
     check("an item with no name yet still counts",
           Ops.progressLine({ moving: false, n: 2, index: 0, name: "" }),

--- a/tests/js/places.js
+++ b/tests/js/places.js
@@ -132,4 +132,15 @@ function run(check) {
     check("every matching duplicate is dropped",
         Places.remove(dupes, "smb://192.168.1.10/data"),
         'file:///home/gm/Downloads Downloads\n')
+
+    var live = [{ label: "tom", uri: "sftp://tom@h/" }]
+    var saved = [{ label: "omv root", uri: "sftp://tom@h:22/" }]
+    var merged = Places.networkEntries(live, saved)
+    check("a live mount and its bookmark are one row", merged.length, 1)
+    check("the bookmark's label wins over gio's username-on-host name", merged[0].label, "omv root")
+    check("the live uri is what Unmount is handed", merged[0].uri, "sftp://tom@h/")
+    check("the collapsed row reads as mounted", merged[0].mounted, true)
+    var onlyMark = Places.networkEntries([], saved)
+    check("an unmounted bookmark keeps its own uri and label",
+          onlyMark[0].label + "|" + onlyMark[0].uri + "|" + onlyMark[0].mounted, "omv root|sftp://tom@h:22/|false")
 }

--- a/tests/js/places.js
+++ b/tests/js/places.js
@@ -89,4 +89,34 @@ function run(check) {
     check("every row is tagged as a favourite", favs[3].group + "/" + favs[3].kind, "favorite/favorite")
     check("the mark is resolved by the caller, so the rail keeps its own Icons import", favs[1].glyph, "mark:Downloads")
     check("a box with neither file still gets Home", Places.favorites("/home/gm", "", "", function () { return "m" }).length, 1)
+
+    check("replace rewrites the matched URI and label",
+        Places.replace(netFile, "smb://192.168.1.10/data", "sftp://tom@nas:22/home/tom", "omv"),
+        'file:///home/gm/Downloads Downloads\n'
+        + 'sftp://tom@nas:22/home/tom omv\n'
+        + 'smb://10.0.0.9/backups Backups\n')
+    check("a trailing-slash live uri still finds the written line",
+        Places.replace(netFile, "smb://192.168.1.10/data/", "smb://192.168.1.10/isos", "ISOs"),
+        'file:///home/gm/Downloads Downloads\n'
+        + 'smb://192.168.1.10/isos ISOs\n'
+        + 'smb://10.0.0.9/backups Backups\n')
+    check("an empty old uri appends, which is the add dialog",
+        Places.replace(netFile, "", "smb://host/share", "Share"),
+        netFile + "smb://host/share Share\n")
+    check("an unmatched old uri appends rather than dropping the edit",
+        Places.replace(netFile, "smb://missing/x", "smb://host/share", "Share"),
+        netFile + "smb://host/share Share\n")
+    check("an empty new uri is a no-op", Places.replace(netFile, "smb://192.168.1.10/data", "", "X"), netFile)
+    check("a blank label falls back to the path leaf",
+        Places.replace("", "smb://h/data", "smb://h/data", "  "), "smb://h/data data\n")
+    check("an embedded newline in the new label cannot fork a line",
+        Places.replace(netFile, "smb://192.168.1.10/data", "smb://192.168.1.10/data", "Home\nlab"),
+        'file:///home/gm/Downloads Downloads\n'
+        + 'smb://192.168.1.10/data Homelab\n'
+        + 'smb://10.0.0.9/backups Backups\n')
+    check("every matching duplicate rewrites to the new uri",
+        Places.replace(dupes, "smb://192.168.1.10/data", "sftp://nas/data", "Homelab"),
+        'sftp://nas/data Homelab\n'
+        + 'file:///home/gm/Downloads Downloads\n'
+        + 'sftp://nas/data Homelab\n')
 }

--- a/tests/js/places.js
+++ b/tests/js/places.js
@@ -143,4 +143,17 @@ function run(check) {
     var onlyMark = Places.networkEntries([], saved)
     check("an unmounted bookmark keeps its own uri and label",
           onlyMark[0].label + "|" + onlyMark[0].uri + "|" + onlyMark[0].mounted, "omv root|sftp://tom@h:22/|false")
+
+    var home = [{ label: "tom@omv ts", uri: "sftp://tom@h:22/home/tom" }]
+    var both = Places.networkEntries(live, saved.concat(home))
+    check("a second sftp path on the same host stays its own row", both.length, 2)
+    check("and reads as mounted because gio only lists the connection root",
+          both[0].mounted + "|" + both[1].label + "|" + both[1].mounted, "true|tom@omv ts|true")
+    check("Unmount of either path is handed gio's live root uri",
+          Places.coveringUri(live, home[0].uri), "sftp://tom@h/")
+    var smbLive = [{ label: "data", uri: "smb://nas/data/" }]
+    var smbMarks = [{ label: "data", uri: "smb://nas/data" }, { label: "isos", uri: "smb://nas/isos" }]
+    var smb = Places.networkEntries(smbLive, smbMarks)
+    check("an SMB share does not mark a different share on the same host mounted",
+          smb.length + "|" + smb[0].mounted + "|" + smb[1].label + "|" + smb[1].mounted, "2|true|isos|false")
 }

--- a/tests/js/places.js
+++ b/tests/js/places.js
@@ -89,6 +89,7 @@ function run(check) {
     check("every row is tagged as a favourite", favs[3].group + "/" + favs[3].kind, "favorite/favorite")
     check("the mark is resolved by the caller, so the rail keeps its own Icons import", favs[1].glyph, "mark:Downloads")
     check("a box with neither file still gets Home", Places.favorites("/home/gm", "", "", function () { return "m" }).length, 1)
+    check("a bracketed IPv6 address stays copyable", Places.authority("sftp://pi@[fd7a::1]:2222/home"), "[fd7a::1]:2222")
 
     check("replace rewrites the matched URI and label",
         Places.replace(netFile, "smb://192.168.1.10/data", "sftp://tom@nas:22/home/tom", "omv"),
@@ -156,4 +157,23 @@ function run(check) {
     var smb = Places.networkEntries(smbLive, smbMarks)
     check("an SMB share does not mark a different share on the same host mounted",
           smb.length + "|" + smb[0].mounted + "|" + smb[1].label + "|" + smb[1].mounted, "2|true|isos|false")
+
+    var peers = [
+        { label:"Tail box", uri:"sftp://tom@h/", kind:"peer", origin:"tailnet", health:"online", address:"h", peerId:"p", taildrop:true },
+        { label:"LAN NAS", uri:"smb://nas/data", kind:"discovered", origin:"lan", health:"online", address:"nas", mac:"aa:bb:cc:dd:ee:ff" }
+    ]
+    var enriched = Places.networkEntries(live, saved, peers, { "sftp://tom@h/": "connecting" })
+    check("a discovered SFTP peer deduplicates against a live bookmarked host", enriched.length, 2)
+    check("the bookmark remains editable while discovery enriches it", enriched[0].kind, "share")
+    check("a confirmed live mount wins over transient health", enriched[0].health, "mounted")
+    check("an unmatched discovered LAN service is appended with its Wake metadata",
+          enriched[1].kind + "|" + enriched[1].origin + "|" + enriched[1].mac,
+          "discovered|lan|aa:bb:cc:dd:ee:ff")
+    var oldRecent = { label:"Tail box", uri:"sftp://tom@h/", kind:"recent", origin:"recent", health:"unknown" }
+    var livePeer = { label:"Tail box", uri:"sftp://tom@h/", kind:"peer", origin:"tailnet", health:"online", address:"h", peerId:"p", taildrop:true }
+    var fresh = Places.networkEntries([], [], [oldRecent, livePeer])
+    check("live discovery enriches rather than duplicates an older recent", fresh.length + "|" + fresh[0].health + "|" + fresh[0].taildrop, "1|online|true")
+    var profile = { label:"Tail box", uri:"sftp://tom@h/", kind:"profile", origin:"lan", health:"unknown", mac:"11:22:33:44:55:66" }
+    var awake = Places.networkEntries([], [], [oldRecent, profile])
+    check("a Wake profile enriches a matching recent", awake[0].origin + "|" + awake[0].mac, "lan|11:22:33:44:55:66")
 }

--- a/tests/js/places.js
+++ b/tests/js/places.js
@@ -93,7 +93,7 @@ function run(check) {
     check("replace rewrites the matched URI and label",
         Places.replace(netFile, "smb://192.168.1.10/data", "sftp://tom@nas:22/home/tom", "omv"),
         'file:///home/gm/Downloads Downloads\n'
-        + 'sftp://tom@nas:22/home/tom omv\n'
+        + 'sftp://tom@nas/home/tom omv\n'
         + 'smb://10.0.0.9/backups Backups\n')
     check("a trailing-slash live uri still finds the written line",
         Places.replace(netFile, "smb://192.168.1.10/data/", "smb://192.168.1.10/isos", "ISOs"),

--- a/tests/js/places.js
+++ b/tests/js/places.js
@@ -119,4 +119,17 @@ function run(check) {
         'sftp://nas/data Homelab\n'
         + 'file:///home/gm/Downloads Downloads\n'
         + 'sftp://nas/data Homelab\n')
+
+    check("remove drops the matched line and keeps the rest",
+        Places.remove(netFile, "smb://192.168.1.10/data"),
+        'file:///home/gm/Downloads Downloads\n'
+        + 'smb://10.0.0.9/backups Backups\n')
+    check("a trailing-slash live uri still finds the written line to drop",
+        Places.remove(netFile, "smb://192.168.1.10/data/"),
+        'file:///home/gm/Downloads Downloads\n'
+        + 'smb://10.0.0.9/backups Backups\n')
+    check("an empty uri is a no-op", Places.remove(netFile, ""), netFile)
+    check("every matching duplicate is dropped",
+        Places.remove(dupes, "smb://192.168.1.10/data"),
+        'file:///home/gm/Downloads Downloads\n')
 }

--- a/tests/js/protocols.js
+++ b/tests/js/protocols.js
@@ -56,6 +56,10 @@ function run(check) {
     check("and only SMB asks for a domain",
           ["SMB", "SFTP", "WebDAV"].map(function (p) { return Protocols.fieldsFor(p).domain }).join("|"),
           "true|false|false")
+
+    var ipv6 = Protocols.parse("sftp://pi@[fd7a:115c:a1e0::1]:2222/home/pi")
+    check("a bracketed IPv6 host parses without becoming its port", ipv6.host + "|" + ipv6.port,
+          "[fd7a:115c:a1e0::1]|2222")
     check("while only the two schemes that have a plaintext twin carry a TLS box",
           ["SMB", "SFTP", "FTPS", "WebDAV", "NFS"].map(function (p) { return Protocols.fieldsFor(p).tls }).join("|"),
           "false|false|true|true|false")
@@ -104,8 +108,8 @@ function run(check) {
           Protocols.parse("sftp://tom@omv.example:22/~").path, "~")
     check("a missing scheme is not a location", Protocols.parse("nas/share") === null, true)
     check("an unknown scheme is refused", Protocols.parse("afp://h/share") === null, true)
-    check("a host with a non-numeric colon is refused rather than split",
-          Protocols.parse("sftp://u@[::1]/home") === null, true)
+    check("a bracketed IPv6 host with no port stays whole",
+          Protocols.parse("sftp://u@[::1]/home").host, "[::1]")
     check("an @ in the path is not stolen as a username",
           roundtrip({ protocol: "SFTP", host: "h", port: "22", path: "inbox@2026", user: "u" }),
           "sftp://u@h:22/inbox@2026")

--- a/tests/js/protocols.js
+++ b/tests/js/protocols.js
@@ -77,4 +77,33 @@ function run(check) {
           Protocols.label({ label: "", host: "h", path: "/media/isos" }), "isos")
     check("falling back to the host when there is no path either",
           Protocols.label({ label: "", host: "nas", path: "/" }), "nas")
+
+    function roundtrip(form) {
+        var built = Protocols.uri(form)
+        var parsed = Protocols.parse(built)
+        return Protocols.uri(parsed)
+    }
+    check("parse inverts the SFTP URI the canvas draws",
+          roundtrip({ protocol: "SFTP", host: "username.servername.example.com", port: "22",
+                      path: "/downloads", user: "username", tls: false }),
+          "sftp://username@username.servername.example.com:22/downloads")
+    check("and the SMB domain form",
+          roundtrip({ protocol: "SMB", host: "nas", port: "445", path: "isos",
+                      user: "gm", domain: "WORKGROUP", tls: false }),
+          "smb://WORKGROUP;gm@nas:445/isos")
+    check("and NFS, which carries no credentials",
+          roundtrip({ protocol: "NFS", host: "nas", port: "2049", path: "/export", user: "gm", tls: false }),
+          "nfs://nas:2049/export")
+    check("and WebDAV with TLS on",
+          roundtrip({ protocol: "WebDAV", host: "h", port: "443", path: "/webdav", user: "u", tls: true }),
+          "davs://u@h:443/webdav")
+    check("ftp is the TLS-off twin of FTPS",
+          Protocols.parse("ftp://u@h:21/").protocol + "|" + Protocols.parse("ftp://u@h:21/").tls,
+          "FTPS|false")
+    check("a bookmark whose path is a literal tilde keeps it, gio does not expand ~",
+          Protocols.parse("sftp://tom@omv.example:22/~").path, "~")
+    check("a missing scheme is not a location", Protocols.parse("nas/share") === null, true)
+    check("an unknown scheme is refused", Protocols.parse("afp://h/share") === null, true)
+    check("a host with a non-numeric colon is refused rather than split",
+          Protocols.parse("sftp://u@[::1]/home") === null, true)
 }

--- a/tests/js/protocols.js
+++ b/tests/js/protocols.js
@@ -106,4 +106,10 @@ function run(check) {
     check("an unknown scheme is refused", Protocols.parse("afp://h/share") === null, true)
     check("a host with a non-numeric colon is refused rather than split",
           Protocols.parse("sftp://u@[::1]/home") === null, true)
+    check("an @ in the path is not stolen as a username",
+          roundtrip({ protocol: "SFTP", host: "h", port: "22", path: "inbox@2026", user: "u" }),
+          "sftp://u@h:22/inbox@2026")
+    check("and parse keeps that path and the real user",
+          Protocols.parse("sftp://u@h:22/inbox@2026").path + "|"
+          + Protocols.parse("sftp://u@h:22/inbox@2026").user, "inbox@2026|u")
 }

--- a/tests/js/quickconnect.js
+++ b/tests/js/quickconnect.js
@@ -1,0 +1,17 @@
+.import "../../ui/js/QuickConnect.js" as QuickConnect
+
+function run(check) {
+    check("user host colon path means SFTP", QuickConnect.parse("pi@box:/home/pi").uri, "sftp://pi@box/home/pi")
+    check("host colon path means SFTP", QuickConnect.parse("box:/srv/media").uri, "sftp://box/srv/media")
+    check("host slash share means SMB", QuickConnect.parse("nas/photos").uri, "smb://nas/photos")
+    check("a bare host defaults to SFTP", QuickConnect.parse("server.local").uri, "sftp://server.local/")
+    check("an IPv4 defaults to SFTP", QuickConnect.parse("100.64.0.8").uri, "sftp://100.64.0.8/")
+    check("a bracketed IPv6 colon path survives", QuickConnect.parse("[fd7a::1]:/srv").uri, "sftp://[fd7a::1]/srv")
+    check("an explicit protocol wins", QuickConnect.parse("davs://docs.example/path").protocol, "WebDAV")
+    check("an unsupported scheme is refused", QuickConnect.parse("gopher://host/x"), null)
+    check("an embedded password is refused", QuickConnect.parse("sftp://pi:secret@host/home"), null)
+    check("a query token is refused rather than bookmarked", QuickConnect.parse("davs://host/path?token=secret"), null)
+    check("a fragment is refused rather than silently changing identity", QuickConnect.parse("sftp://host/path#private"), null)
+    check("shorthand cannot smuggle a query token", QuickConnect.parse("host/path?token=secret"), null)
+    check("newline input is refused", QuickConnect.parse("host\nother"), null)
+}

--- a/tests/js/recents.js
+++ b/tests/js/recents.js
@@ -1,0 +1,27 @@
+.import "../../ui/js/Recents.js" as Recents
+
+function run(check) {
+    check("empty history is empty", Recents.parse("").length, 0)
+    check("malformed history is empty", Recents.parse("not json").length, 0)
+    var rows = Recents.record([], "sftp://pi:secret@host/home?token=nope", "Box\nInjected", 20, "AA-BB-CC-DD-EE-FF")
+    check("passwords queries and label newlines never persist", rows[0].uri + "|" + rows[0].label, "sftp://pi@host/home|BoxInjected")
+    check("MAC addresses normalize", rows[0].mac, "aa:bb:cc:dd:ee:ff")
+    rows = Recents.record(rows, "sftp://pi@host/home/", "New label", 30, "")
+    check("a success moves a duplicate to the front", rows.length + "|" + rows[0].label, "1|New label")
+    for (var i = 0; i < 12; i++)
+        rows = Recents.record(rows, "sftp://host" + i + "/", "h" + i, i, "")
+    check("history is bounded", rows.length, Recents.LIMIT)
+    var round = Recents.parse(Recents.serialize(rows))
+    check("serialized history round trips", round.map(function (r) { return r.uri }).join("|"), rows.map(function (r) { return r.uri }).join("|"))
+    check("recent entries carry unknown health", Recents.entries(round)[0].health, "unknown")
+    var profiles = Recents.rememberProfile([], "", "sftp://lan/", "Sleeping box", "AABBCCDDEEFF")
+    check("a saved Wake profile carries only a normalized MAC", Recents.profileEntries(profiles)[0].mac, "aa:bb:cc:dd:ee:ff")
+    var state = Recents.parseState(Recents.serializeState(rows, profiles))
+    check("recent history and Wake profiles persist independently", state.recent.length + "|" + state.profiles.length, "8|1")
+    check("an invalid MAC never creates a Wake profile", Recents.rememberProfile(profiles, "", "sftp://x/", "x", "bad").length, 1)
+    profiles = Recents.rememberProfile(profiles, "sftp://lan/", "sftp://new-lan/", "Renamed", "112233445566")
+    check("editing a profile removes its old identity", profiles.length + "|" + profiles[0].uri, "1|sftp://new-lan/")
+    profiles = Recents.rememberProfile(profiles, "sftp://new-lan/", "sftp://new-lan/", "Renamed", "")
+    check("clearing a MAC removes the stale Wake profile", profiles.length, 0)
+    check("recent removal compares normalized identities", Recents.remove([{ uri: "sftp://host/path/" }], "sftp://host/path").length, 0)
+}

--- a/tests/js/remote.js
+++ b/tests/js/remote.js
@@ -4,8 +4,13 @@ function run(check) {
     var remote = "/run/user/1000/gvfs/sftp:host=box/home/pi"
     check("a GVFS path is remote", Remote.isRemotePath(remote), true)
     check("a local lookalike is local", Remote.isRemotePath("/tmp/gvfs/box"), false)
+    check("the mount root stops before the path inside it", Remote.remoteRoot(remote), "/run/user/1000/gvfs/sftp:host=box")
     check("two mounted endpoints are remote to remote", Remote.transferKind([remote + "/a"], "/run/user/1000/gvfs/smb-share:server=nas,share=data"), "remote-to-remote")
     check("a local source to a mount is named separately", Remote.transferKind(["/tmp/a"], remote), "local-to-remote")
+    check("a mixed batch is not mislabeled as entirely between remote hosts",
+          Remote.transferKind([remote + "/a", "/tmp/b"], "/run/user/1000/gvfs/smb-share:server=nas,share=data"), "local-to-remote")
+    check("a transfer within one mount is not described as crossing hosts",
+          Remote.transferKind([remote + "/a"], remote + "/folder"), "same-remote")
     check("a remote destination line is explicit", Remote.transferPrefix("remote-to-remote", false), "Copying between remote hosts")
     var peer = { group:"network", kind:"peer", uri:"sftp://pi@box/", health:"online", origin:"tailnet", taildrop:true, mac:"" }
     check("a Tailnet peer gets safe remote actions", Remote.menu(peer).map(function (r) { return r.action }).join("|"), "copy-address|open-ssh|taildrop-peer")

--- a/tests/js/remote.js
+++ b/tests/js/remote.js
@@ -1,0 +1,21 @@
+.import "../../ui/js/Remote.js" as Remote
+
+function run(check) {
+    var remote = "/run/user/1000/gvfs/sftp:host=box/home/pi"
+    check("a GVFS path is remote", Remote.isRemotePath(remote), true)
+    check("a local lookalike is local", Remote.isRemotePath("/tmp/gvfs/box"), false)
+    check("two mounted endpoints are remote to remote", Remote.transferKind([remote + "/a"], "/run/user/1000/gvfs/smb-share:server=nas,share=data"), "remote-to-remote")
+    check("a local source to a mount is named separately", Remote.transferKind(["/tmp/a"], remote), "local-to-remote")
+    check("a remote destination line is explicit", Remote.transferPrefix("remote-to-remote", false), "Copying between remote hosts")
+    var peer = { group:"network", kind:"peer", uri:"sftp://pi@box/", health:"online", origin:"tailnet", taildrop:true, mac:"" }
+    check("a Tailnet peer gets safe remote actions", Remote.menu(peer).map(function (r) { return r.action }).join("|"), "copy-address|open-ssh|taildrop-peer")
+    check("the terminal argv keeps the host one argument", Remote.terminalArgv(peer).join("|"), "omarchy-launch-terminal|ssh|pi@box")
+    var lan = { group:"network", kind:"discovered", uri:"sftp://lan/", health:"offline", origin:"lan", mac:"aa:bb:cc:dd:ee:ff" }
+    check("an offline LAN host offers reconnect and Wake but not SSH", Remote.menu(lan).map(function (r) { return r.action }).join("|"), "reconnect|copy-address|wake")
+    check("an offline Taildrop peer never offers a doomed send", Remote.menu({group:"network",kind:"peer",uri:"sftp://box/",health:"offline",origin:"tailnet",taildrop:true}).map(function (r) { return r.action }).join("|"), "reconnect|copy-address")
+    check("invalid MACs never offer Wake", Remote.validMac("aa:bb"), false)
+    check("a custom SSH port stays in separate argv slots", Remote.terminalArgv({uri:"sftp://pi@host:2222/"}).join("|"), "omarchy-launch-terminal|ssh|-p|2222|pi@host")
+    check("a bracketed IPv6 host becomes an SSH target without URI brackets", Remote.terminalArgv({uri:"sftp://pi@[fd7a::1]:2222/"}).join("|"), "omarchy-launch-terminal|ssh|-p|2222|pi@fd7a::1")
+    check("a hostile SSH authority is refused", Remote.terminalArgv({uri:"sftp://host;touch/"}).length, 0)
+    check("an invalid SSH port is refused", Remote.terminalArgv({uri:"sftp://host:99999/"}).length, 0)
+}

--- a/tests/js/tailnet.js
+++ b/tests/js/tailnet.js
@@ -1,0 +1,26 @@
+.import "../../ui/js/Tailnet.js" as Tailnet
+
+function run(check) {
+    var body = JSON.stringify({ BackendState: "Running", Self: { UserID: 7 }, Peer: {
+        z: { HostName: "offline", Online: false, TailscaleIPs: ["100.1.2.5"], UserID: 7 },
+        a: { HostName: "online", DNSName: "online.tail.ts.net.", Online: true, TaildropTarget: 1, UserID: 7 },
+        m: { HostName: "relay.mullvad.ts.net", Online: true, TailscaleIPs: ["100.2.2.2"] }
+    }})
+    var ready = Tailnet.parseResult(0, body, "")
+    check("running Tailscale is ready", ready.state, "ready")
+    check("online peers sort first and relays disappear", ready.peers.map(function (p) { return p.label }).join("|"), "online|offline")
+    check("Taildrop metadata does not filter discovery", ready.peers[0].taildrop + "|" + ready.peers[1].taildrop, "true|true")
+    check("DNS names lose only their terminal dot", ready.peers[0].address, "online.tail.ts.net")
+    var entries = Tailnet.entries(ready.peers, "pi")
+    check("a peer is an ordinary SFTP location", entries[0].uri, "sftp://pi@online.tail.ts.net/")
+    check("offline state survives into the rail", entries[1].health, "offline")
+    check("an unsafe local user is never embedded", Tailnet.entries([ready.peers[0]], "bad@user")[0].uri, "sftp://online.tail.ts.net/")
+    check("IPv6 addresses are bracketed", Tailnet.entries([{id:"v6",label:"v6",address:"fd7a::1",online:true}], "")[0].uri, "sftp://[fd7a::1]/")
+    check("a missing command is named", Tailnet.parseResult(127, "", "command not found").state, "missing")
+    check("a stopped daemon is named", Tailnet.parseResult(1, "", "failed to connect to local tailscaled; not running").state, "daemon-stopped")
+    check("stopped-daemon guidance names the recovery command",
+          Tailnet.parseResult(1, "", "failed to connect to local tailscaled").message.indexOf("systemctl enable --now tailscaled") >= 0, true)
+    check("a logged-out backend is named", Tailnet.parseResult(0, '{"BackendState":"NeedsLogin"}', "").state, "logged-out")
+    check("a ready tailnet with no peers is distinct", Tailnet.parseResult(0, '{"BackendState":"Running","Peer":{}}', "").state, "no-peers")
+    check("malformed status never throws", Tailnet.parseResult(0, "not json", "").state, "failed")
+}

--- a/tests/modes.sh
+++ b/tests/modes.sh
@@ -117,6 +117,11 @@ check "and that sentence names the handler" "1" "$(echo "$out" | grep -c 'nothin
 out=$($BIN --open 2>&1 </dev/null)
 check "--open with no path is a usage error" "1" "$(echo "$out" | grep -c -- '--open')"
 
+out=$($BIN --wake not-a-mac 2>&1 </dev/null)
+rc=$?
+check "--wake rejects an invalid MAC before networking" "1" "$rc"
+check "and names the accepted MAC shape" "1" "$(echo "$out" | grep -c 'aa:bb:cc:dd:ee:ff')"
+
 # The stub qs is what exec_qs launched, so it inherits huge pages off; --open must hand them back.
 printf '#!/bin/sh\ngrep -i "^THP_enabled" /proc/self/status | sed "s/^/QS /"\nexec %s --open %s\n' "$PWD/$BIN" "$D/file.txt" > "$D/bin/qs"
 chmod +x "$D/bin/qs"

--- a/tests/network-services.qml
+++ b/tests/network-services.qml
@@ -1,0 +1,88 @@
+//@ pragma ShellId flea-network-services-test
+
+import QtQuick
+import Quickshell
+
+ShellRoot {
+    id: root
+
+    readonly property string mode: Quickshell.env("FLEA_SERVICE_MODE") || "discover"
+    property bool started: false
+
+    NetworkDiscovery {
+        id: discovery
+        visible: false
+    }
+
+    NetworkHistory {
+        id: history
+        visible: false
+    }
+
+    NetworkActions {
+        id: actions
+        visible: false
+        onMessage: function (text, isError) {
+            console.log("ACTION " + (isError ? "error " : "ok ") + text)
+            root.finish()
+        }
+    }
+
+    Loader {
+        id: mountsLoader
+        active: root.mode === "list-timeout"
+        sourceComponent: Component {
+            NetworkMounts {
+                onMessage: function (text, isError) {
+                    console.log("MOUNTS " + (isError ? "error " : "ok ") + text)
+                    root.finish()
+                }
+            }
+        }
+    }
+
+    function finish() {
+        Quickshell.execDetached(["kill", String(Quickshell.processId)])
+    }
+
+    Timer {
+        interval: 50
+        running: true
+        repeat: true
+        onTriggered: {
+            if (root.mode === "discover") {
+                if (discovery.tailnetState === "unknown" || discovery.lanState === "unknown") return
+                console.log("DISCOVERY " + discovery.tailnetState + " " + discovery.lanState
+                            + " peers=" + discovery.tailnetPeers.length + " lan=" + discovery.lanEntries.length
+                            + " message=" + discovery.tailnetMessage)
+                root.finish()
+                stop()
+                return
+            }
+            if (root.started) return
+            root.started = true
+            if (root.mode === "history") {
+                history.record("sftp://pi:secret@box/home?token=bad", "Box\nInjected", 0)
+                history.rememberProfile("", "sftp://lan/", "Sleeping box", "AA-BB-CC-DD-EE-FF")
+                console.log("HISTORY recent=" + history.recent.length + " profiles=" + history.profiles.length)
+                root.finish()
+            } else if (root.mode === "copy") {
+                actions.copyAddress({ address: "host; touch should-not-exist" })
+            } else if (root.mode === "wake") {
+                actions.wake({ label: "box", mac: "aa:bb:cc:dd:ee:ff" })
+            } else if (root.mode === "list-timeout") {
+                mountsLoader.item.listShares("smb://host/")
+            }
+            stop()
+        }
+    }
+
+    Timer {
+        interval: 14000
+        running: true
+        onTriggered: {
+            console.log("HARNESS timeout")
+            root.finish()
+        }
+    }
+}

--- a/tests/network-services.sh
+++ b/tests/network-services.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# Drives the real Quickshell network services with argv-logging stubs and no window.
+set -u
+. "$(dirname "$0")/../tools/flea-sandbox-guard"
+cd "$(dirname "$0")/.." || exit 1
+
+D="$FIXTURE_ROOT/flea-network-services-$$"
+fail=0
+cleanup() { sandbox_remove "$D"; }
+trap cleanup EXIT
+sandbox_make "$D"
+mkdir -p "$D/bin" "$D/home/.config" "$D/config"
+ln -s "$PWD/tests/network-services.qml" "$D/config/shell.qml"
+ln -s "$PWD/ui/NetworkDiscovery.qml" "$D/config/NetworkDiscovery.qml"
+ln -s "$PWD/ui/NetworkHistory.qml" "$D/config/NetworkHistory.qml"
+ln -s "$PWD/ui/NetworkActions.qml" "$D/config/NetworkActions.qml"
+ln -s "$PWD/ui/NetworkMounts.qml" "$D/config/NetworkMounts.qml"
+ln -s "$PWD/ui/js" "$D/config/js"
+
+check() {
+  local label="$1" expected="$2" actual="$3"
+  if [[ "$expected" != "$actual" ]]; then
+    printf 'FAIL %s\n  expected: %s\n  actual:   %s\n' "$label" "$expected" "$actual"
+    fail=1
+  else
+    printf 'ok   %s\n' "$label"
+  fi
+}
+
+cat > "$D/bin/tailscale" <<'EOS'
+#!/bin/sh
+case "${FLEA_TS_CASE:-ready}" in
+  ready) printf '%s\n' '{"BackendState":"Running","Self":{"UserID":7},"Peer":{"p":{"HostName":"tailbox","Online":true,"TaildropTarget":1,"UserID":7,"TailscaleIPs":["100.64.0.8"]}}}' ;;
+  missing) echo 'command not found' >&2; exit 127 ;;
+  stopped) echo 'failed to connect to local tailscaled; not running' >&2; exit 1 ;;
+  loggedout) printf '%s\n' '{"BackendState":"NeedsLogin","Peer":{}}' ;;
+  nopeers) printf '%s\n' '{"BackendState":"Running","Peer":{}}' ;;
+  malformed) printf '%s\n' 'not json' ;;
+  timeout) sleep 10 ;;
+esac
+EOS
+cat > "$D/bin/avahi-browse" <<'EOS'
+#!/bin/sh
+case "${FLEA_LAN_CASE:-ready}" in
+  ready) printf '%s\n' '=;eth0;IPv4;LAN Box;_ssh._tcp;local;lanbox.local;192.168.1.8;22;"mac=aa:bb:cc:dd:ee:ff"' ;;
+  empty) : ;;
+  malformed) printf '%s\n' 'not avahi output' ;;
+  failed) exit 1 ;;
+  timeout) sleep 10 ;;
+esac
+EOS
+cat > "$D/bin/wl-copy" <<'EOS'
+#!/bin/sh
+printf 'copy:%s:<%s>\n' "$#" "$1" >> "$FLEA_STUB_LOG"
+[ "${FLEA_ACTION_FAIL:-0}" = 1 ] && exit 1
+exit 0
+EOS
+cat > "$D/bin/flea-wake" <<'EOS'
+#!/bin/sh
+printf 'wake:%s:<%s>:<%s>\n' "$#" "$1" "$2" >> "$FLEA_STUB_LOG"
+[ "${FLEA_ACTION_FAIL:-0}" = 1 ] && exit 1
+exit 0
+EOS
+cat > "$D/bin/gio" <<'EOS'
+#!/bin/sh
+if [ "$1" = list ]; then sleep 20; exit 0; fi
+if [ "$1 $2" = 'mount -l' ]; then exit 0; fi
+exit 1
+EOS
+chmod +x "$D/bin/"*
+
+run_service() {
+  env HOME="$D/home" PATH="$D/bin:/usr/bin:/bin" FLEA_STUB_LOG="$D/actions.log" \
+    FLEA_BIN="$D/bin/flea-wake" QT_FORCE_STDERR_LOGGING=1 timeout 12 \
+    qs -p "$D/config" 2>&1
+}
+
+out=$(FLEA_TS_CASE=ready FLEA_LAN_CASE=ready FLEA_SERVICE_MODE=discover run_service)
+check "ready discovery crosses both real Process boundaries" "1" "$(grep -c 'DISCOVERY ready ready peers=1 lan=1' <<< "$out")"
+
+for spec in \
+  'missing missing Tailscale is unavailable' \
+  'stopped daemon-stopped Tailscale is stopped' \
+  'loggedout logged-out Tailscale is logged out' \
+  'nopeers no-peers No machines were found' \
+  'malformed failed unreadable status'; do
+  read -r scenario state words <<< "$spec"
+  out=$(FLEA_TS_CASE="$scenario" FLEA_LAN_CASE=empty FLEA_SERVICE_MODE=discover run_service)
+  check "Tailscale $scenario has its precise state" "1" "$(grep -c "DISCOVERY $state empty" <<< "$out")"
+  check "Tailscale $scenario has recovery/status guidance" "1" "$(grep -c "$words" <<< "$out")"
+done
+
+for scenario in empty malformed failed; do
+  out=$(FLEA_TS_CASE=ready FLEA_LAN_CASE="$scenario" FLEA_SERVICE_MODE=discover run_service)
+  want="$scenario"
+  [[ "$scenario" = malformed ]] && want=empty
+  [[ "$scenario" = failed ]] && want=unavailable
+  check "LAN $scenario remains optional" "1" "$(grep -c "DISCOVERY ready $want peers=1 lan=0" <<< "$out")"
+done
+
+out=$(FLEA_TS_CASE=timeout FLEA_LAN_CASE=timeout FLEA_SERVICE_MODE=discover run_service)
+check "wedged discovery processes are bounded" "1" "$(grep -c 'DISCOVERY failed failed peers=0 lan=0' <<< "$out")"
+out=$(FLEA_SERVICE_MODE=list-timeout run_service)
+check "a wedged share listing is bounded and visible" "1" "$(grep -c 'MOUNTS error Listing shares timed out' <<< "$out")"
+
+: > "$D/actions.log"
+out=$(FLEA_SERVICE_MODE=copy run_service)
+check "copy reports success only after the command exits" "1" "$(grep -c 'ACTION ok Network address copied' <<< "$out")"
+check "copy preserves a hostile address as one argv item" 'copy:1:<host; touch should-not-exist>' "$(cat "$D/actions.log")"
+[[ ! -e should-not-exist ]] || { printf 'FAIL hostile clipboard text executed as shell\n'; fail=1; }
+
+: > "$D/actions.log"
+out=$(FLEA_SERVICE_MODE=wake run_service)
+check "Wake reports success only after the command exits" "1" "$(grep -c 'ACTION ok Wake-on-LAN packet sent' <<< "$out")"
+check "Wake uses an argv-direct internal mode" 'wake:2:<--wake>:<aa:bb:cc:dd:ee:ff>' "$(cat "$D/actions.log")"
+
+: > "$D/actions.log"
+out=$(FLEA_ACTION_FAIL=1 FLEA_SERVICE_MODE=copy run_service)
+check "clipboard command failure is visible" "1" "$(grep -c 'ACTION error The network address could not be copied' <<< "$out")"
+out=$(FLEA_ACTION_FAIL=1 FLEA_SERVICE_MODE=wake run_service)
+check "Wake command failure is visible" "1" "$(grep -c 'ACTION error Wake-on-LAN could not send' <<< "$out")"
+
+out=$(FLEA_SERVICE_MODE=history run_service)
+check "successful-open history and Wake profile cross FileView" "1" "$(grep -c 'HISTORY recent=1 profiles=1' <<< "$out")"
+check "history strips URI passwords and queries" "1" "$(grep -c 'sftp://pi@box/home' "$D/home/.config/flea-network-recents.json")"
+check "history stores no secret material" "0" "$(grep -Ec 'secret|token=bad' "$D/home/.config/flea-network-recents.json")"
+
+[[ "$fail" -eq 0 ]] && printf 'network-services: all checks passed\n'
+exit "$fail"

--- a/tests/ops.sh
+++ b/tests/ops.sh
@@ -143,6 +143,21 @@ check "undo put it back where it came from" "moving" "$(cat "$D/m.txt" 2>/dev/nu
 check "the destination copy is gone" "no" "$([ -e "$D/dest/m.txt" ] && echo yes || echo no)"
 stop_backend
 
+echo "--- transfers between two synthetic GVFS mount roots use the normal backend ---"
+start_backend
+mkdir -p "$D/run/user/1000/gvfs/sftp:host=source" "$D/run/user/1000/gvfs/smb-share:server=dest,share=data"
+printf 'remote copy' > "$D/run/user/1000/gvfs/sftp:host=source/copy.txt"
+printf 'remote move' > "$D/run/user/1000/gvfs/sftp:host=source/move.txt"
+remote_src="$D/run/user/1000/gvfs/sftp:host=source"
+remote_dst="$D/run/user/1000/gvfs/smb-share:server=dest,share=data"
+send "{\"c\":\"transfer\",\"op\":\"copy\",\"paths\":[\"$remote_src/copy.txt\"],\"dest\":\"$remote_dst\"}"
+await '"t":"transferdone"' || fail=1
+check "remote-to-remote copy preserves source bytes" "remote copy|remote copy" "$(cat "$remote_src/copy.txt")|$(cat "$remote_dst/copy.txt")"
+send "{\"c\":\"transfer\",\"op\":\"move\",\"paths\":[\"$remote_src/move.txt\"],\"dest\":\"$remote_dst\"}"
+for _attempt in $(seq 1 200); do [[ $(seen '"t":"transferdone"') -ge 2 ]] && break; sleep 0.05; done
+check "remote-to-remote move removes the source only after landing" "no|remote move" "$([ -e "$remote_src/move.txt" ] && echo yes || echo no)|$(cat "$remote_dst/move.txt")"
+stop_backend
+
 echo "--- one failing item is data, and the batch carries on ---"
 start_backend
 printf 'good' > "$D/good.txt"; mkdir -p "$D/dest"

--- a/tests/ops.sh
+++ b/tests/ops.sh
@@ -155,6 +155,7 @@ await '"t":"transferdone"' || fail=1
 check "remote-to-remote copy preserves source bytes" "remote copy|remote copy" "$(cat "$remote_src/copy.txt")|$(cat "$remote_dst/copy.txt")"
 send "{\"c\":\"transfer\",\"op\":\"move\",\"paths\":[\"$remote_src/move.txt\"],\"dest\":\"$remote_dst\"}"
 for _attempt in $(seq 1 200); do [[ $(seen '"t":"transferdone"') -ge 2 ]] && break; sleep 0.05; done
+[[ $(seen '"t":"transferdone"') -ge 2 ]] || { printf 'FAIL remote move never completed\n'; fail=1; }
 check "remote-to-remote move removes the source only after landing" "no|remote move" "$([ -e "$remote_src/move.txt" ] && echo yes || echo no)|$(cat "$remote_dst/move.txt")"
 stop_backend
 

--- a/tests/process-output.qml
+++ b/tests/process-output.qml
@@ -1,0 +1,66 @@
+//@ pragma ShellId flea-process-output-test
+
+import QtQuick
+import Quickshell
+
+// Each service owns a StdioCollector fallback because Process.onExited can race the collector's
+// text property. These values deliberately poison every fallback, then start a second run. The
+// reset is synchronous, so this catches stale cross-run output without depending on signal order.
+ShellRoot {
+    id: root
+
+    property bool checked: false
+
+    NetworkMounts { id: network }
+    DeviceMounts { id: devices }
+    Taildrop { id: taildrop }
+
+    function finish() {
+        Quickshell.execDetached(["kill", String(Quickshell.processId)])
+    }
+
+    Timer {
+        interval: 500
+        running: true
+        repeat: false
+        onTriggered: {
+            root.checked = true
+
+            network._mountErrOutput = "old mount error: already mounted"
+            network.openShare("smb://new-host/share", false, "New")
+
+            network._infoOutput = "local path: /old/share"
+            network.runInfo("smb://new-host/share")
+
+            network._listSharesOutput = "old-share"
+            network.listShares("smb://new-host/")
+
+            network._mountListOutput = "Mount(0): old -> smb://old/share/"
+            network.pollMounts()
+
+            devices._listOutput = '{"blockdevices":[{"name":"old"}]}'
+            devices.poll()
+
+            taildrop._statusOutput = '{"Peer":{"old":{}}}'
+            taildrop.refresh()
+
+            var fresh = network._mountErrOutput === ""
+                && network._infoOutput === ""
+                && network._listSharesOutput === ""
+                && network._mountListOutput === ""
+                && devices._listOutput === ""
+                && taildrop._statusOutput === ""
+            console.log("PROCESS_OUTPUT fresh=" + (fresh ? "yes" : "no"))
+            root.finish()
+        }
+    }
+
+    Timer {
+        interval: 5000
+        running: true
+        onTriggered: {
+            console.log("PROCESS_OUTPUT timeout checked=" + root.checked)
+            root.finish()
+        }
+    }
+}

--- a/tests/process-output.sh
+++ b/tests/process-output.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Proves reusable QML Process fallbacks are cleared before every new command.
+set -u
+. "$(dirname "$0")/../tools/flea-sandbox-guard"
+cd "$(dirname "$0")/.." || exit 1
+
+D="$FIXTURE_ROOT/flea-process-output-$$"
+cleanup() { sandbox_remove "$D"; }
+trap cleanup EXIT
+sandbox_make "$D"
+mkdir -p "$D/bin" "$D/home/.config" "$D/config"
+
+for file in NetworkMounts.qml DeviceMounts.qml Taildrop.qml; do
+  ln -s "$PWD/ui/$file" "$D/config/$file"
+done
+ln -s "$PWD/ui/js" "$D/config/js"
+ln -s "$PWD/tests/process-output.qml" "$D/config/shell.qml"
+
+cat > "$D/bin/gio" <<'EOS'
+#!/bin/sh
+[ "$1 $2" = "mount -l" ] && exit 0
+sleep 3
+EOS
+cat > "$D/bin/lsblk" <<'EOS'
+#!/bin/sh
+printf '%s\n' '{"blockdevices":[]}'
+EOS
+cat > "$D/bin/tailscale" <<'EOS'
+#!/bin/sh
+sleep 3
+EOS
+chmod +x "$D/bin/"*
+
+out=$(env HOME="$D/home" PATH="$D/bin:/usr/bin:/bin" QT_FORCE_STDERR_LOGGING=1 \
+  timeout 7 qs -p "$D/config" 2>&1)
+count=$(grep -c 'PROCESS_OUTPUT fresh=yes' <<< "$out")
+if [ "$count" -ne 1 ]; then
+  printf 'FAIL reusable Process output crossed command boundaries\n%s\n' "$out"
+  exit 1
+fi
+
+printf 'process-output: all fallbacks start fresh\n'

--- a/tests/run-all.sh
+++ b/tests/run-all.sh
@@ -24,7 +24,7 @@ if [ ! -x target/release/flea ]; then
     cargo build -q --release || { printf 'run-all: release build failed, nothing else was run\n' >&2; exit 1; }
 fi
 
-headless="js keymap-gen charts budget sandbox ops modes protocol archive thumbs scroll"
+headless="js keymap-gen charts budget sandbox ops modes protocol archive thumbs network-services scroll"
 failed=0
 ran=0
 

--- a/tests/run-all.sh
+++ b/tests/run-all.sh
@@ -24,7 +24,7 @@ if [ ! -x target/release/flea ]; then
     cargo build -q --release || { printf 'run-all: release build failed, nothing else was run\n' >&2; exit 1; }
 fi
 
-headless="js keymap-gen charts budget sandbox ops modes protocol archive thumbs"
+headless="js keymap-gen charts budget sandbox ops modes protocol archive thumbs scroll"
 failed=0
 ran=0
 

--- a/tests/run-all.sh
+++ b/tests/run-all.sh
@@ -24,7 +24,7 @@ if [ ! -x target/release/flea ]; then
     cargo build -q --release || { printf 'run-all: release build failed, nothing else was run\n' >&2; exit 1; }
 fi
 
-headless="js keymap-gen charts budget sandbox ops modes protocol archive thumbs network-services scroll"
+headless="js keymap-gen charts budget sandbox ops modes protocol archive thumbs network-services scroll process-output"
 failed=0
 ran=0
 

--- a/tests/scroll.qml
+++ b/tests/scroll.qml
@@ -1,0 +1,64 @@
+import QtQuick
+import Quickshell
+import "." as Test
+
+Item {
+    id: root
+    width: 100
+    height: 100
+
+    property int checked: 0
+    property var failures: []
+
+    function check(label, actual, expected) {
+        root.checked++
+        if (actual !== expected)
+            root.failures.push(label + ": got " + actual + ", expected " + expected)
+    }
+
+    Flickable {
+        id: target
+        width: 100
+        height: 100
+        contentWidth: width
+        contentHeight: 500
+    }
+
+    Test.FastScrollHandler {
+        id: handler
+        parent: root
+        flickable: target
+        mouseWheelStep: 72
+    }
+
+    Component.onCompleted: {
+        target.contentY = 200
+        root.check("smooth pixels retain their fractional value and accelerate",
+                   handler.scrollByDeltas(10.5, 120), 158)
+        root.check("pixel input wins when a device reports both delta forms", target.contentY, 158)
+
+        target.contentY = 200
+        root.check("one wheel notch follows the line preference and accelerates",
+                   handler.scrollByDeltas(0, 120), 0)
+        target.contentY = 100
+        root.check("wheel direction reverses exactly", handler.scrollByDeltas(0, -120), 388)
+
+        target.contentY = 12
+        root.check("the top boundary is hard", handler.scrollByDeltas(20, 0), 0)
+        target.contentY = 390
+        root.check("the bottom boundary is hard", handler.scrollByDeltas(-20, 0), 400)
+        root.check("zero and horizontal-only input do nothing", handler.scrollByDeltas(0, 0), 400)
+
+        target.interactive = false
+        root.check("a disabled viewport does not move", handler.scrollByDeltas(0, 120), 400)
+        target.interactive = true
+        target.contentHeight = 50
+        root.check("content shorter than its viewport has no scroll range",
+                   handler.scrollByDeltas(0, -120), 0)
+
+        for (var i = 0; i < root.failures.length; i++)
+            console.log("FAIL " + root.failures[i])
+        console.log(root.checked + " checks, " + root.failures.length + " failed")
+        Quickshell.execDetached(["kill", String(Quickshell.processId)])
+    }
+}

--- a/tests/scroll.sh
+++ b/tests/scroll.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Proves the wheel arithmetic through the real QML component, then pins every vertical viewport to
+# that shared policy so a newly-unreachable surface cannot hide behind the arithmetic tests.
+set -uo pipefail
+cd "$(dirname "$0")/.." || exit 1
+
+D=$(mktemp -d /tmp/flea-scroll.XXXXXX)
+trap 'rm -rf "$D"' EXIT
+ln -s "$PWD/tests/scroll.qml" "$D/shell.qml"
+ln -s "$PWD/ui/FastScrollHandler.qml" "$D/FastScrollHandler.qml"
+
+out=$(QT_QPA_PLATFORM=offscreen QT_QPA_PLATFORMTHEME= QT_STYLE_OVERRIDE=Basic \
+      QT_FORCE_STDERR_LOGGING=1 timeout 30 qs -p "$D" 2>&1)
+code=$?
+printf '%s\n' "$out"
+[[ "$code" -ne 124 ]] || { printf 'scroll.sh: QML harness timed out\n'; exit 1; }
+printf '%s' "$out" | grep -qE '9 checks, 0 failed' || exit 1
+# The harness ends its own Quickshell process with SIGTERM after printing the authoritative tally.
+[[ "$code" -eq 0 || "$code" -eq 143 ]] || exit "$code"
+
+declare -A want=(
+    [ui/List.qml]=1
+    [ui/GridArea.qml]=1
+    [ui/ColumnPane.qml]=1
+    [ui/Sidebar.qml]=1
+    [ui/PreviewText.qml]=1
+    [ui/PdfViewer.qml]=1
+    [ui/ShareBrowser.qml]=1
+    [ui/ContextMenu.qml]=2
+)
+
+for file in "${!want[@]}"; do
+    seen=$(grep -c 'FastScrollHandler {' "$file")
+    [[ "$seen" -eq "${want[$file]}" ]] || {
+        printf 'scroll.sh: %s has %s handlers, expected %s\n' "$file" "$seen" "${want[$file]}"
+        exit 1
+    }
+done
+
+grep -q 'id: shareView' ui/ShareBrowser.qml || { printf 'scroll.sh: share browser is not a view\n'; exit 1; }
+grep -q 'height: Menu.boundedExtent' ui/ContextMenu.qml || { printf 'scroll.sh: menus are not viewport-bounded\n'; exit 1; }
+printf 'scroll: accelerated arithmetic and 9 vertical surfaces passed\n'

--- a/tests/ui.sh
+++ b/tests/ui.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Drives the real Quickshell window with omarchy-drive and asserts through the read-only IPC seam.
-# Usage: ./tests/ui.sh [cursor|terminal|open|click|menu|hidden|selection|select|colour|lifted|icons|thumbs|hashcache|stale|nosweep|oem|header|overflow|focus|preview|network|sharebrowser|unmount|eject|rename|renamelife|taildrop|grid|columns|operations|tabs ...]; no argument runs all thirty-one.
+# Usage: ./tests/ui.sh [cursor|terminal|open|click|menu|hidden|selection|select|colour|lifted|icons|thumbs|hashcache|stale|nosweep|oem|header|overflow|focus|preview|network|networkedit|sharebrowser|unmount|eject|rename|renamelife|taildrop|grid|columns|operations|tabs ...]; no argument runs all thirty-two.
 set -u
 set -o pipefail
 # Hard rule 9's guard, which owns FIXTURE_ROOT and every create and delete this suite makes.
@@ -2184,6 +2184,90 @@ case_network() {
     sandbox_remove "$fixture_home"
 }
 
+# A bookmarked SFTP URI whose path is a literal tilde does not mount (gio has no ~ expansion).
+# Edit opens the same form over that line and Save rewrites it in place.
+case_networkedit() {
+    local dir="$fixture_root/networkedit"
+    sandbox_scratch "$dir"
+    : > "$dir/0-one.txt"
+    : > "$dir/0-two.txt"
+
+    local fixture_home="$fixture_root/networkedit-home"
+    fixture_home_make "$fixture_home"
+    mkdir -p "$fixture_home/.config/gtk-3.0"
+    local bookmarks="$fixture_home/.config/gtk-3.0/bookmarks"
+    printf 'sftp://tom@omv.example:22/~ omv\n' > "$bookmarks"
+    local real_home="$HOME"
+
+    export HOME="$fixture_home"
+    launch "$dir"
+    export HOME="$real_home"
+    wait_listing 3
+    wait_rail 2
+    for _attempt in $(seq 1 100); do
+        [[ "$(ipc networkEntries)" == "omv|network|share|false" ]] && break
+        sleep 0.05
+    done
+    [[ "$(ipc networkEntries)" == "omv|network|share|false" ]] \
+        || fail "networkedit: the seeded bookmark never reached the rail, got $(ipc networkEntries)"
+
+    key -k Tab >/dev/null
+    settle
+    [[ "$(ipc focusView)" == "rail" ]] || fail "networkedit: Tab did not reach the rail"
+    # Home(0), omv(1).
+    key j >/dev/null
+    settle
+    [[ "$(ipc railCursor)" == "1" ]] || fail "networkedit: cursor did not reach omv, it is $(ipc railCursor)"
+
+    click_rail_row 1 right
+    settle
+    printf 'NETWORKEDIT menu visible=%s entries=%s glyphs=%s\n' \
+        "$(ipc contextMenuVisible)" "$(ipc contextMenuEntries)" "$(ipc contextMenuGlyphs)"
+    shot networkedit-menu
+    [[ "$(ipc contextMenuVisible)" == "true" ]] || fail "networkedit: right click opened no menu on the bookmark"
+    [[ "$(ipc contextMenuEntries)" == "Edit" ]] \
+        || fail "networkedit: the bookmark's menu is $(ipc contextMenuEntries), not one Edit row"
+    [[ "$(ipc contextMenuGlyphs)" == "rename" ]] \
+        || fail "networkedit: the Edit row draws $(ipc contextMenuGlyphs), not the rename mark"
+
+    key -k Return >/dev/null
+    settle
+    [[ "$(ipc dialogOpen)" == "true" ]] || fail "networkedit: choosing Edit did not open the dialog"
+    [[ "$(ipc networkTitle)" == "EDIT NETWORK LOCATION" ]] \
+        || fail "networkedit: the heading is $(ipc networkTitle), not EDIT NETWORK LOCATION"
+    [[ "$(ipc networkProtocol)" == "SFTP" ]] || fail "networkedit: protocol is $(ipc networkProtocol), not SFTP"
+    [[ "$(ipc networkHost)" == "omv.example" ]] || fail "networkedit: host is $(ipc networkHost)"
+    [[ "$(ipc networkUser)" == "tom" ]] || fail "networkedit: user is $(ipc networkUser)"
+    [[ "$(ipc networkPath)" == "~" ]] || fail "networkedit: path is $(ipc networkPath), not the literal tilde"
+    [[ "$(ipc networkLabel)" == "omv" ]] || fail "networkedit: label is $(ipc networkLabel)"
+    [[ "$(ipc networkUri)" == "sftp://tom@omv.example:22/~" ]] \
+        || fail "networkedit: Mounts-as is $(ipc networkUri)"
+    shot networkedit-dialog
+
+    # Host has the caret. Tab past Port onto Path, drop the tilde, type the real remote home.
+    key -k Tab >/dev/null
+    key -k Tab >/dev/null
+    key -k BackSpace >/dev/null
+    key "home/tom" >/dev/null
+    settle
+    [[ "$(ipc networkUri)" == "sftp://tom@omv.example:22/home/tom" ]] \
+        || fail "networkedit: rewriting the path left Mounts-as as $(ipc networkUri)"
+    key -k Return >/dev/null
+    settle
+    [[ "$(ipc dialogOpen)" == "false" ]] || fail "networkedit: Save did not close the dialog"
+    for _attempt in $(seq 1 100); do
+        [[ "$(ipc networkEntries)" == "omv|network|share|false" ]] && break
+        sleep 0.05
+    done
+    [[ "$(ipc networkEntries)" == "omv|network|share|false" ]] \
+        || fail "networkedit: the rail lost the row after save, got $(ipc networkEntries)"
+    [[ "$(cat "$bookmarks")" == "sftp://tom@omv.example:22/home/tom omv" ]] \
+        || fail "networkedit: bookmarks became $(cat "$bookmarks")"
+    printf 'NETWORKEDIT menu=ok prefill=ok rewrite=ok\n'
+    kill_flea
+    sandbox_remove "$fixture_home"
+}
+
 # Item 1 of Task 15 fix round 2: activating a bare smb://host/ entry lists its shares as pane
 # rows (ui/ShareBrowser.qml) instead of round 1's superseded sidebar bookmark expansion, and Enter
 # on a row mounts and opens through the exact ui/NetworkMounts.qml pipeline a bookmarked share
@@ -2405,10 +2489,10 @@ EOS
         "$(ipc contextMenuVisible)" "$(ipc contextMenuEntries)" "$(ipc contextMenuGlyphs)"
     shot unmount-menu
     [[ "$(ipc contextMenuVisible)" == "true" ]] || fail "unmount: right click opened no menu on the share"
-    [[ "$(ipc contextMenuEntries)" == "Unmount" ]] \
-        || fail "unmount: the share's menu is $(ipc contextMenuEntries), not one Unmount row"
-    [[ "$(ipc contextMenuGlyphs)" == "eject" ]] \
-        || fail "unmount: the Unmount row draws $(ipc contextMenuGlyphs), not the eject mark"
+    [[ "$(ipc contextMenuEntries)" == "Unmount|Edit" ]] \
+        || fail "unmount: the share's menu is $(ipc contextMenuEntries), not Unmount then Edit"
+    [[ "$(ipc contextMenuGlyphs)" == "eject|rename" ]] \
+        || fail "unmount: the share's glyphs are $(ipc contextMenuGlyphs), not eject then rename"
     [[ -z "$(cat "$unmount_log")" ]] || fail "unmount: opening the menu already unmounted: $(cat "$unmount_log")"
 
     # Escape closes it and still nothing has run, which is what makes the menu the confirmation.
@@ -2989,7 +3073,7 @@ cache_snapshot
 trap cleanup EXIT
 
 declare -a wanted=("$@")
-[[ ${#wanted[@]} -eq 0 ]] && wanted=(cursor terminal open click menu hidden selection select colour lifted icons thumbs hashcache stale nosweep oem header overflow focus preview network sharebrowser unmount eject rename renamelife taildrop grid columns operations tabs)
+[[ ${#wanted[@]} -eq 0 ]] && wanted=(cursor terminal open click menu hidden selection select colour lifted icons thumbs hashcache stale nosweep oem header overflow focus preview network networkedit sharebrowser unmount eject rename renamelife taildrop grid columns operations tabs)
 
 : > "$run_log"
 : > "$flea_log"

--- a/tests/ui.sh
+++ b/tests/ui.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Drives the real Quickshell window with omarchy-drive and asserts through the read-only IPC seam.
-# Usage: ./tests/ui.sh [cursor|terminal|open|click|menu|hidden|selection|select|colour|lifted|icons|thumbs|hashcache|stale|nosweep|oem|header|overflow|focus|preview|network|networkedit|sharebrowser|unmount|eject|rename|renamelife|taildrop|grid|columns|operations|tabs ...]; no argument runs all thirty-two.
+# Usage: ./tests/ui.sh [cursor|terminal|open|click|menu|hidden|selection|select|colour|lifted|icons|thumbs|hashcache|stale|nosweep|oem|header|overflow|focus|preview|network|networkedit|networkremove|sharebrowser|unmount|eject|rename|renamelife|taildrop|grid|columns|operations|tabs ...]; no argument runs all thirty-three.
 set -u
 set -o pipefail
 # Hard rule 9's guard, which owns FIXTURE_ROOT and every create and delete this suite makes.
@@ -2533,6 +2533,121 @@ EOS
     sandbox_remove "$fixture_home"
 }
 
+# Remove of a live share must not drop the bookmark if gio -u fails; an unmounted bookmark
+# is dropped immediately with no gio call.
+case_networkremove() {
+    local dir="$fixture_root/networkremove"
+    sandbox_scratch "$dir"
+    mkdir -p "$dir/bin"
+    : > "$dir/0-one.txt"
+
+    local unmount_log="$dir/unmount.log"
+    : > "$unmount_log"
+    local share_uri="smb://stubhost/stubshare/"
+    cat > "$dir/bin/gio" <<EOS
+#!/bin/sh
+case "\$1 \$2" in
+  "mount -l")
+    printf 'Mount(0): stubshare on stubhost -> $share_uri\n  Type: GDaemonMount\n'
+    exit 0
+    ;;
+  "mount -u")
+    printf 'UNMOUNT %s\n' "\$3" >> "$unmount_log"
+    exit 1
+    ;;
+esac
+exit 0
+EOS
+    chmod +x "$dir/bin/gio"
+
+    local fixture_home="$fixture_root/networkremove-home"
+    fixture_home_make "$fixture_home"
+    mkdir -p "$fixture_home/.config/gtk-3.0"
+    local bookmarks="$fixture_home/.config/gtk-3.0/bookmarks"
+    printf '%s Stub\n' "$share_uri" > "$bookmarks"
+    local real_home="$HOME" saved_path="$PATH"
+
+    export PATH="$dir/bin:$PATH"
+    export HOME="$fixture_home"
+    launch "$dir"
+    export HOME="$real_home"
+    export PATH="$saved_path"
+    wait_listing 2
+    wait_rail 2
+    for _attempt in $(seq 1 100); do
+        [[ "$(ipc networkEntries)" == "Stub|network|share|true" ]] && break
+        sleep 0.05
+    done
+    [[ "$(ipc networkEntries)" == "Stub|network|share|true" ]] \
+        || fail "networkremove: the stub mount never appeared live, got $(ipc networkEntries)"
+
+    key -k Tab >/dev/null
+    settle
+    [[ "$(ipc focusView)" == "rail" ]] || fail "networkremove: Tab did not reach the rail"
+    key j >/dev/null
+    settle
+    click_rail_row 1 right
+    settle
+    [[ "$(ipc contextMenuEntries)" == "Unmount|Edit|Remove" ]] \
+        || fail "networkremove: menu is $(ipc contextMenuEntries)"
+    key j >/dev/null
+    key j >/dev/null
+    key -k Return >/dev/null
+    wait_message "That share could not be unmounted; it may still be in use."
+    [[ "$(cat "$unmount_log")" == "UNMOUNT $share_uri" ]] \
+        || fail "networkremove: Remove did not try to unmount, log is: $(cat "$unmount_log")"
+    [[ "$(cat "$bookmarks")" == "$share_uri Stub" ]] \
+        || fail "networkremove: a failed unmount dropped the bookmark, file is $(cat "$bookmarks")"
+
+    kill_flea
+    : > "$unmount_log"
+    cat > "$dir/bin/gio" <<EOS
+#!/bin/sh
+exit 0
+EOS
+    chmod +x "$dir/bin/gio"
+    printf '%s Stub\n' "$share_uri" > "$bookmarks"
+
+    export PATH="$dir/bin:$PATH"
+    export HOME="$fixture_home"
+    launch "$dir"
+    export HOME="$real_home"
+    export PATH="$saved_path"
+    wait_listing 2
+    wait_rail 2
+    for _attempt in $(seq 1 100); do
+        [[ "$(ipc networkEntries)" == "Stub|network|share|false" ]] && break
+        sleep 0.05
+    done
+    [[ "$(ipc networkEntries)" == "Stub|network|share|false" ]] \
+        || fail "networkremove: the unmounted bookmark never appeared, got $(ipc networkEntries)"
+
+    key -k Tab >/dev/null
+    settle
+    key j >/dev/null
+    settle
+    click_rail_row 1 right
+    settle
+    [[ "$(ipc contextMenuEntries)" == "Edit|Remove" ]] \
+        || fail "networkremove: unmounted menu is $(ipc contextMenuEntries)"
+    key j >/dev/null
+    key -k Return >/dev/null
+    settle
+    for _attempt in $(seq 1 100); do
+        [[ -z "$(ipc networkEntries)" ]] && break
+        sleep 0.05
+    done
+    [[ -z "$(ipc networkEntries)" ]] \
+        || fail "networkremove: the unmounted bookmark stayed on the rail, got $(ipc networkEntries)"
+    [[ "$(cat "$bookmarks")" != *"$share_uri"* ]] \
+        || fail "networkremove: the unmounted bookmark was not dropped, file is $(cat "$bookmarks")"
+    [[ -z "$(cat "$unmount_log")" ]] || fail "networkremove: an unmounted Remove called gio -u"
+
+    printf 'NETWORKREMOVE fail-keeps-bookmark=ok idle-drops=ok\n'
+    kill_flea
+    sandbox_remove "$fixture_home"
+}
+
 # The eject half of the same menu, and the one property that must never bend: "safe to unplug" is
 # read off an lsblk listing taken after gio exits, never off gio's exit code. Both are stubbed, so
 # no real device is touched and no privilege is needed; the gio stub always exits 0, which is the
@@ -3073,7 +3188,7 @@ cache_snapshot
 trap cleanup EXIT
 
 declare -a wanted=("$@")
-[[ ${#wanted[@]} -eq 0 ]] && wanted=(cursor terminal open click menu hidden selection select colour lifted icons thumbs hashcache stale nosweep oem header overflow focus preview network networkedit sharebrowser unmount eject rename renamelife taildrop grid columns operations tabs)
+[[ ${#wanted[@]} -eq 0 ]] && wanted=(cursor terminal open click menu hidden selection select colour lifted icons thumbs hashcache stale nosweep oem header overflow focus preview network networkedit networkremove sharebrowser unmount eject rename renamelife taildrop grid columns operations tabs)
 
 : > "$run_log"
 : > "$flea_log"

--- a/tests/ui.sh
+++ b/tests/ui.sh
@@ -2225,10 +2225,10 @@ case_networkedit() {
         "$(ipc contextMenuVisible)" "$(ipc contextMenuEntries)" "$(ipc contextMenuGlyphs)"
     shot networkedit-menu
     [[ "$(ipc contextMenuVisible)" == "true" ]] || fail "networkedit: right click opened no menu on the bookmark"
-    [[ "$(ipc contextMenuEntries)" == "Edit" ]] \
-        || fail "networkedit: the bookmark's menu is $(ipc contextMenuEntries), not one Edit row"
-    [[ "$(ipc contextMenuGlyphs)" == "rename" ]] \
-        || fail "networkedit: the Edit row draws $(ipc contextMenuGlyphs), not the rename mark"
+    [[ "$(ipc contextMenuEntries)" == "Edit|Remove" ]] \
+        || fail "networkedit: the bookmark's menu is $(ipc contextMenuEntries), not Edit then Remove"
+    [[ "$(ipc contextMenuGlyphs)" == "rename|trash" ]] \
+        || fail "networkedit: the glyphs are $(ipc contextMenuGlyphs), not rename then trash"
 
     key -k Return >/dev/null
     settle
@@ -2489,10 +2489,10 @@ EOS
         "$(ipc contextMenuVisible)" "$(ipc contextMenuEntries)" "$(ipc contextMenuGlyphs)"
     shot unmount-menu
     [[ "$(ipc contextMenuVisible)" == "true" ]] || fail "unmount: right click opened no menu on the share"
-    [[ "$(ipc contextMenuEntries)" == "Unmount|Edit" ]] \
-        || fail "unmount: the share's menu is $(ipc contextMenuEntries), not Unmount then Edit"
-    [[ "$(ipc contextMenuGlyphs)" == "eject|rename" ]] \
-        || fail "unmount: the share's glyphs are $(ipc contextMenuGlyphs), not eject then rename"
+    [[ "$(ipc contextMenuEntries)" == "Unmount|Edit|Remove" ]] \
+        || fail "unmount: the share's menu is $(ipc contextMenuEntries), not Unmount, Edit, Remove"
+    [[ "$(ipc contextMenuGlyphs)" == "eject|rename|trash" ]] \
+        || fail "unmount: the share's glyphs are $(ipc contextMenuGlyphs), not eject, rename, trash"
     [[ -z "$(cat "$unmount_log")" ]] || fail "unmount: opening the menu already unmounted: $(cat "$unmount_log")"
 
     # Escape closes it and still nothing has run, which is what makes the menu the confirmation.

--- a/tests/ui.sh
+++ b/tests/ui.sh
@@ -303,7 +303,7 @@ launch() {
     kill_flea
     cat "$flea_log" >> "$run_log" 2>/dev/null || true
     : > "$flea_log"
-    FLEA_PATH="$start_path" FLEA_BIN="$flea_bin" \
+    FLEA_PATH="$start_path" FLEA_BIN="$flea_bin" FLEA_DISABLE_NETWORK_DISCOVERY=1 \
         setsid nohup qs -p "$flea_ui" >"$flea_log" 2>&1 </dev/null &
     omarchy-drive wait window flea --timeout 15 >/dev/null
     omarchy-drive focus flea >/dev/null
@@ -2050,12 +2050,12 @@ case_network() {
     settle
     [[ "$(ipc dialogOpen)" == "true" ]] || fail "network: a from the rail did not open the add-location dialog"
     shot network-dialog-open
-    # The form opens with the caret in Host, which is the one field it actually needs.
-    # TEST-NET-2 (RFC 5737): guaranteed non-routable, so this never actually dials out.
+    # The form opens in Quick Connect. TEST-NET-2 (RFC 5737) is guaranteed non-routable,
+    # and saving a bookmark never dials it.
     key "198.51.100.1" >/dev/null
     settle
-    [[ "$(ipc networkUri)" == "smb://198.51.100.1:445/" ]] \
-        || fail "network: the Mounts-as line reads $(ipc networkUri)"
+    [[ "$(ipc networkQuickUri)" == "sftp://198.51.100.1/" ]] \
+        || fail "network: Quick Connect previews $(ipc networkQuickUri)"
     key -k Return >/dev/null
     settle
     [[ "$(ipc dialogOpen)" == "false" ]] || fail "network: Enter did not submit and close the dialog"
@@ -2111,6 +2111,7 @@ case_network() {
     key a >/dev/null
     settle
     [[ "$(ipc dialogOpen)" == "true" ]] || fail "network: the dialog did not reopen for the traversal walk"
+    key -k Tab >/dev/null
     key "hh" >/dev/null
     key -k Tab >/dev/null
     key -k Tab >/dev/null
@@ -2156,6 +2157,7 @@ case_network() {
     key a >/dev/null
     settle
     [[ "$(ipc dialogOpen)" == "true" ]] || fail "network: the dialog did not reopen for the re-home walk"
+    key -k Tab >/dev/null
     key "hh" >/dev/null
     key -k Tab >/dev/null
     key -k Tab >/dev/null

--- a/ui/ColumnPane.qml
+++ b/ui/ColumnPane.qml
@@ -46,6 +46,11 @@ Item {
         boundsBehavior: Flickable.StopAtBounds
         reuseItems: true
 
+        Flea.FastScrollHandler {
+            parent: view
+            flickable: view
+        }
+
         delegate: Flea.ColumnRow {
             required property int index
             width: view.width

--- a/ui/ContextMenu.qml
+++ b/ui/ContextMenu.qml
@@ -212,14 +212,33 @@ Item {
     function openSubmenu(index) {
         root.openSubmenuRow = index
         root.submenuCursor = 0
+        Qt.callLater(root.revealSubmenuCursor)
     }
 
-    // Rows above the open one are a mix of full rows and separators, so the offset is summed, not multiplied.
-    function submenuOffset() {
+    function entriesHeight(items) {
         var y = 0
-        for (var i = 0; i < root.openSubmenuRow; i++)
-            y += root.entries[i].separator === true ? separatorProbe.separatorHeight : Theme.rowHeight
+        for (var i = 0; i < items.length; i++)
+            y += items[i].separator === true ? separatorProbe.separatorHeight : Theme.rowHeight
         return y
+    }
+
+    function revealMainCursor() {
+        if (root.opened && !root.submenuOpen)
+            rows.positionViewAtIndex(root.cursor, ListView.Contain)
+    }
+
+    function revealSubmenuCursor() {
+        if (root.submenuOpen)
+            peers.positionViewAtIndex(root.submenuCursor, ListView.Contain)
+    }
+
+    onCursorChanged: root.revealMainCursor()
+    onSubmenuCursorChanged: root.revealSubmenuCursor()
+
+    function flyoutY() {
+        var row = rows.itemAtIndex(root.openSubmenuRow)
+        var wanted = row ? frame.y + Theme.spacing.rowPaddingY + row.y - rows.contentY : frame.y
+        return Menu.clamp(wanted, flyout.height, root.height)
     }
 
     // One row off the model, only so the two heights above are read from MenuRow rather than repeated here.
@@ -239,7 +258,7 @@ Item {
         id: frame
         width: Theme.menuWidth
         // The vertical inset keeps the first and last row's square highlight off the rounded corners.
-        height: rows.implicitHeight + 2 * Theme.spacing.rowPaddingY
+        height: Menu.boundedExtent(root.entriesHeight(root.entries) + 2 * Theme.spacing.rowPaddingY, root.height)
         // The height this menu is actually going to have, arriving after place() has already run.
         onHeightChanged: if (root.opened) root.clampFrame()
         color: Theme.color.surface
@@ -248,28 +267,34 @@ Item {
         // Mirrors hyprland decoration:rounding, same as NetworkDialog; 0 on a stock box stays square.
         radius: Style.cornerRadius
 
-        Column {
+        ListView {
             id: rows
-            width: parent.width
-            y: Theme.spacing.rowPaddingY
+            anchors.fill: parent
+            anchors.topMargin: Theme.spacing.rowPaddingY
+            anchors.bottomMargin: Theme.spacing.rowPaddingY
+            model: root.entries
+            clip: true
+            boundsBehavior: Flickable.StopAtBounds
 
-            Repeater {
-                model: root.entries
-                delegate: Flea.MenuRow {
-                    id: row
-                    required property var modelData
-                    required property int index
-                    width: rows.width
-                    entry: row.modelData
-                    compact: root.forRail
-                    current: !root.submenuOpen && root.cursor === row.index
-                    onHoverEntered: root.cursor = row.index
-                    onActivated: {
-                        if (Menu.hasSubmenu(row.modelData))
-                            root.openSubmenu(row.index)
-                        else
-                            root.choose(row.modelData.action)
-                    }
+            Flea.FastScrollHandler {
+                parent: rows
+                flickable: rows
+            }
+
+            delegate: Flea.MenuRow {
+                id: row
+                required property var modelData
+                required property int index
+                width: rows.width
+                entry: row.modelData
+                compact: root.forRail
+                current: !root.submenuOpen && root.cursor === row.index
+                onHoverEntered: root.cursor = row.index
+                onActivated: {
+                    if (Menu.hasSubmenu(row.modelData))
+                        root.openSubmenu(row.index)
+                    else
+                        root.choose(row.modelData.action)
                 }
             }
         }
@@ -279,36 +304,41 @@ Item {
     Rectangle {
         id: flyout
         visible: root.submenuOpen
-        x: frame.x + frame.width
-        // peers.y already carries the inset, so the flyout frame itself stays on the row grid.
-        y: frame.y + root.submenuOffset()
+        x: Menu.adjacentX(frame.x, frame.width, width, root.width)
+        y: root.flyoutY()
         width: Theme.menuWidth
-        height: peers.implicitHeight + 2 * Theme.spacing.rowPaddingY
+        height: Menu.boundedExtent(root.entriesHeight(root.submenuEntries) + 2 * Theme.spacing.rowPaddingY, root.height)
         color: Theme.color.surface
         border.width: Theme.spacing.hairline
         border.color: Theme.color.muted
         radius: Style.cornerRadius
 
-        Column {
+        ListView {
             id: peers
-            width: parent.width
-            y: Theme.spacing.rowPaddingY
+            anchors.fill: parent
+            anchors.topMargin: Theme.spacing.rowPaddingY
+            anchors.bottomMargin: Theme.spacing.rowPaddingY
+            model: root.submenuEntries
+            clip: true
+            boundsBehavior: Flickable.StopAtBounds
 
-            Repeater {
-                model: root.submenuEntries
-                delegate: Flea.MenuRow {
-                    id: subRow
-                    required property var modelData
-                    required property int index
-                    width: peers.width
-                    // A Taildrop peer is a machine and takes the sidebar's own server mark; an archive
-                    // format is a file about to exist and takes the archive mark.
-                    entry: ({ label: subRow.modelData.label, action: "",
-                              glyph: root.entries[root.openSubmenuRow].action === "taildrop" ? "server" : "archive" })
-                    current: root.submenuCursor === subRow.index
-                    onHoverEntered: root.submenuCursor = subRow.index
-                    onActivated: root.chooseSub(subRow.modelData.id)
-                }
+            Flea.FastScrollHandler {
+                parent: peers
+                flickable: peers
+            }
+
+            delegate: Flea.MenuRow {
+                id: subRow
+                required property var modelData
+                required property int index
+                width: peers.width
+                // A Taildrop peer is a machine and takes the sidebar's own server mark; an archive
+                // format is a file about to exist and takes the archive mark.
+                entry: ({ label: subRow.modelData.label, action: "",
+                          glyph: root.entries[root.openSubmenuRow].action === "taildrop" ? "server" : "archive" })
+                current: root.submenuCursor === subRow.index
+                onHoverEntered: root.submenuCursor = subRow.index
+                onActivated: root.chooseSub(subRow.modelData.id)
             }
         }
     }

--- a/ui/DeviceMounts.qml
+++ b/ui/DeviceMounts.qml
@@ -74,6 +74,8 @@ Item {
         root._listTimedOut = false
         root._streamPending = true
         root._listingsStarted += 1
+        // lsblk can legitimately return an empty tree. Never rebuild from the previous poll.
+        root._listOutput = ""
         listProcess.running = true
         listTimeout.restart()
     }

--- a/ui/FastScrollHandler.qml
+++ b/ui/FastScrollHandler.qml
@@ -1,0 +1,53 @@
+import QtQuick
+
+// Multiplies both smooth touchpad deltas and discrete wheel notches, then writes the bounded
+// position directly. A MouseArea is intentional: a Flickable consumes wheel events before a child
+// WheelHandler can answer them, while acceptedButtons: Qt.NoButton leaves taps and drags alone.
+MouseArea {
+    id: root
+
+    required property var flickable
+    property real speedMultiplier: 4
+    property real mouseWheelStep: Math.max(1,
+        Number(Application.styleHints.wheelScrollLines) || 3) * 24
+
+    anchors.fill: parent
+    acceptedButtons: Qt.NoButton
+    z: 1000
+
+    function scrollDistance(pixelDeltaY, angleDeltaY) {
+        var distance = Number(pixelDeltaY) || 0
+        if (distance === 0)
+            distance = (Number(angleDeltaY) || 0) / 120 * root.mouseWheelStep
+        return distance * root.speedMultiplier
+    }
+
+    function boundedContentY(value) {
+        var minimum = Number(root.flickable.originY) || 0
+        var maximum = Math.max(minimum,
+                               minimum + Math.max(0, Number(root.flickable.contentHeight) || 0)
+                               - Math.max(0, Number(root.flickable.height) || 0))
+        return Math.max(minimum, Math.min(maximum, value))
+    }
+
+    function scrollByDeltas(pixelDeltaY, angleDeltaY) {
+        var distance = root.scrollDistance(pixelDeltaY, angleDeltaY)
+        if (distance === 0 || !root.flickable.interactive)
+            return root.flickable.contentY
+        var previous = root.flickable.contentY
+        root.flickable.cancelFlick()
+        root.flickable.contentY = root.boundedContentY(root.flickable.contentY - distance)
+        return root.flickable.contentY
+    }
+
+    onWheel: function (wheel) {
+        var distance = root.scrollDistance(wheel.pixelDelta.y, wheel.angleDelta.y)
+        if (distance === 0 || !root.flickable.interactive) {
+            wheel.accepted = false
+            return
+        }
+        var previous = root.flickable.contentY
+        var current = root.scrollByDeltas(wheel.pixelDelta.y, wheel.angleDelta.y)
+        wheel.accepted = Math.abs(current - previous) > 0.01
+    }
+}

--- a/ui/GridArea.qml
+++ b/ui/GridArea.qml
@@ -34,6 +34,11 @@ GridView {
     boundsBehavior: Flickable.StopAtBounds
     reuseItems: true
 
+    Flea.FastScrollHandler {
+        parent: root
+        flickable: root
+    }
+
     delegate: Flea.GridTile {
         required property int index
         width: root.cellWidth

--- a/ui/Ipc.qml
+++ b/ui/Ipc.qml
@@ -250,6 +250,12 @@ QtObject {
         function networkPath(): string { return root.networkDialog.formPath() }
         function networkUser(): string { return root.networkDialog.formUser() }
         function networkLabel(): string { return root.networkDialog.formLabel() }
+        function networkMac(): string { return root.networkDialog.formMac() }
+        function networkQuickText(): string { return root.networkDialog.quickText() }
+        function networkQuickUri(): string { return root.networkDialog.quickUri() }
+        function tailnetState(): string { return root.pane.sidebar.tailnetState }
+        function tailnetMessage(): string { return root.pane.sidebar.tailnetMessage }
+        function lanDiscoveryState(): string { return root.pane.sidebar.lanState }
         // A protocol chip carries a label and no tree, so a test clicks its centre the way it does a row.
         function networkChipCentre(name: string): string { return root.fleaWindow.centreOf(root.networkDialog.formChip(name)) }
         function shareBrowserOpen(): bool { return root.shareBrowser.active }

--- a/ui/Ipc.qml
+++ b/ui/Ipc.qml
@@ -245,6 +245,11 @@ QtObject {
         function networkPort(): string { return root.networkDialog.formPort() }
         function networkUri(): string { return root.networkDialog.formUri() }
         function networkPathLabel(): string { return root.networkDialog.formPathLabel() }
+        function networkTitle(): string { return root.networkDialog.titleText }
+        function networkHost(): string { return root.networkDialog.formHost() }
+        function networkPath(): string { return root.networkDialog.formPath() }
+        function networkUser(): string { return root.networkDialog.formUser() }
+        function networkLabel(): string { return root.networkDialog.formLabel() }
         // A protocol chip carries a label and no tree, so a test clicks its centre the way it does a row.
         function networkChipCentre(name: string): string { return root.fleaWindow.centreOf(root.networkDialog.formChip(name)) }
         function shareBrowserOpen(): bool { return root.shareBrowser.active }

--- a/ui/List.qml
+++ b/ui/List.qml
@@ -41,6 +41,11 @@ ListView {
     // Every property the delegate draws is a binding on index, so a row leaving the buffer is re-bound rather than rebuilt.
     reuseItems: true
 
+    Flea.FastScrollHandler {
+        parent: root
+        flickable: root
+    }
+
     delegate: Flea.Row {
         id: cell
         required property int index

--- a/ui/NetworkActions.qml
+++ b/ui/NetworkActions.qml
@@ -1,0 +1,49 @@
+import QtQuick
+import Quickshell
+import Quickshell.Io
+import "js/Remote.js" as Remote
+
+// Host-side actions remain argv-direct. Privileged recovery is guidance only; this service never
+// starts tailscaled or logs a user into a tailnet behind their back.
+Item {
+    id: root
+
+    signal message(string text, bool isError)
+
+    function copyAddress(entry) {
+        if (copyProcess.running || !entry) return
+        copyProcess.command = ["wl-copy", String(entry.address || entry.uri || "")]
+        copyProcess.running = true
+    }
+
+    function openSsh(entry) {
+        var argv = Remote.terminalArgv(entry)
+        if (argv.length === 0) {
+            root.message("That location has no safe default SSH target.", true)
+            return
+        }
+        Quickshell.execDetached(argv)
+    }
+
+    function wake(entry) {
+        if (wakeProcess.running || !entry || !Remote.validMac(entry.mac)) return
+        wakeProcess.command = [Quickshell.env("FLEA_BIN") || "flea", "--wake", entry.mac]
+        wakeProcess.running = true
+    }
+
+    Process {
+        id: copyProcess
+        onExited: function (exitCode) {
+            root.message(exitCode === 0 ? "Network address copied to the clipboard."
+                                        : "The network address could not be copied.", exitCode !== 0)
+        }
+    }
+
+    Process {
+        id: wakeProcess
+        onExited: function (exitCode) {
+            root.message(exitCode === 0 ? "Wake-on-LAN packet sent."
+                                        : "Wake-on-LAN could not send a packet.", exitCode !== 0)
+        }
+    }
+}

--- a/ui/NetworkDialog.qml
+++ b/ui/NetworkDialog.qml
@@ -5,11 +5,12 @@ import qs.Commons
 import qs.Ui
 import "." as Flea
 import "js/Mounts.js" as Mounts
+import "js/Places.js" as Places
 import "js/Protocols.js" as Protocols
 import "js/Motion.js" as Motion
 
-// The Network group's add popup: a form over a gvfs URI, written to the same GTK bookmarks file
-// nautilus writes, plus a separate Add Dropbox action that runs the stock installer.
+// The Network group's add/edit popup: a form over a gvfs URI, written to the same GTK bookmarks
+// file nautilus writes. Add appends; Edit rewrites the line it opened on. Dropbox install is add-only.
 //
 // The form records a bookmark and mounts nothing, so it asks for a username (which the URI carries)
 // and never for a password. gio's own prompt is what asks for a secret at mount time. The canvas
@@ -21,6 +22,9 @@ Item {
     property bool opened: false
     property string statusText: ""
     property bool dropboxInstalled: false
+    // Empty while adding; the bookmark URI being rewritten while editing.
+    property string editingUri: ""
+    readonly property string titleText: root.editingUri.length > 0 ? "EDIT NETWORK LOCATION" : "ADD NETWORK LOCATION"
 
     signal closed()
     // Sidebar's own bookmarksFile FileView never watched a directory absent at its own
@@ -35,10 +39,26 @@ Item {
 
     function open() {
         root.statusText = ""
+        root.editingUri = ""
         form.reset()
         root.checkDropbox()
         root.opened = true
         // The host is the one field the form actually needs, so it takes the caret on open.
+        form.focusHost()
+    }
+
+    function openEdit(uri, label) {
+        root.statusText = ""
+        root.editingUri = uri
+        var parsed = Protocols.parse(uri)
+        if (!parsed) {
+            form.reset()
+            root.statusText = "This location could not be parsed."
+        } else {
+            form.load(parsed, label)
+        }
+        root.checkDropbox()
+        root.opened = true
         form.focusHost()
     }
 
@@ -53,17 +73,15 @@ Item {
             root.statusText = "A host is the one thing this needs; the rest is optional."
             return
         }
-        root.appendBookmark(form.uri, form.labelText())
+        root.writeBookmark(root.editingUri, form.uri, form.labelText())
         root.close()
     }
 
-    function appendBookmark(uri, label) {
+    function writeBookmark(oldUri, uri, label) {
         // Canonical form, so this line dedups against a later gio-reported mount of the same share.
         var canonical = Mounts.normalize(uri)
         var body = bookmarksWrite.text()
-        if (body.length > 0 && body.charAt(body.length - 1) !== "\n")
-            body += "\n"
-        bookmarksWrite.setText(body + canonical + " " + label + "\n")
+        bookmarksWrite.setText(Places.replace(body, oldUri, canonical, label))
         // Blocks until this write actually lands, not just until it is queued: without it,
         // Sidebar's reload() (fired by saved(), below) can race the write and read stale content.
         bookmarksWrite.waitForJob()
@@ -75,6 +93,10 @@ Item {
     function formPort() { return form.port }
     function formUri() { return form.uri }
     function formPathLabel() { return form.spec.pathLabel }
+    function formHost() { return form.host }
+    function formPath() { return form.path }
+    function formUser() { return form.user }
+    function formLabel() { return form.label }
     function formChip(name) { return form.chipFor(name) }
 
     function checkDropbox() {
@@ -174,7 +196,7 @@ Item {
                 spacing: Style.space(10)
 
                 PanelSectionHeader {
-                    text: "ADD NETWORK LOCATION"
+                    text: root.titleText
                 }
 
                 NetworkForm {
@@ -219,11 +241,16 @@ Item {
                 }
             }
 
-            PanelSeparator {}
+            PanelSeparator {
+                visible: root.editingUri.length === 0
+                height: visible ? implicitHeight : 0
+            }
 
             Column {
                 width: parent.width
                 spacing: Style.space(10)
+                visible: root.editingUri.length === 0
+                height: visible ? implicitHeight : 0
 
                 PanelSectionHeader {
                     text: "DROPBOX"

--- a/ui/NetworkDialog.qml
+++ b/ui/NetworkDialog.qml
@@ -8,6 +8,7 @@ import "js/Mounts.js" as Mounts
 import "js/Places.js" as Places
 import "js/Protocols.js" as Protocols
 import "js/Motion.js" as Motion
+import "js/QuickConnect.js" as QuickConnect
 
 // The Network group's add/edit popup: a form over a gvfs URI, written to the same GTK bookmarks
 // file nautilus writes. Add appends; Edit rewrites the line it opened on. Dropbox install is add-only.
@@ -25,11 +26,13 @@ Item {
     // Empty while adding; the bookmark URI being rewritten while editing.
     property string editingUri: ""
     readonly property string titleText: root.editingUri.length > 0 ? "EDIT NETWORK LOCATION" : "ADD NETWORK LOCATION"
+    readonly property var quickParsed: QuickConnect.parse(quickField.text)
+    readonly property string quickPreview: root.quickParsed ? root.quickParsed.uri : ""
 
     signal closed()
     // Sidebar's own bookmarksFile FileView never watched a directory absent at its own
     // construction, so a plain watch is not enough the first run; the caller reloads on this.
-    signal saved()
+    signal saved(string oldUri, string uri, string label, string mac)
 
     // A plain overlay, not a QQC Popup, the same call ui/ContextMenu.qml already made.
     anchors.fill: parent
@@ -40,26 +43,38 @@ Item {
     function open() {
         root.statusText = ""
         root.editingUri = ""
+        quickField.text = ""
         form.reset()
         root.checkDropbox()
         root.opened = true
-        // The host is the one field the form actually needs, so it takes the caret on open.
-        form.focusHost()
+        quickField.takeFocus()
     }
 
-    function openEdit(uri, label) {
+    function openEdit(uri, label, mac) {
         root.statusText = ""
         root.editingUri = uri
+        quickField.text = ""
         var parsed = Protocols.parse(uri)
         if (!parsed) {
             form.reset()
             root.statusText = "This location could not be parsed."
         } else {
-            form.load(parsed, label)
+            form.load(parsed, label, mac)
         }
         root.checkDropbox()
         root.opened = true
         form.focusHost()
+    }
+
+    function submitQuick() {
+        if (!root.quickParsed) {
+            root.statusText = "Enter a host, host/share, user@host:/path, or a supported URI."
+            return
+        }
+        var parsed = root.quickParsed
+        form.load(parsed.form, "", "")
+        root.writeBookmark("", parsed.uri, Protocols.label(parsed.form), "")
+        root.close()
     }
 
     function close() {
@@ -73,11 +88,11 @@ Item {
             root.statusText = "A host is the one thing this needs; the rest is optional."
             return
         }
-        root.writeBookmark(root.editingUri, form.uri, form.labelText())
+        root.writeBookmark(root.editingUri, form.uri, form.labelText(), form.mac)
         root.close()
     }
 
-    function writeBookmark(oldUri, uri, label) {
+    function writeBookmark(oldUri, uri, label, mac) {
         // Canonical form, so this line dedups against a later gio-reported mount of the same share.
         var canonical = Mounts.normalize(uri)
         var body = bookmarksWrite.text()
@@ -85,7 +100,7 @@ Item {
         // Blocks until this write actually lands, not just until it is queued: without it,
         // Sidebar's reload() (fired by saved(), below) can race the write and read stale content.
         bookmarksWrite.waitForJob()
-        root.saved()
+        root.saved(oldUri, canonical, label, mac)
     }
 
     // Read back by shell.qml's IPC so a test asserts the protocol swap without OCR.
@@ -97,7 +112,10 @@ Item {
     function formPath() { return form.path }
     function formUser() { return form.user }
     function formLabel() { return form.label }
+    function formMac() { return form.mac }
     function formChip(name) { return form.chipFor(name) }
+    function quickText() { return quickField.text }
+    function quickUri() { return root.quickPreview }
 
     function checkDropbox() {
         if (dropboxCheck.running) return
@@ -197,6 +215,28 @@ Item {
 
                 PanelSectionHeader {
                     text: root.titleText
+                }
+
+                Flea.DialogField {
+                    id: quickField
+                    visible: root.editingUri.length === 0
+                    height: visible ? implicitHeight : 0
+                    width: parent.width
+                    label: "Quick Connect"
+                    placeholder: "host/share or user@host:/path"
+                    onAccepted: root.submitQuick()
+                    onTabbed: form.focusHost()
+                }
+
+                Text {
+                    visible: quickField.visible && quickField.text.length > 0
+                    width: parent.width
+                    text: root.quickPreview.length > 0 ? "CONNECTS AS  " + root.quickPreview : "ADDRESS NOT RECOGNIZED"
+                    color: root.quickPreview.length > 0 ? Theme.color.muted : Theme.color.error
+                    font.family: Theme.font.family
+                    font.pixelSize: Theme.font.caption
+                    elide: Text.ElideMiddle
+                    textFormat: Text.PlainText
                 }
 
                 NetworkForm {

--- a/ui/NetworkDiscovery.qml
+++ b/ui/NetworkDiscovery.qml
@@ -1,0 +1,115 @@
+import QtQuick
+import Quickshell
+import Quickshell.Io
+import "js/Discovery.js" as Discovery
+import "js/Tailnet.js" as Tailnet
+
+// Optional, bounded discovery. Neither process owns mounting: both produce ordinary network rows
+// and ui/NetworkMounts.qml remains the one service that hands a URI to gio.
+Item {
+    id: root
+
+    property var tailnetPeers: []
+    property var lanEntries: []
+    property string tailnetState: "unknown"
+    property string tailnetMessage: ""
+    property string lanState: "unknown"
+    property string _tailOut: ""
+    property string _tailErr: ""
+    property string _lanOut: ""
+    property bool _tailTimedOut: false
+    property bool _lanTimedOut: false
+    readonly property bool disabled: Quickshell.env("FLEA_DISABLE_NETWORK_DISCOVERY") === "1"
+    readonly property var entries: Tailnet.entries(root.tailnetPeers, Quickshell.env("USER"))
+        .concat(root.lanEntries).concat(root.statusEntries())
+
+    signal message(string text, bool isError)
+
+    function statusEntries() {
+        if (root.tailnetState === "unknown" || root.tailnetState === "ready") return []
+        return [{ path:"", label:root.tailnetMessage, group:"network", kind:"status",
+                  uri:"flea-status://tailscale/", mounted:false, glyph:"alert", origin:"tailnet",
+                  health:root.tailnetState === "no-peers" ? "unknown" : "failed",
+                  address:"", peerId:"", taildrop:false, mac:"" }]
+    }
+
+    function refresh() {
+        if (!tailProcess.running) {
+            root._tailTimedOut = false
+            root._tailOut = ""
+            root._tailErr = ""
+            tailProcess.running = true
+            tailTimeout.restart()
+        }
+        if (!lanProcess.running) {
+            root._lanTimedOut = false
+            root._lanOut = ""
+            lanProcess.running = true
+            lanTimeout.restart()
+        }
+    }
+
+    Component.onCompleted: if (!root.disabled) root.refresh()
+
+    Timer {
+        interval: 30000
+        running: !root.disabled
+        repeat: true
+        onTriggered: root.refresh()
+    }
+
+    Timer {
+        id: tailTimeout
+        interval: 5000
+        onTriggered: {
+            if (!tailProcess.running) return
+            root._tailTimedOut = true
+            tailProcess.running = false
+            root.tailnetState = "failed"
+            root.tailnetMessage = "Tailscale status timed out."
+        }
+    }
+
+    Process {
+        id: tailProcess
+        command: ["tailscale", "status", "--json"]
+        stdout: StdioCollector { id: tailOut; waitForEnd: true; onStreamFinished: root._tailOut = text }
+        stderr: StdioCollector { id: tailErr; waitForEnd: true; onStreamFinished: root._tailErr = text }
+        onExited: function (exitCode) {
+            tailTimeout.stop()
+            if (root._tailTimedOut) return
+            var parsed = Tailnet.parseResult(exitCode, tailOut.text || root._tailOut, tailErr.text || root._tailErr)
+            root.tailnetState = parsed.state
+            root.tailnetMessage = parsed.message
+            root.tailnetPeers = parsed.peers
+        }
+    }
+
+    Timer {
+        id: lanTimeout
+        interval: 5000
+        onTriggered: {
+            if (!lanProcess.running) return
+            root._lanTimedOut = true
+            lanProcess.running = false
+            root.lanState = "failed"
+        }
+    }
+
+    Process {
+        id: lanProcess
+        command: ["avahi-browse", "-artp"]
+        stdout: StdioCollector { id: lanOut; waitForEnd: true; onStreamFinished: root._lanOut = text }
+        onExited: function (exitCode) {
+            lanTimeout.stop()
+            if (root._lanTimedOut) return
+            if (exitCode !== 0) {
+                root.lanState = "unavailable"
+                root.lanEntries = []
+                return
+            }
+            root.lanEntries = Discovery.parse(lanOut.text || root._lanOut)
+            root.lanState = root.lanEntries.length > 0 ? "ready" : "empty"
+        }
+    }
+}

--- a/ui/NetworkForm.qml
+++ b/ui/NetworkForm.qml
@@ -18,6 +18,7 @@ Column {
     readonly property string path: pathField.text
     readonly property string domain: domainField.text
     readonly property string user: userField.text
+    readonly property string mac: macField.text
     // The TLS box flips dav/davs and ftp/ftps, and the canvas draws it ticked.
     property bool tls: true
 
@@ -69,7 +70,7 @@ Column {
                 ring.push(kids[i])
             }
         }
-        ring.push(labelField, hostField, portField, pathField, domainField, userField, tlsRow)
+        ring.push(labelField, hostField, portField, pathField, domainField, userField, macField, tlsRow)
         return ring
     }
 
@@ -105,13 +106,14 @@ Column {
         pathField.text = ""
         domainField.text = ""
         userField.text = ""
+        macField.text = ""
         root.tls = true
         root.pick("SMB")
     }
 
     // Fill from Protocols.parse, without pick(), so a non-default port survives rather than
     // snapping back to the protocol's own default the way a chip click does.
-    function load(parsed, name) {
+    function load(parsed, name, mac) {
         if (!parsed) {
             reset()
             return
@@ -124,6 +126,7 @@ Column {
         pathField.text = parsed.path || ""
         domainField.text = parsed.domain || ""
         userField.text = parsed.user || ""
+        macField.text = mac || ""
     }
 
     Row {
@@ -200,6 +203,15 @@ Column {
         visible: root.spec.credentials
         height: visible ? implicitHeight : 0
         label: "Username"
+        onAccepted: root.submitted()
+        onTabbed: function (from, back) { root.step(from, back ? -1 : 1) }
+    }
+
+    Flea.DialogField {
+        id: macField
+        width: parent.width
+        label: "Wake MAC (optional)"
+        placeholder: "aa:bb:cc:dd:ee:ff"
         onAccepted: root.submitted()
         onTabbed: function (from, back) { root.step(from, back ? -1 : 1) }
     }

--- a/ui/NetworkForm.qml
+++ b/ui/NetworkForm.qml
@@ -109,6 +109,23 @@ Column {
         root.pick("SMB")
     }
 
+    // Fill from Protocols.parse, without pick(), so a non-default port survives rather than
+    // snapping back to the protocol's own default the way a chip click does.
+    function load(parsed, name) {
+        if (!parsed) {
+            reset()
+            return
+        }
+        root.protocol = parsed.protocol
+        root.tls = !!parsed.tls
+        portField.text = String(parsed.port || Protocols.defaultPort(parsed.protocol))
+        labelField.text = name || ""
+        hostField.text = parsed.host || ""
+        pathField.text = parsed.path || ""
+        domainField.text = parsed.domain || ""
+        userField.text = parsed.user || ""
+    }
+
     Row {
         id: chips
         spacing: Theme.spacing.hairline * 6

--- a/ui/NetworkHistory.qml
+++ b/ui/NetworkHistory.qml
@@ -1,0 +1,54 @@
+import QtQuick
+import Quickshell
+import Quickshell.Io
+import "js/Recents.js" as Recents
+
+// Successful opens only, in a file that carries no credentials. GTK bookmarks remain Favorites;
+// this bounded list is recency, not a second source of truth for what the operator pinned.
+Item {
+    id: root
+
+    property var recent: []
+    property var profiles: []
+    readonly property var entries: Recents.entries(root.recent)
+    readonly property var profileEntries: Recents.profileEntries(root.profiles)
+
+    function write() {
+        historyFile.setText(Recents.serializeState(root.recent, root.profiles))
+        historyFile.waitForJob()
+    }
+
+    function record(uri, label, mac) {
+        root.recent = Recents.record(root.recent, uri, label, Date.now(), mac)
+        root.write()
+    }
+
+    function rememberProfile(oldUri, uri, label, mac) {
+        root.profiles = Recents.rememberProfile(root.profiles, oldUri, uri, label, mac)
+        root.write()
+    }
+
+    function remove(uri) {
+        root.recent = Recents.remove(root.recent, uri)
+        root.profiles = Recents.remove(root.profiles, uri)
+        root.write()
+    }
+
+    FileView {
+        id: historyFile
+        path: Quickshell.env("HOME") + "/.config/flea-network-recents.json"
+        atomicWrites: true
+        watchChanges: true
+        printErrors: false
+        onLoaded: {
+            var state = Recents.parseState(text())
+            root.recent = state.recent
+            root.profiles = state.profiles
+        }
+        onFileChanged: reload()
+        onLoadFailed: {
+            root.recent = []
+            root.profiles = []
+        }
+    }
+}

--- a/ui/NetworkMounts.qml
+++ b/ui/NetworkMounts.qml
@@ -136,6 +136,9 @@ Item {
             root.runInfo(uri)
             return
         }
+        // The collector belongs to the Process, but this fallback belongs to us and survives
+        // restarts. A quiet failure must never inherit an earlier "already mounted" stderr.
+        root._mountErrOutput = ""
         mountProcess.command = ["gio", "mount", uri]
         mountProcess.running = true
         mountTimeout.restart()
@@ -155,6 +158,8 @@ Item {
     }
 
     function runInfo(uri) {
+        // An empty reply is an answer. Do not turn it into the previous share's local path.
+        root._infoOutput = ""
         infoProcess.command = ["gio", "info", uri]
         infoProcess.running = true
     }
@@ -173,6 +178,8 @@ Item {
     function listShares(uri) {
         if (listSharesProcess.running) return
         root._listSharesTimedOut = false
+        // A server that now lists nothing must not reopen the prior server's rows.
+        root._listSharesOutput = ""
         listSharesProcess.command = ["gio", "list", uri]
         listSharesProcess.running = true
         listSharesTimeout.restart()
@@ -240,6 +247,8 @@ Item {
             return
         }
         root._listTimedOut = false
+        // Successful empty output means there are no live mounts; the prior poll is not a fallback.
+        root._mountListOutput = ""
         mountListProcess.running = true
         listTimeout.restart()
     }

--- a/ui/NetworkMounts.qml
+++ b/ui/NetworkMounts.qml
@@ -164,13 +164,11 @@ Item {
     function isBareRoot(uri) {
         return /^[a-z][a-z0-9+.-]*:\/\/[^\/]+\/?$/i.test(uri)
     }
-
     // Reads gio's own words rather than guessing from the uri's shape; see AGENTS.md "'Already
     // mounted' is not just a bare-root quirk" for why isBareRoot() alone was wrong here.
     function isAlreadyMountedQuirk(text) {
         return /already mounted/i.test(String(text || ""))
     }
-
     // Client-side only, never writes bookmarks; see AGENTS.md "The share browser overlay".
     function listShares(uri) {
         if (listSharesProcess.running) return
@@ -179,7 +177,6 @@ Item {
         listSharesProcess.running = true
         listSharesTimeout.restart()
     }
-
     // Right click unmounts directly, no confirmation popup: see AGENTS.md "A second ContextMenu
     // instance breaks the whole window's keyboard focus" for why one was tried and reverted.
     function unmount(index) {
@@ -201,12 +198,10 @@ Item {
         root.runUnmount(target)
         return true
     }
-
     function runUnmount(uri) {
         unmountProcess.command = ["gio", "mount", "-u", uri]
         unmountProcess.running = true
     }
-
     function dropBookmark(uri) {
         var body = bookmarksWrite.text()
         bookmarksWrite.setText(Places.remove(body, uri))

--- a/ui/NetworkMounts.qml
+++ b/ui/NetworkMounts.qml
@@ -42,6 +42,10 @@ Item {
     // report a second, redundant failure for the exact same mount attempt.
     property bool _mountTimedOut: false
     property string _pendingUnmountLabel: ""
+    property string _pendingUnmountUri: ""
+    // The FUSE path last opened for a share, so Unmount can leave it before gio -u (busy otherwise).
+    property string _openFuse: ""
+    property string _openFuseKey: ""
     // A re-read asked for mid-listing used to be dropped, leaving a just-mounted share to wait out
     // the poll; this remembers it instead, and mountListProcess runs it the moment the listing ends.
     property bool _pollAgain: false
@@ -84,25 +88,11 @@ Item {
         onTriggered: root.pollMounts()
     }
 
-    // Three sources, deduped on the normalized uri (see ui/js/Mounts.js "normalize"): a live gio mount wins over a bookmark for the same share even when the trailing slash differs.
+    // Three sources, deduped on the normalized uri (see ui/js/Mounts.js "normalize"): a live gio
+    // mount wins the row, the bookmark keeps the label. Places.networkEntries is that merge.
     function rebuild() {
         var home = Quickshell.env("HOME")
-        var out = []
-        var seen = {}
-        var mounts = Mounts.parseMounts(root._mountListing)
-        for (var i = 0; i < mounts.length; i++) {
-            var mkey = Mounts.normalize(mounts[i].uri)
-            if (seen[mkey]) continue
-            seen[mkey] = true
-            out.push({ path: "", label: mounts[i].label, group: "network", kind: "share", uri: mounts[i].uri, mounted: true, glyph: "server" })
-        }
-        var marks = Mounts.nonFileBookmarks(root.bookmarksText)
-        for (var j = 0; j < marks.length; j++) {
-            var bkey = Mounts.normalize(marks[j].uri)
-            if (seen[bkey]) continue
-            seen[bkey] = true
-            out.push({ path: "", label: marks[j].label, group: "network", kind: "share", uri: marks[j].uri, mounted: false, glyph: "server" })
-        }
+        var out = Places.networkEntries(Mounts.parseMounts(root._mountListing), Mounts.nonFileBookmarks(root.bookmarksText))
         if (dropboxFile.loaded) {
             out.push({ path: home + "/Dropbox", label: "Dropbox", group: "network", kind: "dropbox", uri: "", mounted: true, glyph: "" })
         }
@@ -162,9 +152,21 @@ Item {
     // instance breaks the whole window's keyboard focus" for why one was tried and reverted.
     function unmount(index) {
         var e = root.entries[index]
-        if (!e || e.kind !== "share" || !e.mounted || unmountProcess.running) return
+        if (!e || e.kind !== "share" || !e.mounted || unmountProcess.running || unmountDelay.running) return
         root._pendingUnmountLabel = e.label
-        unmountProcess.command = ["gio", "mount", "-u", e.uri]
+        root._pendingUnmountUri = e.uri
+        if (root._openFuseKey.length > 0 && Mounts.normalize(e.uri) === root._openFuseKey) {
+            root._openFuse = ""
+            root._openFuseKey = ""
+            root.opened(Quickshell.env("HOME"))
+            unmountDelay.restart()
+            return
+        }
+        root.runUnmount(e.uri)
+    }
+
+    function runUnmount(uri) {
+        unmountProcess.command = ["gio", "mount", "-u", uri]
         unmountProcess.running = true
     }
 
@@ -227,6 +229,18 @@ Item {
         }
     }
 
+    Timer {
+        id: unmountDelay
+        interval: 150
+        repeat: false
+        onTriggered: {
+            var uri = root._pendingUnmountUri
+            root._pendingUnmountUri = ""
+            if (uri.length > 0)
+                root.runUnmount(uri)
+        }
+    }
+
     Process {
         id: mountProcess
         stderr: StdioCollector { id: mountErr; waitForEnd: true; onStreamFinished: root._mountErrOutput = text }
@@ -254,7 +268,10 @@ Item {
             var body = String(infoOut.text || root._infoOutput || "")
             var line = body.split("\n").find(function (l) { return l.indexOf("local path: ") === 0 })
             if (exitCode === 0 && line) {
-                root.opened(line.substring("local path: ".length).trim())
+                var localPath = line.substring("local path: ".length).trim()
+                root._openFuse = localPath
+                root._openFuseKey = Mounts.normalize(root._pendingUri)
+                root.opened(localPath)
                 return
             }
             if (root.isBareRoot(root._pendingUri)) {

--- a/ui/NetworkMounts.qml
+++ b/ui/NetworkMounts.qml
@@ -43,6 +43,8 @@ Item {
     property bool _mountTimedOut: false
     property string _pendingUnmountLabel: ""
     property string _pendingUnmountUri: ""
+    // Set by Remove on a live share; the bookmark is dropped only after gio -u succeeds.
+    property string _pendingRemoveUri: ""
     // The FUSE path last opened for a share, so Unmount can leave it before gio -u (busy otherwise).
     property string _openFuse: ""
     property string _openFuseKey: ""
@@ -152,7 +154,8 @@ Item {
     // instance breaks the whole window's keyboard focus" for why one was tried and reverted.
     function unmount(index) {
         var e = root.entries[index]
-        if (!e || e.kind !== "share" || !e.mounted || unmountProcess.running || unmountDelay.running) return
+        if (!e || e.kind !== "share" || !e.mounted || unmountProcess.running || unmountDelay.running)
+            return false
         root._pendingUnmountLabel = e.label
         // gio lists one SFTP mount for the host; -u must be that URI, not a path on it.
         var target = Places.coveringUri(Mounts.parseMounts(root._mountListing), e.uri)
@@ -162,9 +165,10 @@ Item {
             root._openFuseKey = ""
             root.opened(Quickshell.env("HOME"))
             unmountDelay.restart()
-            return
+            return true
         }
         root.runUnmount(target)
+        return true
     }
 
     function runUnmount(uri) {
@@ -172,17 +176,25 @@ Item {
         unmountProcess.running = true
     }
 
-    // Drops the bookmark line. A live mount is unmounted too, so the row leaves the rail instead
-    // of turning into a mount-only leftover of the place the operator just deleted.
+    function dropBookmark(uri) {
+        var body = bookmarksWrite.text()
+        bookmarksWrite.setText(Places.remove(body, uri))
+        bookmarksWrite.waitForJob()
+        root.renamed()
+    }
+
+    // An unmounted bookmark is dropped immediately. A live one is unmounted first; the file is
+    // rewritten from unmountProcess.onExited only when gio succeeds, so a busy share keeps its row.
     function remove(index) {
         var e = root.entries[index]
         if (!e || e.kind !== "share") return
-        var body = bookmarksWrite.text()
-        bookmarksWrite.setText(Places.remove(body, e.uri))
-        bookmarksWrite.waitForJob()
-        root.renamed()
-        if (e.mounted)
-            root.unmount(index)
+        if (!e.mounted) {
+            root.dropBookmark(e.uri)
+            return
+        }
+        root._pendingRemoveUri = e.uri
+        if (!root.unmount(index))
+            root._pendingRemoveUri = ""
     }
 
     // Rewrites uri's own label, or appends a bookmark for it if it was only ever a live mount;
@@ -301,12 +313,18 @@ Item {
     Process {
         id: unmountProcess
         onExited: function (exitCode) {
+            var removeUri = root._pendingRemoveUri
+            root._pendingRemoveUri = ""
             root.pollMounts()
             // A success message replaces the arm prompt, which would otherwise linger, stale,
             // for up to its own 4 s clear window with nothing on screen to say it already fired.
-            root.message(exitCode === 0
-                ? "Unmounted " + root._pendingUnmountLabel + "."
-                : "That share could not be unmounted; it may still be in use.", exitCode !== 0)
+            if (exitCode === 0) {
+                if (removeUri.length > 0)
+                    root.dropBookmark(removeUri)
+                root.message("Unmounted " + root._pendingUnmountLabel + ".", false)
+                return
+            }
+            root.message("That share could not be unmounted; it may still be in use.", true)
         }
     }
 

--- a/ui/NetworkMounts.qml
+++ b/ui/NetworkMounts.qml
@@ -154,15 +154,17 @@ Item {
         var e = root.entries[index]
         if (!e || e.kind !== "share" || !e.mounted || unmountProcess.running || unmountDelay.running) return
         root._pendingUnmountLabel = e.label
-        root._pendingUnmountUri = e.uri
-        if (root._openFuseKey.length > 0 && Mounts.normalize(e.uri) === root._openFuseKey) {
+        // gio lists one SFTP mount for the host; -u must be that URI, not a path on it.
+        var target = Places.coveringUri(Mounts.parseMounts(root._mountListing), e.uri)
+        root._pendingUnmountUri = target
+        if (root._openFuseKey.length > 0 && Places.connectionKey(e.uri) === root._openFuseKey) {
             root._openFuse = ""
             root._openFuseKey = ""
             root.opened(Quickshell.env("HOME"))
             unmountDelay.restart()
             return
         }
-        root.runUnmount(e.uri)
+        root.runUnmount(target)
     }
 
     function runUnmount(uri) {
@@ -270,7 +272,7 @@ Item {
             if (exitCode === 0 && line) {
                 var localPath = line.substring("local path: ".length).trim()
                 root._openFuse = localPath
-                root._openFuseKey = Mounts.normalize(root._pendingUri)
+                root._openFuseKey = Places.connectionKey(root._pendingUri)
                 root.opened(localPath)
                 return
             }

--- a/ui/NetworkMounts.qml
+++ b/ui/NetworkMounts.qml
@@ -10,6 +10,8 @@ Item {
     id: root
 
     property string bookmarksText: ""
+    property var extraEntries: []
+    property var healthMap: ({})
     property var entries: []
 
     signal opened(string path)
@@ -18,6 +20,7 @@ Item {
     signal sharesListed(string baseUri, string baseLabel, var names)
     // Fired once the write below has actually landed, so a caller's reload reads it, not stale content.
     signal renamed()
+    signal connectionSucceeded(string uri, string label, string mac)
 
     // Nothing filesystem-watchable tells us when a share appears or drops: a mount materialises a
     // directory under /run/user/1000/gvfs that inotify never reports an event for, measured on this box.
@@ -41,6 +44,7 @@ Item {
     // Set right before mountTimeout terminates the process, so its own onExited does not also
     // report a second, redundant failure for the exact same mount attempt.
     property bool _mountTimedOut: false
+    property bool _listSharesTimedOut: false
     property string _pendingUnmountLabel: ""
     property string _pendingUnmountUri: ""
     // Set by Remove on a live share; the bookmark is dropped only after gio -u succeeds.
@@ -56,8 +60,10 @@ Item {
     property bool _listTimedOut: false
     // The entry's own label at activation time, carried through to the sharesListed signal.
     property string _pendingLabel: ""
+    property string _pendingMac: ""
 
     onBookmarksTextChanged: root.rebuild()
+    onExtraEntriesChanged: root.rebuild()
 
     // ~/Dropbox does not exist until the stock service is installed and authenticated; this
     // FileView never reads text(), it only watches the path's own existence flip.
@@ -94,7 +100,9 @@ Item {
     // mount wins the row, the bookmark keeps the label. Places.networkEntries is that merge.
     function rebuild() {
         var home = Quickshell.env("HOME")
-        var out = Places.networkEntries(Mounts.parseMounts(root._mountListing), Mounts.nonFileBookmarks(root.bookmarksText))
+        var out = Places.networkEntries(Mounts.parseMounts(root._mountListing),
+                                        Mounts.nonFileBookmarks(root.bookmarksText),
+                                        root.extraEntries, root.healthMap)
         if (dropboxFile.loaded) {
             out.push({ path: home + "/Dropbox", label: "Dropbox", group: "network", kind: "dropbox", uri: "", mounted: true, glyph: "" })
         }
@@ -107,17 +115,23 @@ Item {
     function activate(index) {
         var e = root.entries[index]
         if (!e) return
-        if (e.kind === "share") {
-            root.openShare(e.uri, e.mounted, e.label)
+        if (e.kind === "status") {
+            root.message(e.label, e.health === "failed")
+            return
+        }
+        if (e.kind !== "dropbox") {
+            root.openShare(e.uri, e.mounted, e.label, e.mac)
             return
         }
         root.opened(e.path)
     }
 
-    function openShare(uri, alreadyMounted, label) {
+    function openShare(uri, alreadyMounted, label, mac) {
         if (mountProcess.running || infoProcess.running) return
         root._pendingUri = uri
         root._pendingLabel = label || ""
+        root._pendingMac = mac || ""
+        root.setHealth(uri, "connecting")
         if (alreadyMounted) {
             root.runInfo(uri)
             return
@@ -125,6 +139,19 @@ Item {
         mountProcess.command = ["gio", "mount", uri]
         mountProcess.running = true
         mountTimeout.restart()
+    }
+
+    function setHealth(uri, state) {
+        var next = {}
+        var target = Mounts.normalize(uri)
+        for (var key in root.healthMap) {
+            if (key !== target)
+                next[key] = root.healthMap[key]
+        }
+        if (state.length > 0)
+            next[target] = state
+        root.healthMap = next
+        root.rebuild()
     }
 
     function runInfo(uri) {
@@ -146,15 +173,19 @@ Item {
 
     // Client-side only, never writes bookmarks; see AGENTS.md "The share browser overlay".
     function listShares(uri) {
+        if (listSharesProcess.running) return
+        root._listSharesTimedOut = false
         listSharesProcess.command = ["gio", "list", uri]
         listSharesProcess.running = true
+        listSharesTimeout.restart()
     }
 
     // Right click unmounts directly, no confirmation popup: see AGENTS.md "A second ContextMenu
     // instance breaks the whole window's keyboard focus" for why one was tried and reverted.
     function unmount(index) {
         var e = root.entries[index]
-        if (!e || e.kind !== "share" || !e.mounted || unmountProcess.running || unmountDelay.running)
+        if (!e || e.kind === "dropbox" || e.kind === "status" || !e.mounted
+                || unmountProcess.running || unmountDelay.running)
             return false
         root._pendingUnmountLabel = e.label
         // gio lists one SFTP mount for the host; -u must be that URI, not a path on it.
@@ -228,6 +259,7 @@ Item {
             // Ending it is what lets the next poll run at all; a listing nobody can end froze the rail.
             root._listTimedOut = true
             mountListProcess.running = false
+            root.message("Network status timed out; keeping the last known connections.", true)
         }
     }
 
@@ -239,6 +271,7 @@ Item {
             if (!mountProcess.running) return
             root._mountTimedOut = true
             mountProcess.running = false
+            root.setHealth(root._pendingUri, "failed")
             root.message("That network location did not respond; check the address and try again.", true)
         }
     }
@@ -249,9 +282,21 @@ Item {
         repeat: false
         onTriggered: {
             var uri = root._pendingUnmountUri
-            root._pendingUnmountUri = ""
             if (uri.length > 0)
                 root.runUnmount(uri)
+        }
+    }
+
+    Timer {
+        id: listSharesTimeout
+        interval: root.listTimeoutMs
+        repeat: false
+        onTriggered: {
+            if (!listSharesProcess.running) return
+            root._listSharesTimedOut = true
+            listSharesProcess.running = false
+            root.setHealth(root._pendingUri, "failed")
+            root.message("Listing shares timed out; the server may be offline.", true)
         }
     }
 
@@ -266,6 +311,7 @@ Item {
             var errText = String(mountErr.text || root._mountErrOutput || "")
             // gio's own "already mounted" quirk is still worth listing; only a real failure is fatal.
             if (exitCode !== 0 && !root.isAlreadyMountedQuirk(errText)) {
+                root.setHealth(root._pendingUri, "failed")
                 root.message("That network location could not be mounted; check the address and try again.", true)
                 return
             }
@@ -285,6 +331,8 @@ Item {
                 var localPath = line.substring("local path: ".length).trim()
                 root._openFuse = localPath
                 root._openFuseKey = Places.connectionKey(root._pendingUri)
+                root.setHealth(root._pendingUri, "mounted")
+                root.connectionSucceeded(root._pendingUri, root._pendingLabel, root._pendingMac)
                 root.opened(localPath)
                 return
             }
@@ -293,6 +341,7 @@ Item {
                 return
             }
             root.message("This network location has no browsable folder; bookmark a specific share instead.", false)
+            root.setHealth(root._pendingUri, "failed")
         }
     }
 
@@ -300,12 +349,16 @@ Item {
         id: listSharesProcess
         stdout: StdioCollector { id: listSharesOut; waitForEnd: true; onStreamFinished: root._listSharesOutput = text }
         onExited: function (exitCode) {
+            listSharesTimeout.stop()
+            if (root._listSharesTimedOut) return
             var body = String(listSharesOut.text || root._listSharesOutput || "")
             var names = body.split("\n").map(function (s) { return s.trim() }).filter(function (s) { return s.length > 0 })
             if (exitCode !== 0 || names.length === 0) {
+                root.setHealth(root._pendingUri, "failed")
                 root.message("This network location has no browsable folder; bookmark a specific share instead.", false)
                 return
             }
+            root.setHealth(root._pendingUri, "online")
             root.sharesListed(root._pendingUri, root._pendingLabel, names)
         }
     }
@@ -316,15 +369,18 @@ Item {
             var removeUri = root._pendingRemoveUri
             root._pendingRemoveUri = ""
             root.pollMounts()
+            root.setHealth(root._pendingUnmountUri, exitCode === 0 ? "" : "failed")
             // A success message replaces the arm prompt, which would otherwise linger, stale,
             // for up to its own 4 s clear window with nothing on screen to say it already fired.
             if (exitCode === 0) {
                 if (removeUri.length > 0)
                     root.dropBookmark(removeUri)
                 root.message("Unmounted " + root._pendingUnmountLabel + ".", false)
-                return
+            } else {
+                root.message("That share could not be unmounted; it may still be in use.", true)
             }
-            root.message("That share could not be unmounted; it may still be in use.", true)
+            root._pendingUnmountUri = ""
+            root._pendingUnmountLabel = ""
         }
     }
 

--- a/ui/NetworkMounts.qml
+++ b/ui/NetworkMounts.qml
@@ -8,12 +8,10 @@ import "js/Places.js" as Places
 // that touches gio or the filesystem. ui/Sidebar.qml only reads "entries" and renders it.
 Item {
     id: root
-
     property string bookmarksText: ""
     property var extraEntries: []
     property var healthMap: ({})
     property var entries: []
-
     signal opened(string path)
     signal message(string text, bool isError)
     // Client-side only, see "listShares" below: ui/ShareBrowser.qml renders these as pane rows.
@@ -21,7 +19,6 @@ Item {
     // Fired once the write below has actually landed, so a caller's reload reads it, not stale content.
     signal renamed()
     signal connectionSucceeded(string uri, string label, string mac)
-
     // Nothing filesystem-watchable tells us when a share appears or drops: a mount materialises a
     // directory under /run/user/1000/gvfs that inotify never reports an event for, measured on this box.
     readonly property int mountPollMs: 5000
@@ -61,16 +58,13 @@ Item {
     // The entry's own label at activation time, carried through to the sharesListed signal.
     property string _pendingLabel: ""
     property string _pendingMac: ""
-
     onBookmarksTextChanged: root.rebuild()
     onExtraEntriesChanged: root.rebuild()
-
     // ~/Dropbox does not exist until the stock service is installed and authenticated; this
     // FileView never reads text(), it only watches the path's own existence flip.
     // The context menu's own gate for "Move to Dropbox": the same watch the sidebar row uses, because
     // ~/Dropbox does not exist until the stock service is installed and authenticated.
     readonly property bool dropboxReady: dropboxFile.loaded
-
     FileView {
         id: dropboxFile
         path: Quickshell.env("HOME") + "/Dropbox"
@@ -79,7 +73,6 @@ Item {
         onLoaded: root.rebuild()
         onLoadFailed: root.rebuild()
     }
-
     // A second FileView on the same path as ui/Sidebar.qml's own read-only watch, the identical
     // split ui/NetworkDialog.qml already uses to write this file without fighting that watch.
     FileView {
@@ -87,7 +80,6 @@ Item {
         path: Quickshell.env("HOME") + "/.config/gtk-3.0/bookmarks"
         printErrors: false
     }
-
     Timer {
         interval: root.mountPollMs
         running: true
@@ -95,7 +87,6 @@ Item {
         triggeredOnStart: true
         onTriggered: root.pollMounts()
     }
-
     // Three sources, deduped on the normalized uri (see ui/js/Mounts.js "normalize"): a live gio
     // mount wins the row, the bookmark keeps the label. Places.networkEntries is that merge.
     function rebuild() {
@@ -136,8 +127,7 @@ Item {
             root.runInfo(uri)
             return
         }
-        // The collector belongs to the Process, but this fallback belongs to us and survives
-        // restarts. A quiet failure must never inherit an earlier "already mounted" stderr.
+        // A quiet failure must never inherit an earlier "already mounted" stderr fallback.
         root._mountErrOutput = ""
         mountProcess.command = ["gio", "mount", uri]
         mountProcess.running = true

--- a/ui/NetworkMounts.qml
+++ b/ui/NetworkMounts.qml
@@ -168,6 +168,19 @@ Item {
         unmountProcess.running = true
     }
 
+    // Drops the bookmark line. A live mount is unmounted too, so the row leaves the rail instead
+    // of turning into a mount-only leftover of the place the operator just deleted.
+    function remove(index) {
+        var e = root.entries[index]
+        if (!e || e.kind !== "share") return
+        var body = bookmarksWrite.text()
+        bookmarksWrite.setText(Places.remove(body, e.uri))
+        bookmarksWrite.waitForJob()
+        root.renamed()
+        if (e.mounted)
+            root.unmount(index)
+    }
+
     // Rewrites uri's own label, or appends a bookmark for it if it was only ever a live mount;
     // either way this is what makes the rename survive a reboot. waitForJob() blocks until the
     // write actually lands, the same fix AGENTS.md "A FileView write can race a reload" applies

--- a/ui/NetworkRail.qml
+++ b/ui/NetworkRail.qml
@@ -1,0 +1,61 @@
+import QtQuick
+
+// One façade for the rail's four network concerns: persisted recents, optional discovery, GIO
+// mounts, and argv-direct host actions. Sidebar renders entries and owns no process itself.
+Item {
+    id: root
+
+    property string bookmarksText: ""
+    readonly property alias entries: mounts.entries
+    readonly property alias dropboxReady: mounts.dropboxReady
+    readonly property alias tailnetState: discovery.tailnetState
+    readonly property alias tailnetMessage: discovery.tailnetMessage
+    readonly property alias lanState: discovery.lanState
+
+    signal opened(string path)
+    signal message(string text, bool isError)
+    signal sharesListed(string baseUri, string baseLabel, var names)
+    signal renamed()
+    signal taildropRequested(string peerId)
+
+    function activate(index) { mounts.activate(index) }
+    function openShare(uri, mounted, label, mac) { mounts.openShare(uri, mounted, label, mac) }
+    function unmount(index) { mounts.unmount(index) }
+    function rename(uri, label) { mounts.rename(uri, label) }
+    function copyAddress(entry) { actions.copyAddress(entry) }
+    function openSsh(entry) { actions.openSsh(entry) }
+    function wake(entry) { actions.wake(entry) }
+    function rememberProfile(oldUri, uri, label, mac) { history.rememberProfile(oldUri, uri, label, mac) }
+
+    function remove(index) {
+        var entry = mounts.entries[index]
+        if (entry && entry.kind === "recent") {
+            history.remove(entry.uri)
+            return
+        }
+        mounts.remove(index)
+    }
+
+    NetworkDiscovery {
+        id: discovery
+        onMessage: function (text, isError) { root.message(text, isError) }
+    }
+
+    NetworkHistory { id: history }
+
+    NetworkActions {
+        id: actions
+        onMessage: function (text, isError) { root.message(text, isError) }
+    }
+
+    NetworkMounts {
+        id: mounts
+        bookmarksText: root.bookmarksText
+        extraEntries: history.entries.concat(history.profileEntries).concat(discovery.entries)
+        onOpened: function (path) { root.opened(path) }
+        onMessage: function (text, isError) { root.message(text, isError) }
+        onSharesListed: function (baseUri, baseLabel, names) { root.sharesListed(baseUri, baseLabel, names) }
+        onRenamed: root.renamed()
+        onConnectionSucceeded: function (uri, label, mac) { history.record(uri, label, mac) }
+    }
+}

--- a/ui/Pane.qml
+++ b/ui/Pane.qml
@@ -242,6 +242,7 @@ FocusScope {
         menu: menu
         // The rename TextField takes real Qt focus itself; this only hands it back once it is done.
         onRenameFinished: list.forceActiveFocus()
+        onTaildropPeerRequested: function (peerId) { root.sendTaildrop(peerId) }
     }
 
     Flea.Header {

--- a/ui/Pane.qml
+++ b/ui/Pane.qml
@@ -112,6 +112,7 @@ FocusScope {
     property var pathsPending: null
     // What the status bar's sticky slot is reporting, or an idle transfer; see ui/js/Ops.js.
     property var transfer: Ops.emptyTransfer()
+    property string pendingTransferKind: "local"
     // The row that is its own editor right now, or -1; ui/List.qml's delegate reads it per row.
     property int renamingIndex: -1
     // Set by a pointer-committed rename so the reply reveals nothing; ui/js/Nav.js clears it.

--- a/ui/PaneWire.qml
+++ b/ui/PaneWire.qml
@@ -146,7 +146,8 @@ Item {
         // The verb comes off the wire, never off the clipboard: paste spends a cut before this line
         // arrives, and a Dropbox move never touches the clipboard at all.
         function onTransferStarted(id, n, moving) {
-            pane.transfer = Ops.started(id, moving, n)
+            pane.transfer = Ops.started(id, moving, n, pane.pendingTransferKind)
+            pane.pendingTransferKind = "local"
             pane.sticky(Ops.progressLine(pane.transfer))
         }
 

--- a/ui/PaneWire.qml
+++ b/ui/PaneWire.qml
@@ -242,6 +242,7 @@ Item {
         }
 
         function onFailed(where, input, message, mode) {
+            Ops.clearPendingKind(pane, where)
             var text = Errors.sentence(where, message)
             // A refused sort changes nothing in the backend, so it changes nothing here: a notice in the
             // plain role, never the error role, which is for a listing that stopped being true.

--- a/ui/PdfViewer.qml
+++ b/ui/PdfViewer.qml
@@ -149,6 +149,11 @@ Item {
         contentHeight: height * root.zoom
         boundsBehavior: Flickable.StopAtBounds
 
+        Flea.FastScrollHandler {
+            parent: pageFlick
+            flickable: pageFlick
+        }
+
         Rectangle {
             width: pageFlick.contentWidth
             height: pageFlick.contentHeight

--- a/ui/PreviewText.qml
+++ b/ui/PreviewText.qml
@@ -31,11 +31,17 @@ Item {
     }
 
     Flickable {
+        id: textFlick
         anchors.fill: parent
         clip: true
         contentWidth: width
         contentHeight: Math.max(height, body.implicitHeight)
         visible: !root.tooLarge && !root.readFailed
+
+        FastScrollHandler {
+            parent: textFlick
+            flickable: textFlick
+        }
 
         Text {
             id: body

--- a/ui/ShareBrowser.qml
+++ b/ui/ShareBrowser.qml
@@ -43,6 +43,8 @@ Item {
         root.cursorIndex = Math.max(0, Math.min(root.shares.length - 1, root.cursorIndex + delta))
     }
 
+    onCursorIndexChanged: shareView.positionViewAtIndex(root.cursorIndex, ListView.Contain)
+
     function activateCursor() {
         var name = root.shares[root.cursorIndex]
         if (name === undefined)
@@ -90,29 +92,35 @@ Item {
             onClicked: {}
         }
 
-        Column {
+        ListView {
+            id: shareView
             anchors.fill: parent
+            model: root.shares
+            clip: true
+            boundsBehavior: Flickable.StopAtBounds
+            reuseItems: true
 
-            Repeater {
-                model: root.shares
+            Flea.FastScrollHandler {
+                parent: shareView
+                flickable: shareView
+            }
 
-                // Network.dc.html draws the sidebar's own server mark and the share name, and no
-                // columns: nothing is known about a share until it is mounted, so a "-" size and a
-                // "--" date were columns of nothing. ui/MenuRow.qml is the mark-and-label row.
-                delegate: Flea.MenuRow {
-                    id: shareRow
-                    required property int index
-                    required property string modelData
-                    width: root.width
-                    entry: ({ label: shareRow.modelData, action: "", glyph: "server" })
-                    // The keyboard cursor is the pick and takes the accent; the pointer only lifts
-                    // the row it is over, which is what ui/Row.qml did here before.
-                    picked: shareRow.index === root.cursorIndex
-                    current: shareRow.hovered
-                    onActivated: {
-                        root.cursorIndex = shareRow.index
-                        root.activateCursor()
-                    }
+            // Network.dc.html draws the sidebar's own server mark and the share name, and no
+            // columns: nothing is known about a share until it is mounted, so a "-" size and a
+            // "--" date were columns of nothing. ui/MenuRow.qml is the mark-and-label row.
+            delegate: Flea.MenuRow {
+                id: shareRow
+                required property int index
+                required property string modelData
+                width: shareView.width
+                entry: ({ label: shareRow.modelData, action: "", glyph: "server" })
+                // The keyboard cursor is the pick and takes the accent; the pointer only lifts
+                // the row it is over, which is what ui/Row.qml did here before.
+                picked: shareRow.index === root.cursorIndex
+                current: shareRow.hovered
+                onActivated: {
+                    root.cursorIndex = shareRow.index
+                    root.activateCursor()
                 }
             }
         }

--- a/ui/Sidebar.qml
+++ b/ui/Sidebar.qml
@@ -38,6 +38,7 @@ Item {
 
     signal opened(string path)
     signal addRequested()
+    signal editRequested(string uri, string label)
     signal message(string text, bool isError)
     // Bubbled straight from NetworkMounts; shell.qml opens ui/ShareBrowser.qml on this.
     signal sharesListed(string baseUri, string baseLabel, var names)
@@ -146,7 +147,9 @@ Item {
     // A chosen menu row, arriving with the row's key rather than its position; which row that
     // names is Mounts.release', so tests/js/mounts.js drives the resolution with no rail.
     function releaseChosen(action, key) {
-        Mounts.release(action, key, devices, mounts, root.deviceEntries, root.networkEntries)
+        Mounts.release(action, key, devices, mounts, root.deviceEntries, root.networkEntries, {
+            edit: function (uri, label) { root.editRequested(uri, label) }
+        })
     }
 
     Connections {

--- a/ui/Sidebar.qml
+++ b/ui/Sidebar.qml
@@ -26,7 +26,6 @@ Item {
     onNetworkEntriesChanged: root.cancelRename()
     readonly property var deviceEntries: devices.entries
     readonly property var entries: root.favoriteEntries.concat(root.networkEntries).concat(root.deviceEntries)
-
     // Clamped on the aggregate, never on a group: reading root.entries from onDeviceEntriesChanged
     // forces the entries binding's own first evaluation, which fires networkEntriesChanged, which
     // re-enters clampCursor before entries has a value. That threw a TypeError once per launch.
@@ -38,7 +37,8 @@ Item {
 
     signal opened(string path)
     signal addRequested()
-    signal editRequested(string uri, string label)
+    signal editRequested(string uri, string label, string mac)
+    signal taildropPeerRequested(string peerId)
     signal message(string text, bool isError)
     // Bubbled straight from NetworkMounts; shell.qml opens ui/ShareBrowser.qml on this.
     signal sharesListed(string baseUri, string baseLabel, var names)
@@ -91,7 +91,7 @@ Item {
         onMessage: function (text, isError) { root.message(text, isError) }
     }
 
-    NetworkMounts {
+    NetworkRail {
         id: mounts
         bookmarksText: bookmarksFile.text()
         onOpened: function (path) { root.opened(path) }
@@ -101,6 +101,7 @@ Item {
         // write can race a reload fired the moment setText() is called": mounts.rename() already
         // blocked on waitForJob() before this fires, so the reload here reads the write it caused.
         onRenamed: root.reloadBookmarks()
+        onTaildropRequested: function (peerId) { root.taildropPeerRequested(peerId) }
     }
 
     // Home is always first and is not in either file, so it is prepended rather than parsed; the
@@ -110,13 +111,15 @@ Item {
         root.favoriteEntries = Places.favorites(home, userDirsFile.text(), bookmarksFile.text(), Icons.sidebarGlyphFor)
     }
 
-    // ui/NetworkDialog.qml writes this same file; a watch set up before its parent directory
-    // existed never fires, so its own saved() signal drives this explicit reload instead.
+    // Dialog writes drive this reload because a watch created before gtk-3.0 exists stays inert.
     function reloadBookmarks() {
         bookmarksFile.reload()
     }
-
-    // ui/ShareBrowser.qml's own Enter action calls this with the resolved share uri; not yet one of root.entries, so it goes straight to NetworkMounts's own open-a-share path.
+    function rememberNetworkProfile(oldUri, uri, label, mac) { mounts.rememberProfile(oldUri, uri, label, mac) }
+    readonly property alias tailnetState: mounts.tailnetState
+    readonly property alias tailnetMessage: mounts.tailnetMessage
+    readonly property alias lanState: mounts.lanState
+    // ShareBrowser passes a resolved URI straight to the mount service.
     function mountShare(uri, label) {
         mounts.openShare(uri, false, label)
     }
@@ -148,7 +151,14 @@ Item {
     // names is Mounts.release', so tests/js/mounts.js drives the resolution with no rail.
     function releaseChosen(action, key) {
         Mounts.release(action, key, devices, mounts, root.deviceEntries, root.networkEntries, {
-            edit: function (uri, label) { root.editRequested(uri, label) }
+            edit: function (uri, label) {
+                var at = Mounts.rowByKey(root.networkEntries, uri)
+                root.editRequested(uri, label, at >= 0 ? root.networkEntries[at].mac : "")
+            },
+            copyAddress: function (entry) { mounts.copyAddress(entry) },
+            openSsh: function (entry) { mounts.openSsh(entry) },
+            taildrop: function (peerId) { root.taildropPeerRequested(peerId) },
+            wake: function (entry) { mounts.wake(entry) }
         })
     }
 
@@ -241,11 +251,7 @@ Item {
         contentHeight: rail.height + 2 * Style.spacing.rowPaddingX
         boundsBehavior: Flickable.StopAtBounds
 
-        FastScrollHandler {
-            parent: scroller
-            flickable: scroller
-        }
-
+        FastScrollHandler { parent: scroller; flickable: scroller }
         Column {
             id: rail
             anchors.top: parent.top
@@ -383,7 +389,6 @@ Item {
         return devRepeater.itemAt(rest - root.networkEntries.length)
     }
 
-    // The one divider in the whole design.
     Rectangle {
         anchors.right: parent.right
         anchors.top: parent.top

--- a/ui/Sidebar.qml
+++ b/ui/Sidebar.qml
@@ -241,6 +241,11 @@ Item {
         contentHeight: rail.height + 2 * Style.spacing.rowPaddingX
         boundsBehavior: Flickable.StopAtBounds
 
+        FastScrollHandler {
+            parent: scroller
+            flickable: scroller
+        }
+
         Column {
             id: rail
             anchors.top: parent.top

--- a/ui/SidebarRow.qml
+++ b/ui/SidebarRow.qml
@@ -25,19 +25,25 @@ Item {
 
     // A share or a removable volume carries a mount-state dot; the internal disk is always there
     // and always mounted, so a dot on it would say nothing, and a favourite is not a mount at all.
-    readonly property bool showsDot: (root.modelData.group === "network" && root.modelData.kind !== "dropbox")
+    readonly property bool showsDot: (root.modelData.group === "network"
+        && root.modelData.kind !== "dropbox" && root.modelData.kind !== "status")
         || (root.modelData.group === "device" && root.modelData.kind === "volume")
     // Small and fixed: a status dot is not part of the type or icon scale.
     readonly property int dotSize: 6
     // The canvas's own value for a bookmark nothing has mounted yet.
     readonly property real unmountedOpacity: 0.5
+    readonly property string health: String(root.modelData.health || (root.modelData.mounted ? "mounted" : "unknown"))
+    readonly property color healthColor: (root.health === "failed" || root.health === "offline")
+        ? Theme.color.error
+        : (root.health === "connecting" ? Theme.color.accent
+           : ((root.health === "mounted" || root.health === "online") ? Theme.color.executable : Theme.color.muted))
 
     width: parent ? parent.width : 0
     // The rail reads denser than the list it sits beside; see Theme.qml's railRowHeight comment.
     height: Theme.railRowHeight
 
     Accessible.role: Accessible.ListItem
-    Accessible.name: root.modelData.label
+    Accessible.name: root.showsDot ? root.modelData.label + ", " + root.health : root.modelData.label
 
     // A rail row is a row, so its cursor is the list row's own: a square full-bleed fill and the
     // accent bar, per the canvas and the icon spec's "the rail rounds nothing"; see ui/Row.qml.
@@ -135,8 +141,8 @@ Item {
             anchors.centerIn: parent
             width: root.dotSize
             height: root.dotSize
-            color: root.modelData.mounted ? Theme.color.executable : Theme.color.muted
-            opacity: root.modelData.mounted ? 1 : root.unmountedOpacity
+            color: root.healthColor
+            opacity: (root.health === "mounted" || root.health === "online") ? 1 : root.unmountedOpacity
         }
     }
 

--- a/ui/Taildrop.qml
+++ b/ui/Taildrop.qml
@@ -18,6 +18,8 @@ Item {
     function refresh() {
         if (statusProcess.running)
             return
+        // A successful empty status means no targets, not "reuse the last non-empty status".
+        root._statusOutput = ""
         statusProcess.running = true
     }
 

--- a/ui/js/Discovery.js
+++ b/ui/js/Discovery.js
@@ -1,0 +1,71 @@
+.pragma library
+
+.import "Mounts.js" as Mounts
+
+var TYPES = {
+    "_ssh._tcp": { scheme: "sftp", defaultPort: 22 },
+    "_smb._tcp": { scheme: "smb", defaultPort: 445 },
+    "_nfs._tcp": { scheme: "nfs", defaultPort: 2049 },
+    "_webdav._tcp": { scheme: "dav", defaultPort: 80 },
+    "_webdavs._tcp": { scheme: "davs", defaultPort: 443 }
+}
+
+// avahi-browse -artp emits semicolon-separated resolved rows beginning with "=". Duplicate rows
+// collapse by normalized URI; unresolved, removal, malformed, and unsupported rows are ignored.
+function parse(body) {
+    var lines = String(body || "").split("\n")
+    var out = []
+    var seen = {}
+    for (var i = 0; i < lines.length; i++) {
+        var fields = splitLine(lines[i])
+        if (fields.length < 9 || fields[0] !== "=")
+            continue
+        var spec = TYPES[fields[4]]
+        if (!spec)
+            continue
+        var host = cleanHost(fields[6] || fields[7])
+        if (host.length === 0)
+            continue
+        var port = /^\d+$/.test(fields[8]) ? Number(fields[8]) : spec.defaultPort
+        var uri = spec.scheme + "://" + hostForUri(host)
+        if (port !== spec.defaultPort)
+            uri += ":" + port
+        uri = Mounts.normalize(uri + "/")
+        if (seen[uri])
+            continue
+        seen[uri] = true
+        out.push({ path: "", label: fields[3] || host, group: "network", kind: "discovered",
+                   uri: uri, mounted: false, glyph: "server", origin: "lan", health: "online",
+                   address: host, taildrop: false, mac: txtMac(fields.slice(9)) })
+    }
+    out.sort(function (a, b) { return a.label.localeCompare(b.label) })
+    return out
+}
+
+function splitLine(line) {
+    var fields = String(line || "").split(";")
+    for (var i = 0; i < fields.length; i++)
+        fields[i] = unescapeField(fields[i])
+    return fields
+}
+
+function unescapeField(value) {
+    return String(value || "").replace(/\\(\d{3})/g, function (_, digits) {
+        return String.fromCharCode(Number(digits))
+    }).replace(/\\\\/g, "\\")
+}
+
+function cleanHost(value) {
+    var host = String(value || "").trim().replace(/\.$/, "")
+    return /^[A-Za-z0-9._:%-]+$/.test(host) ? host : ""
+}
+
+function hostForUri(host) {
+    return host.indexOf(":") >= 0 && host.charAt(0) !== "[" ? "[" + host + "]" : host
+}
+
+function txtMac(fields) {
+    var text = fields.join(" ")
+    var m = text.match(/(?:^|[ "'])mac=([0-9a-f]{2}(?::[0-9a-f]{2}){5})(?:$|[ "'])/i)
+    return m ? m[1].toLowerCase() : ""
+}

--- a/ui/js/Eject.js
+++ b/ui/js/Eject.js
@@ -122,10 +122,10 @@ function release(root, sidebar, fromRail) {
         root.message("This directory is not inside a removable volume, so there is nothing to eject.", false)
         return
     }
-    var rows = Mounts.railMenu(entry)
-    if (rows.length === 0) {
+    var action = Mounts.releaseAction(entry)
+    if (!action) {
         root.message(entry.label + " has nothing to eject or unmount.", false)
         return
     }
-    sidebar.releaseChosen(rows[0].action, Mounts.railKey(entry))
+    sidebar.releaseChosen(action, Mounts.railKey(entry))
 }

--- a/ui/js/Icons.js
+++ b/ui/js/Icons.js
@@ -121,6 +121,9 @@ var PATHS = {
     "archive-out": "M2 3h20v5H2z M4 8v13h16V8 M12 18v-6 M9 15l3-3 3 3",
     // The Move to Dropbox row, which the canvas draws with the network mark.
     "network": "M9 2h6v6H9z M2 16h6v6H2z M16 16h6v6h-6z M12 8v4 M5 16v-4h14v4",
+    "history": "M3 12a9 9 0 1 0 3-6.7 M3 3v6h6 M12 7v5l3 2",
+    "refresh-cw": "M20 6v6h-6 M4 18v-6h6 M19 12a7 7 0 0 0-12-5L4 10 M5 12a7 7 0 0 0 12 5l3-3",
+    "power": "M12 2v10 M5.6 5.6a9 9 0 1 0 12.8 0",
     // The convert popup's checkbox mark.
     "check": "M4 12l6 6L20 6",
     // The PDF viewer's own three, recut sharp like the rest of the set; "maximize" is lucide's

--- a/ui/js/Menu.js
+++ b/ui/js/Menu.js
@@ -18,6 +18,18 @@ function clamp(point, size, bounds) {
     return Math.max(0, Math.min(bounds - size, point))
 }
 
+function boundedExtent(content, bounds) {
+    return Math.max(0, Math.min(content, bounds))
+}
+
+// Prefer the familiar right-hand flyout; when it would leave the pane, put the whole frame left.
+function adjacentX(frameX, frameWidth, flyoutWidth, bounds) {
+    var right = frameX + frameWidth
+    if (right + flyoutWidth <= bounds)
+        return right
+    return clamp(frameX - flyoutWidth, flyoutWidth, bounds)
+}
+
 // The listing's rows, built from the pane's state in one object so the construction can live here
 // and carry its own suite, tests/js/menu.js. Copy path sits beside Open because both answer
 // "where is this and what runs on it".

--- a/ui/js/Mounts.js
+++ b/ui/js/Mounts.js
@@ -173,6 +173,7 @@ function railMenu(entry) {
         if (entry.mounted)
             rows.push({ label: "Unmount", action: "unmount", glyph: "eject" })
         rows.push({ label: "Edit", action: "edit", glyph: "rename" })
+        rows.push({ label: "Remove", action: "remove", glyph: "trash" })
         return rows
     }
     return []
@@ -261,4 +262,6 @@ function release(action, key, devices, mounts, deviceEntries, networkEntries, ed
         mounts.unmount(share)
     if (action === "edit" && editor)
         editor.edit(networkEntries[share].uri, networkEntries[share].label)
+    if (action === "remove")
+        mounts.remove(share)
 }

--- a/ui/js/Mounts.js
+++ b/ui/js/Mounts.js
@@ -68,9 +68,26 @@ function decodePath(raw) {
     }
 }
 
-// One canonical form: every trailing slash stripped, except a bare host root, which keeps one.
+// gio mount -l omits a scheme's default port; the add form writes it. Same share either way.
+var DEFAULT_PORTS = { smb: "445", sftp: "22", ftp: "21", ftps: "21", dav: "443", davs: "443", nfs: "2049" }
+
+function stripDefaultPort(uri) {
+    var m = String(uri).match(/^([a-z][a-z0-9+.-]*):\/\//i)
+    if (!m)
+        return uri
+    var def = DEFAULT_PORTS[m[1].toLowerCase()]
+    if (!def)
+        return uri
+    var rest = uri.substring(m[0].length)
+    var at = rest.lastIndexOf("@")
+    var hostPart = at >= 0 ? rest.substring(at + 1) : rest
+    var head = at >= 0 ? uri.substring(0, m[0].length + at + 1) : m[0]
+    return head + hostPart.replace(new RegExp("^([^/]+):" + def + "(?=/|$)"), "$1")
+}
+
+// One canonical form: default ports dropped, trailing slashes stripped except a bare host root.
 function normalize(uri) {
-    var stripped = String(uri || "").replace(/\/+$/, "")
+    var stripped = stripDefaultPort(String(uri || "")).replace(/\/+$/, "")
     var bareRoot = /^[a-z][a-z0-9+.-]*:\/\/[^\/]+$/i.test(stripped)
     return bareRoot ? stripped + "/" : stripped
 }

--- a/ui/js/Mounts.js
+++ b/ui/js/Mounts.js
@@ -1,5 +1,7 @@
 .pragma library
 
+.import "Remote.js" as Remote
+
 // Sample input, captured live on the box with one network share mounted (2026-08-31):
 // Drive(0): KBG40ZNS256G NVMe KIOXIA 256GB
 //   Type: GProxyDrive (GProxyVolumeMonitorUDisks2)
@@ -170,6 +172,8 @@ function sameEntries(a, b) {
 function sameEntry(x, y) {
     return x.path === y.path && x.label === y.label && x.group === y.group && x.kind === y.kind
         && x.uri === y.uri && x.device === y.device && x.mounted === y.mounted && x.glyph === y.glyph
+        && x.origin === y.origin && x.health === y.health && x.address === y.address
+        && x.peerId === y.peerId && x.taildrop === y.taildrop && x.mac === y.mac
 }
 
 // Sample input: one rail entry as ui/DeviceMounts.qml and ui/NetworkMounts.qml build them,
@@ -185,14 +189,8 @@ function railMenu(entry) {
         return []
     if (entry.group === "device" && entry.kind === "volume" && entry.mounted)
         return [{ label: "Eject", action: "eject", glyph: "eject" }]
-    if (entry.group === "network" && entry.kind === "share") {
-        var rows = []
-        if (entry.mounted)
-            rows.push({ label: "Unmount", action: "unmount", glyph: "eject" })
-        rows.push({ label: "Edit", action: "edit", glyph: "rename" })
-        rows.push({ label: "Remove", action: "remove", glyph: "trash" })
-        return rows
-    }
+    if (entry.group === "network")
+        return Remote.menu(entry)
     return []
 }
 
@@ -215,7 +213,7 @@ function railKey(entry) {
         return ""
     if (entry.group === "device" && entry.kind === "volume")
         return String(entry.device || "")
-    if (entry.group === "network" && entry.kind === "share")
+    if (entry.group === "network" && entry.kind !== "dropbox")
         return String(entry.uri || "")
     return ""
 }
@@ -265,7 +263,7 @@ function raiseMenu(pane, sidebar) {
 // a five second poll, so the index the menu opened over can name a different row by now. A key
 // that no longer names a row does nothing, because the row it named has left the rail already.
 // Both Services re-check the kind themselves; this only resolves which row was meant.
-function release(action, key, devices, mounts, deviceEntries, networkEntries, editor) {
+function release(action, key, devices, mounts, deviceEntries, networkEntries, actions) {
     if (action === "eject") {
         var volume = rowByKey(deviceEntries, key)
         if (volume >= 0)
@@ -277,8 +275,19 @@ function release(action, key, devices, mounts, deviceEntries, networkEntries, ed
         return
     if (action === "unmount")
         mounts.unmount(share)
-    if (action === "edit" && editor)
-        editor.edit(networkEntries[share].uri, networkEntries[share].label)
+    var entry = networkEntries[share]
+    if (action === "edit" && actions)
+        actions.edit(entry.uri, entry.label)
     if (action === "remove")
         mounts.remove(share)
+    if (action === "reconnect")
+        mounts.activate(share)
+    if (action === "copy-address" && actions)
+        actions.copyAddress(entry)
+    if (action === "open-ssh" && actions)
+        actions.openSsh(entry)
+    if (action === "taildrop-peer" && actions)
+        actions.taildrop(entry.peerId)
+    if (action === "wake" && actions)
+        actions.wake(entry)
 }

--- a/ui/js/Mounts.js
+++ b/ui/js/Mounts.js
@@ -157,18 +157,36 @@ function sameEntry(x, y) {
 
 // Sample input: one rail entry as ui/DeviceMounts.qml and ui/NetworkMounts.qml build them,
 // {label:"128GB", group:"device", kind:"volume", device:"/dev/sda1", mounted:true}.
-// A removable volume ejects and a mounted network share unmounts; every other rail row offers
-// neither and opens no menu. The kind is read here, never re-derived: the internal disk reads as
-// mounted too, the Dropbox row is a local folder the stock service owns, and a favourite is not a
-// mount. gio's -f is offered nowhere: forcing an unmount over an open write is how data is lost.
+// A removable volume ejects and a mounted network share unmounts; a share also offers Edit so a
+// bookmark whose URI is wrong can be rewritten without leaving the rail. Every other rail row
+// offers neither and opens no menu. The kind is read here, never re-derived: the internal disk
+// reads as mounted too, the Dropbox row is a local folder the stock service owns, and a favourite
+// is not a mount. gio's -f is offered nowhere: forcing an unmount over an open write is how data
+// is lost. Unmount stays first on a live share so Ctrl+E still releases rather than opening Edit.
 function railMenu(entry) {
-    if (!entry || !entry.mounted)
+    if (!entry)
         return []
-    if (entry.group === "device" && entry.kind === "volume")
+    if (entry.group === "device" && entry.kind === "volume" && entry.mounted)
         return [{ label: "Eject", action: "eject", glyph: "eject" }]
-    if (entry.group === "network" && entry.kind === "share")
-        return [{ label: "Unmount", action: "unmount", glyph: "eject" }]
+    if (entry.group === "network" && entry.kind === "share") {
+        var rows = []
+        if (entry.mounted)
+            rows.push({ label: "Unmount", action: "unmount", glyph: "eject" })
+        rows.push({ label: "Edit", action: "edit", glyph: "rename" })
+        return rows
+    }
     return []
+}
+
+// The action Ctrl+E fires: eject or unmount, never Edit. A bookmark-only share has a menu and
+// still answers empty here, so the key cannot rewrite a URI the operator did not open a menu for.
+function releaseAction(entry) {
+    var rows = railMenu(entry)
+    for (var i = 0; i < rows.length; i++) {
+        if (rows[i].action === "eject" || rows[i].action === "unmount")
+            return rows[i].action
+    }
+    return ""
 }
 
 // The handle a chosen menu row carries back: a volume's device node, a share's uri, "" for a row
@@ -205,7 +223,7 @@ function holding(entries, dir) {
     var path = String(dir || "")
     for (var i = 0; i < list.length; i++) {
         var e = list[i]
-        if (!e.path || railMenu(e).length === 0)
+        if (!e.path || !releaseAction(e))
             continue
         if (path === e.path || path.indexOf(e.path + "/") === 0)
             return e
@@ -229,16 +247,18 @@ function raiseMenu(pane, sidebar) {
 // a five second poll, so the index the menu opened over can name a different row by now. A key
 // that no longer names a row does nothing, because the row it named has left the rail already.
 // Both Services re-check the kind themselves; this only resolves which row was meant.
-function release(action, key, devices, mounts, deviceEntries, networkEntries) {
+function release(action, key, devices, mounts, deviceEntries, networkEntries, editor) {
     if (action === "eject") {
         var volume = rowByKey(deviceEntries, key)
         if (volume >= 0)
             devices.eject(volume)
         return
     }
-    if (action === "unmount") {
-        var share = rowByKey(networkEntries, key)
-        if (share >= 0)
-            mounts.unmount(share)
-    }
+    var share = rowByKey(networkEntries, key)
+    if (share < 0)
+        return
+    if (action === "unmount")
+        mounts.unmount(share)
+    if (action === "edit" && editor)
+        editor.edit(networkEntries[share].uri, networkEntries[share].label)
 }

--- a/ui/js/Ops.js
+++ b/ui/js/Ops.js
@@ -14,7 +14,7 @@ function emptyTransfer() {
     return { id: 0, moving: false, n: 0, index: 0, name: "", running: false,
              done: 0, bytes: 0, total: 0, kind: "local" }
 }
-
+function clearPendingKind(pane, where) { if (where === "transfer") pane.pendingTransferKind = "local" }
 // "1 item" or "4 items", so no caller builds a plural by hand.
 function items(n) {
     return n + (n === 1 ? " item" : " items")

--- a/ui/js/Ops.js
+++ b/ui/js/Ops.js
@@ -3,17 +3,16 @@
 .import "Archive.js" as Archive
 .import "Convert.js" as Convert
 .import "Transfer.js" as Transfer
-
+.import "Remote.js" as Remote
 // The clipboard is entirely client-side: the backend knows about a transfer, never about a pending paste.
 function emptyClipboard() {
     return { paths: [], moving: false }
 }
-
 // What the status bar and the card are tracking while a transfer runs; id is what a cancel names.
 // done, bytes and total are the card's bar: the items already finished, and the one in flight.
 function emptyTransfer() {
     return { id: 0, moving: false, n: 0, index: 0, name: "", running: false,
-             done: 0, bytes: 0, total: 0 }
+             done: 0, bytes: 0, total: 0, kind: "local" }
 }
 
 // "1 item" or "4 items", so no caller builds a plural by hand.
@@ -24,17 +23,19 @@ function items(n) {
 // A finished operation names its own reversal, which is why none of them needs a confirmation step.
 var UNDO_HINT = " · z undoes"
 
-function started(id, moving, n) {
+function started(id, moving, n, kind) {
     return { id: id, moving: moving, n: n, index: 0, name: "", running: true,
-             done: 0, bytes: 0, total: 0 }
+             done: 0, bytes: 0, total: 0, kind: kind || "local" }
 }
 
 // The canvas's own line: "Copying 2 of 5, photo.heic". The count comes from the card's own
 // headline so the bar and the card can never word the same operation two different ways.
 function progressLine(t) {
-    return t.name.length > 0 ? Transfer.head(t) + ", " + t.name : Transfer.head(t)
+    var head = Transfer.head(t)
+    if (t.kind === "remote-to-remote")
+        head = Remote.transferPrefix(t.kind, t.moving) + " " + (t.index + 1) + " of " + t.n
+    return t.name.length > 0 ? head + ", " + t.name : head
 }
-
 function transferDone(t, ok, failed, cancelled) {
     if (cancelled) {
         return ok > 0 ? "Cancelled after " + items(ok) + UNDO_HINT : "Cancelled."
@@ -188,13 +189,13 @@ function paste(pane) {
         pane.message("There is nothing to paste; y copies and x cuts.", false)
         return
     }
+    pane.pendingTransferKind = Remote.transferKind(clip.paths, pane.path)
     pane.backend.send({ c: "transfer", op: clip.moving ? "move" : "copy", paths: clip.paths, dest: pane.path })
     // A cut is spent by its paste; a copy stays on the clipboard so it can be pasted again.
     if (clip.moving) {
         pane.clipboard = emptyClipboard()
     }
 }
-
 function undo(pane) {
     pane.backend.undo()
 }

--- a/ui/js/Places.js
+++ b/ui/js/Places.js
@@ -62,6 +62,41 @@ function leaf(path) {
     return cut < 0 ? path : path.substring(cut + 1)
 }
 
+function taggedShare(uri, label, mounted) {
+    return { path: "", label: label, group: "network", kind: "share", uri: uri, mounted: mounted, glyph: "server" }
+}
+
+// Live mounts first, then bookmarks not already mounted. A bookmark's label wins over gio's
+// "user on host" name, so a rename survives the next poll while the share is still mounted.
+function networkEntries(mounts, marks) {
+    var labels = {}
+    var list = marks || []
+    for (var j = 0; j < list.length; j++) {
+        var k = Mounts.normalize(list[j].uri)
+        if (k.length === 0 || labels[k] !== undefined)
+            continue
+        labels[k] = list[j].label
+    }
+    var out = []
+    var seen = {}
+    var live = mounts || []
+    for (var i = 0; i < live.length; i++) {
+        var mkey = Mounts.normalize(live[i].uri)
+        if (seen[mkey])
+            continue
+        seen[mkey] = true
+        out.push(taggedShare(live[i].uri, labels[mkey] || live[i].label, true))
+    }
+    for (var n = 0; n < list.length; n++) {
+        var bkey = Mounts.normalize(list[n].uri)
+        if (seen[bkey])
+            continue
+        seen[bkey] = true
+        out.push(taggedShare(list[n].uri, list[n].label, false))
+    }
+    return out
+}
+
 // Sample input: "smb://192.168.1.10/data NAS"; see AGENTS.md "Places.relabel" for the matching, duplicate and control-character rules.
 function relabel(body, path, name) {
     // A trust boundary: an embedded newline could otherwise split one bookmark into two lines.

--- a/ui/js/Places.js
+++ b/ui/js/Places.js
@@ -62,8 +62,21 @@ function leaf(path) {
     return cut < 0 ? path : path.substring(cut + 1)
 }
 
-function taggedShare(uri, label, mounted) {
-    return { path: "", label: label, group: "network", kind: "share", uri: uri, mounted: mounted, glyph: "server" }
+function taggedShare(uri, label, mounted, meta, health, forceShare) {
+    var source = meta || {}
+    return {
+        path: "", label: label, group: "network", kind: forceShare ? "share" : (source.kind || "share"),
+        uri: uri, mounted: mounted, glyph: source.glyph || "server",
+        origin: source.origin || (mounted ? "mount" : "bookmark"),
+        health: mounted ? "mounted" : (health || source.health || "unknown"),
+        address: source.address || authority(uri), peerId: source.peerId || "",
+        taildrop: !!source.taildrop, mac: source.mac || ""
+    }
+}
+
+function authority(uri) {
+    var m = String(uri || "").match(/^[a-z][a-z0-9+.-]*:\/\/([^\/]+)/i)
+    return m ? m[1].replace(/^.*@/, "") : ""
 }
 
 // gvfsd-sftp (and ftp) mounts one connection per host, not per path. SMB/NFS stay per share.
@@ -92,7 +105,7 @@ function coveringUri(mounts, uri) {
 
 // Live mounts first, then bookmarks not already shown. A bookmark's label wins over gio's
 // "user on host" name. An SFTP path on a live host is mounted even when gio only lists the root.
-function networkEntries(mounts, marks) {
+function networkEntries(mounts, marks, discovered, healthMap) {
     var labels = {}
     var list = marks || []
     for (var j = 0; j < list.length; j++) {
@@ -109,7 +122,8 @@ function networkEntries(mounts, marks) {
         if (seen[mkey])
             continue
         seen[mkey] = true
-        out.push(taggedShare(live[i].uri, labels[mkey] || live[i].label, true))
+        out.push(taggedShare(live[i].uri, labels[mkey] || live[i].label, true,
+                             matching(discovered, live[i].uri), stateFor(healthMap, live[i].uri), true))
     }
     for (var n = 0; n < list.length; n++) {
         var bkey = Mounts.normalize(list[n].uri)
@@ -123,9 +137,64 @@ function networkEntries(mounts, marks) {
                 break
             }
         }
-        out.push(taggedShare(list[n].uri, list[n].label, mounted))
+        out.push(taggedShare(list[n].uri, list[n].label, mounted,
+                             matching(discovered, list[n].uri), stateFor(healthMap, list[n].uri), true))
+    }
+    var extras = discovered || []
+    for (var x = 0; x < extras.length; x++) {
+        var duplicate = false
+        for (var y = 0; y < out.length; y++) {
+            if (covers(out[y].uri, extras[x].uri)) {
+                duplicate = true
+                break
+            }
+        }
+        if (duplicate)
+            continue
+        var isMounted = false
+        for (var z = 0; z < live.length; z++) {
+            if (covers(live[z].uri, extras[x].uri)) {
+                isMounted = true
+                break
+            }
+        }
+        var combined = matching(extras, extras[x].uri) || extras[x]
+        out.push(taggedShare(extras[x].uri, extras[x].label, isMounted, combined,
+                             stateFor(healthMap, extras[x].uri), false))
     }
     return out
+}
+
+function matching(entries, uri) {
+    var list = entries || []
+    var found = null
+    for (var i = 0; i < list.length; i++) {
+        if (!covers(list[i].uri, uri))
+            continue
+        if (!found) {
+            found = copyMeta(list[i])
+            continue
+        }
+        found.taildrop = found.taildrop || !!list[i].taildrop
+        if (!found.peerId) found.peerId = list[i].peerId || ""
+        if (!found.address) found.address = list[i].address || ""
+        if (!found.mac) found.mac = list[i].mac || ""
+        if ((found.health || "unknown") === "unknown" && list[i].health)
+            found.health = list[i].health
+    }
+    if (found && found.mac)
+        found.origin = "lan"
+    return found
+}
+
+function copyMeta(entry) {
+    var out = {}
+    for (var key in entry) out[key] = entry[key]
+    return out
+}
+
+function stateFor(map, uri) {
+    return (map && map[Mounts.normalize(uri)]) || ""
 }
 
 // Sample input: "smb://192.168.1.10/data NAS"; see AGENTS.md "Places.relabel" for the matching, duplicate and control-character rules.

--- a/ui/js/Places.js
+++ b/ui/js/Places.js
@@ -121,3 +121,26 @@ function replace(body, oldUri, newUri, label) {
         out += "\n"
     return out + next + " " + trimmed + "\n"
 }
+
+// Drops every line whose uri matches, leaving the rest byte-identical. An empty uri is a no-op
+// so a Dropbox row with no bookmark cannot wipe the file.
+function remove(body, uri) {
+    var target = Mounts.normalize(uri)
+    if (target.length === 0)
+        return String(body || "")
+    var lines = String(body || "").split("\n")
+    var out = []
+    for (var i = 0; i < lines.length; i++) {
+        var line = lines[i]
+        if (line.trim().length === 0) {
+            out.push(line)
+            continue
+        }
+        var space = line.indexOf(" ")
+        var u = space < 0 ? line : line.substring(0, space)
+        if (Mounts.normalize(u) === target)
+            continue
+        out.push(line)
+    }
+    return out.join("\n")
+}

--- a/ui/js/Places.js
+++ b/ui/js/Places.js
@@ -66,8 +66,32 @@ function taggedShare(uri, label, mounted) {
     return { path: "", label: label, group: "network", kind: "share", uri: uri, mounted: mounted, glyph: "server" }
 }
 
-// Live mounts first, then bookmarks not already mounted. A bookmark's label wins over gio's
-// "user on host" name, so a rename survives the next poll while the share is still mounted.
+// gvfsd-sftp (and ftp) mounts one connection per host, not per path. SMB/NFS stay per share.
+function connectionKey(uri) {
+    var n = Mounts.normalize(uri)
+    var s = (n.match(/^([a-z][a-z0-9+.-]*)/i) || [""])[0].toLowerCase()
+    if (s !== "sftp" && s !== "ssh" && s !== "ftp" && s !== "ftps")
+        return n
+    var m = n.match(/^([a-z][a-z0-9+.-]*:\/\/[^\/]+)/i)
+    return m ? Mounts.normalize(m[1]) : n
+}
+
+function covers(liveUri, otherUri) {
+    var a = connectionKey(liveUri)
+    return a.length > 0 && a === connectionKey(otherUri)
+}
+
+function coveringUri(mounts, uri) {
+    var list = mounts || []
+    for (var i = 0; i < list.length; i++) {
+        if (covers(list[i].uri, uri))
+            return list[i].uri
+    }
+    return uri
+}
+
+// Live mounts first, then bookmarks not already shown. A bookmark's label wins over gio's
+// "user on host" name. An SFTP path on a live host is mounted even when gio only lists the root.
 function networkEntries(mounts, marks) {
     var labels = {}
     var list = marks || []
@@ -92,7 +116,14 @@ function networkEntries(mounts, marks) {
         if (seen[bkey])
             continue
         seen[bkey] = true
-        out.push(taggedShare(list[n].uri, list[n].label, false))
+        var mounted = false
+        for (var k = 0; k < live.length; k++) {
+            if (covers(live[k].uri, list[n].uri)) {
+                mounted = true
+                break
+            }
+        }
+        out.push(taggedShare(list[n].uri, list[n].label, mounted))
     }
     return out
 }

--- a/ui/js/Places.js
+++ b/ui/js/Places.js
@@ -89,3 +89,35 @@ function relabel(body, path, name) {
         out += "\n"
     return out + target + " " + trimmed + "\n"
 }
+
+// Sample input: body as relabel's, oldUri the bookmark being rewritten, newUri the form's Mounts-as
+// line. Matching is the same normalized compare relabel uses, so a live gio trailing slash still
+// finds the written line. An empty oldUri matches nothing and appends, which is the add-dialog path.
+function replace(body, oldUri, newUri, label) {
+    var trimmed = String(label || "").replace(/[\r\n]/g, "").trim()
+    var next = Mounts.normalize(newUri)
+    if (next.length === 0)
+        return String(body || "")
+    if (trimmed.length === 0)
+        trimmed = Mounts.leaf(next)
+    var target = Mounts.normalize(oldUri)
+    var lines = String(body || "").split("\n")
+    var found = false
+    for (var i = 0; i < lines.length; i++) {
+        var line = lines[i]
+        if (line.trim().length === 0)
+            continue
+        var space = line.indexOf(" ")
+        var uri = space < 0 ? line : line.substring(0, space)
+        if (target.length > 0 && Mounts.normalize(uri) === target) {
+            lines[i] = next + " " + trimmed
+            found = true
+        }
+    }
+    if (found)
+        return lines.join("\n")
+    var out = String(body || "")
+    if (out.length > 0 && out.charAt(out.length - 1) !== "\n")
+        out += "\n"
+    return out + next + " " + trimmed + "\n"
+}

--- a/ui/js/Protocols.js
+++ b/ui/js/Protocols.js
@@ -97,3 +97,74 @@ function label(form) {
 function complete(form) {
     return String(form.host || "").trim().length > 0
 }
+
+function protocolFor(schemeName) {
+    switch (String(schemeName || "").toLowerCase()) {
+    case "smb": return "SMB"
+    case "sftp": return "SFTP"
+    case "ftp":
+    case "ftps": return "FTPS"
+    case "dav":
+    case "davs": return "WebDAV"
+    case "nfs": return "NFS"
+    }
+    return ""
+}
+
+// Inverse of uri(): a bookmark line's address becomes the form fields that would rebuild it.
+// corner: a host with a colon that is not a port (IPv6 without brackets) is refused rather than
+// split, because the form has no place to round-trip that spelling.
+function parse(uri) {
+    var raw = String(uri || "").trim()
+    var m = raw.match(/^([a-z][a-z0-9+.-]*):\/\/(.*)$/i)
+    if (!m)
+        return null
+    var schemeName = m[1].toLowerCase()
+    var protocol = protocolFor(schemeName)
+    if (!protocol)
+        return null
+    var rest = m[2]
+    var user = ""
+    var domain = ""
+    var at = rest.lastIndexOf("@")
+    if (at >= 0) {
+        var creds = rest.substring(0, at)
+        rest = rest.substring(at + 1)
+        var semi = creds.indexOf(";")
+        if (semi >= 0) {
+            domain = creds.substring(0, semi)
+            user = creds.substring(semi + 1)
+        } else {
+            user = creds
+        }
+    }
+    var path = "/"
+    var slash = rest.indexOf("/")
+    if (slash >= 0) {
+        path = rest.substring(slash)
+        rest = rest.substring(0, slash)
+    }
+    var host = rest
+    var port = ""
+    var colon = rest.lastIndexOf(":")
+    if (colon >= 0) {
+        var maybePort = rest.substring(colon + 1)
+        if (!/^\d+$/.test(maybePort))
+            return null
+        host = rest.substring(0, colon)
+        port = maybePort
+    }
+    if (host.length === 0)
+        return null
+    if (port.length === 0)
+        port = String(defaultPort(protocol))
+    return {
+        protocol: protocol,
+        host: host,
+        port: port,
+        path: path === "/" ? "" : path.replace(/^\/+/, ""),
+        domain: domain,
+        user: user,
+        tls: schemeName === "davs" || schemeName === "ftps"
+    }
+}

--- a/ui/js/Protocols.js
+++ b/ui/js/Protocols.js
@@ -124,8 +124,15 @@ function parse(uri) {
     if (!protocol)
         return null
     var rest = m[2]
+    var path = "/"
+    var slash = rest.indexOf("/")
+    if (slash >= 0) {
+        path = rest.substring(slash)
+        rest = rest.substring(0, slash)
+    }
     var user = ""
     var domain = ""
+    // Authority only: an @ in the path (inbox@2026) must not be read as credentials.
     var at = rest.lastIndexOf("@")
     if (at >= 0) {
         var creds = rest.substring(0, at)
@@ -137,12 +144,6 @@ function parse(uri) {
         } else {
             user = creds
         }
-    }
-    var path = "/"
-    var slash = rest.indexOf("/")
-    if (slash >= 0) {
-        path = rest.substring(slash)
-        rest = rest.substring(0, slash)
     }
     var host = rest
     var port = ""

--- a/ui/js/Protocols.js
+++ b/ui/js/Protocols.js
@@ -147,13 +147,26 @@ function parse(uri) {
     }
     var host = rest
     var port = ""
-    var colon = rest.lastIndexOf(":")
-    if (colon >= 0) {
-        var maybePort = rest.substring(colon + 1)
-        if (!/^\d+$/.test(maybePort))
+    if (rest.charAt(0) === "[") {
+        var close = rest.indexOf("]")
+        if (close < 2)
             return null
-        host = rest.substring(0, colon)
-        port = maybePort
+        host = rest.substring(0, close + 1)
+        var after = rest.substring(close + 1)
+        if (after.length > 0) {
+            if (!/^:\d+$/.test(after))
+                return null
+            port = after.substring(1)
+        }
+    } else {
+        var colon = rest.lastIndexOf(":")
+        if (colon >= 0) {
+            var maybePort = rest.substring(colon + 1)
+            if (!/^\d+$/.test(maybePort))
+                return null
+            host = rest.substring(0, colon)
+            port = maybePort
+        }
     }
     if (host.length === 0)
         return null

--- a/ui/js/QuickConnect.js
+++ b/ui/js/QuickConnect.js
@@ -1,0 +1,46 @@
+.pragma library
+
+.import "Mounts.js" as Mounts
+.import "Protocols.js" as Protocols
+
+// Human shorthand becomes one explicit GIO URI. A colon path means SFTP, a slash means SMB, and a
+// bare host means SFTP. An explicit supported scheme always wins over those conveniences.
+function parse(input) {
+    var raw = String(input || "").trim()
+    if (raw.length === 0 || /[\r\n?#]/.test(raw))
+        return null
+    if (/^[a-z][a-z0-9+.-]*:\/\//i.test(raw))
+        return explicitUri(raw)
+    var colon = raw.match(/^((?:[A-Za-z0-9._-]+@)?(?:\[[0-9A-Fa-f:]+\]|[A-Za-z0-9._-]+)):(\/.*)$/)
+    if (colon)
+        return answer("sftp://" + colon[1] + cleanPath(colon[2]), "SFTP")
+    var slash = raw.match(/^([A-Za-z0-9._-]+)\/(.+)$/)
+    if (slash)
+        return answer("smb://" + slash[1] + cleanPath(slash[2]), "SMB")
+    if (/^(?:[A-Za-z0-9._-]+|\[[0-9A-Fa-f:]+\])$/.test(raw))
+        return answer("sftp://" + raw + "/", "SFTP")
+    return null
+}
+
+function explicitUri(raw) {
+    var parsed = Protocols.parse(raw)
+    if (!parsed || passwordEmbedded(raw) || /[?#]/.test(raw))
+        return null
+    return answer(raw, parsed.protocol)
+}
+
+function passwordEmbedded(uri) {
+    var m = String(uri).match(/^[a-z][a-z0-9+.-]*:\/\/([^\/@]*)@/i)
+    return !!(m && m[1].indexOf(":") >= 0)
+}
+
+function cleanPath(path) {
+    var value = String(path || "").replace(/^\/+/, "")
+    return value.length > 0 ? "/" + value : "/"
+}
+
+function answer(uri, protocol) {
+    var normalized = Mounts.normalize(uri)
+    var form = Protocols.parse(normalized)
+    return form ? { uri: normalized, protocol: protocol, form: form } : null
+}

--- a/ui/js/Recents.js
+++ b/ui/js/Recents.js
@@ -1,0 +1,136 @@
+.pragma library
+
+.import "Mounts.js" as Mounts
+
+var LIMIT = 8
+
+function parse(body) {
+    return parseState(body).recent
+}
+
+function parseState(body) {
+    if (String(body || "").trim().length === 0)
+        return { recent: [], profiles: [] }
+    var value
+    try { value = JSON.parse(String(body)) } catch (e) { return { recent: [], profiles: [] } }
+    if (!value)
+        return { recent: [], profiles: [] }
+    var out = []
+    var source = Array.isArray(value.recent) ? value.recent : []
+    for (var i = 0; i < source.length && out.length < LIMIT; i++) {
+        var row = clean(source[i])
+        if (row)
+            out.push(row)
+    }
+    var profiles = []
+    var rawProfiles = Array.isArray(value.profiles) ? value.profiles : []
+    for (var p = 0; p < rawProfiles.length; p++) {
+        var profile = clean(rawProfiles[p])
+        if (profile && profile.mac.length > 0)
+            profiles.push(profile)
+    }
+    return { recent: dedupe(out), profiles: dedupe(profiles) }
+}
+
+// Called only after gio resolved a browsable local path. A failure never reaches this function.
+function record(list, uri, label, usedAt, mac) {
+    var row = clean({ uri: sanitizeUri(uri), label: label, usedAt: usedAt, mac: mac })
+    if (!row)
+        return (list || []).slice(0, LIMIT)
+    return dedupe([row].concat(list || [])).slice(0, LIMIT)
+}
+
+function serialize(list) {
+    return serializeState(list, [])
+}
+
+function serializeState(list, profiles) {
+    return JSON.stringify({ version: 1, recent: (list || []).slice(0, LIMIT), profiles: profiles || [] }, null, 2) + "\n"
+}
+
+function rememberProfile(list, oldUri, uri, label, mac) {
+    var oldKey = Mounts.normalize(oldUri)
+    var newKey = Mounts.normalize(uri)
+    var kept = (list || []).filter(function (entry) {
+        var key = Mounts.normalize(entry.uri)
+        return key !== oldKey && key !== newKey
+    })
+    var row = clean({ uri: uri, label: label, usedAt: 0, mac: mac })
+    if (!row || row.mac.length === 0)
+        return kept
+    return dedupe([row].concat(kept))
+}
+
+function remove(list, uri) {
+    var key = Mounts.normalize(uri)
+    return (list || []).filter(function (entry) { return Mounts.normalize(entry.uri) !== key })
+}
+
+function profileEntries(list) {
+    var rows = entries(list)
+    for (var i = 0; i < rows.length; i++) {
+        rows[i].kind = "profile"
+        rows[i].origin = "lan"
+        rows[i].glyph = "server"
+    }
+    return rows
+}
+
+function entries(list) {
+    var out = []
+    for (var i = 0; i < (list || []).length; i++) {
+        var row = list[i]
+        out.push({ path: "", label: row.label, group: "network", kind: "recent", uri: row.uri,
+                   mounted: false, glyph: "history", origin: "recent", health: "unknown",
+                   address: authority(row.uri), taildrop: false, mac: row.mac })
+    }
+    return out
+}
+
+function clean(row) {
+    if (!row)
+        return null
+    var uri = sanitizeUri(row.uri)
+    if (uri.length === 0)
+        return null
+    var label = String(row.label || "").replace(/[\r\n]/g, "").trim() || authority(uri)
+    var stamp = Number(row.usedAt)
+    return { uri: uri, label: label, usedAt: isFinite(stamp) ? stamp : 0, mac: normalizeMac(row.mac) }
+}
+
+function sanitizeUri(uri) {
+    var raw = String(uri || "").trim().replace(/[?#].*$/, "")
+    var m = raw.match(/^([a-z][a-z0-9+.-]*:\/\/)([^\/]*)(.*)$/i)
+    if (!m)
+        return ""
+    var auth = m[2]
+    var at = auth.lastIndexOf("@")
+    if (at >= 0) {
+        var user = auth.substring(0, at).split(":")[0]
+        auth = (user.length > 0 ? user + "@" : "") + auth.substring(at + 1)
+    }
+    return Mounts.normalize(m[1] + auth + m[3])
+}
+
+function authority(uri) {
+    var m = String(uri || "").match(/^[a-z][a-z0-9+.-]*:\/\/([^\/]+)/i)
+    return m ? m[1].replace(/^.*@/, "") : ""
+}
+
+function normalizeMac(value) {
+    var compact = String(value || "").replace(/[^0-9a-f]/gi, "").toLowerCase()
+    return compact.length === 12 ? compact.match(/../g).join(":") : ""
+}
+
+function dedupe(list) {
+    var out = []
+    var seen = {}
+    for (var i = 0; i < list.length; i++) {
+        var key = Mounts.normalize(list[i].uri)
+        if (seen[key])
+            continue
+        seen[key] = true
+        out.push(list[i])
+    }
+    return out
+}

--- a/ui/js/Remote.js
+++ b/ui/js/Remote.js
@@ -1,0 +1,76 @@
+.pragma library
+
+function isRemotePath(path) {
+    return /^\/run\/user\/\d+\/gvfs\//.test(String(path || ""))
+}
+
+function transferKind(paths, destination) {
+    if (!isRemotePath(destination))
+        return "local"
+    var list = paths || []
+    for (var i = 0; i < list.length; i++) {
+        if (isRemotePath(list[i]))
+            return "remote-to-remote"
+    }
+    return "local-to-remote"
+}
+
+function transferPrefix(kind, moving) {
+    var verb = moving ? "Moving" : "Copying"
+    return kind === "remote-to-remote" ? verb + " between remote hosts" : verb
+}
+
+function menu(entry) {
+    if (!entry || entry.group !== "network" || entry.kind === "dropbox" || entry.kind === "status")
+        return []
+    var rows = []
+    if (entry.mounted)
+        rows.push(item("Unmount", "unmount", "eject"))
+    if (entry.health === "failed" || entry.health === "offline")
+        rows.push(item("Reconnect", "reconnect", "refresh-cw"))
+    rows.push(item("Copy address", "copy-address", "file-text"))
+    if (sshTarget(entry.uri).length > 0 && entry.health !== "offline")
+        rows.push(item("Open terminal over SSH", "open-ssh", "terminal"))
+    if (entry.taildrop && entry.health === "online")
+        rows.push(item("Send with Taildrop", "taildrop-peer", "network"))
+    if (entry.origin === "lan" && validMac(entry.mac))
+        rows.push(item("Wake", "wake", "power"))
+    if (entry.kind !== "peer" && entry.kind !== "discovered") {
+        rows.push(item("Edit", "edit", "rename"))
+        rows.push(item("Remove", "remove", "trash"))
+    }
+    return rows
+}
+
+function item(label, action, glyph) { return { label: label, action: action, glyph: glyph } }
+
+function sshTarget(uri) {
+    var spec = sshSpec(uri)
+    return spec ? spec.target : ""
+}
+
+function terminalArgv(entry) {
+    var spec = sshSpec(entry && entry.uri)
+    if (!spec)
+        return []
+    var out = ["omarchy-launch-terminal", "ssh"]
+    if (spec.port.length > 0)
+        out = out.concat(["-p", spec.port])
+    out.push(spec.target)
+    return out
+}
+
+function sshSpec(uri) {
+    var m = String(uri || "").match(/^(?:sftp|ssh):\/\/((?:[A-Za-z0-9._%-]+@)?)(\[[0-9A-Fa-f:%._-]+\]|[A-Za-z0-9._-]+)(?::(\d+))?(?:\/.*)?$/i)
+    if (!m)
+        return null
+    var port = m[3] || ""
+    if (port.length > 0 && (Number(port) < 1 || Number(port) > 65535))
+        return null
+    var host = m[2].charAt(0) === "[" ? m[2].slice(1, -1) : m[2]
+    return { target: m[1] + host, port: port }
+}
+
+function validMac(value) {
+    return /^[0-9a-f]{2}(?::[0-9a-f]{2}){5}$/i.test(String(value || ""))
+}

--- a/ui/js/Remote.js
+++ b/ui/js/Remote.js
@@ -1,18 +1,29 @@
 .pragma library
 
 function isRemotePath(path) {
-    return /^\/run\/user\/\d+\/gvfs\//.test(String(path || ""))
+    return remoteRoot(path).length > 0
+}
+
+function remoteRoot(path) {
+    var match = String(path || "").match(/^(\/run\/user\/\d+\/gvfs\/[^\/]+)(?:\/|$)/)
+    return match ? match[1] : ""
 }
 
 function transferKind(paths, destination) {
-    if (!isRemotePath(destination))
+    var destinationRoot = remoteRoot(destination)
+    if (destinationRoot.length === 0)
         return "local"
     var list = paths || []
+    if (list.length === 0)
+        return "local-to-remote"
     for (var i = 0; i < list.length; i++) {
-        if (isRemotePath(list[i]))
-            return "remote-to-remote"
+        var sourceRoot = remoteRoot(list[i])
+        if (sourceRoot.length === 0)
+            return "local-to-remote"
+        if (sourceRoot === destinationRoot)
+            return "same-remote"
     }
-    return "local-to-remote"
+    return "remote-to-remote"
 }
 
 function transferPrefix(kind, moving) {

--- a/ui/js/Tailnet.js
+++ b/ui/js/Tailnet.js
@@ -1,0 +1,131 @@
+.pragma library
+
+// Tailscale supplies reachability and identity, never a filesystem. These peers become ordinary
+// SFTP locations (or a protocol the operator later chooses) and keep Taildrop as a separate action.
+function parseResult(exitCode, stdout, stderr) {
+    var error = String(stderr || "").toLowerCase()
+    if (exitCode !== 0) {
+        if (/not found|no such file|failed to start/.test(error))
+            return result("missing", "Tailscale is unavailable; install its CLI to discover tailnet peers.", [])
+        if (/tailscaled|failed to connect|not running/.test(error))
+            return result("daemon-stopped", "Tailscale is stopped; run sudo systemctl enable --now tailscaled.", [])
+        if (/logged out|needs login|not logged in/.test(error))
+            return result("logged-out", "Tailscale is logged out; run sudo tailscale up in a terminal.", [])
+        return result("failed", "Tailscale status could not be read.", [])
+    }
+    var data
+    try {
+        data = JSON.parse(String(stdout || ""))
+    } catch (e) {
+        return result("failed", "Tailscale returned an unreadable status.", [])
+    }
+    var state = String((data && data.BackendState) || "")
+    if (state === "NeedsLogin" || state === "NoState")
+        return result("logged-out", "Tailscale is logged out; run sudo tailscale up in a terminal.", [])
+    if (state === "Stopped")
+        return result("daemon-stopped", "Tailscale is stopped; run sudo systemctl enable --now tailscaled.", [])
+    if (state !== "Running")
+        return result("failed", "Tailscale is not ready (" + (state || "unknown state") + ").", [])
+    var peers = parsePeers(data)
+    return peers.length > 0
+        ? result("ready", "Tailscale peers are ready.", peers)
+        : result("no-peers", "No machines were found on this tailnet.", [])
+}
+
+function result(state, message, peers) {
+    return { state: state, message: message, peers: peers }
+}
+
+function parsePeers(data) {
+    var raw = (data && data.Peer) || {}
+    var selfUserId = String((data && data.Self && data.Self.UserID) || "")
+    var out = []
+    for (var id in raw) {
+        var peer = raw[id] || {}
+        if (isMullvad(peer))
+            continue
+        var address = peerAddress(peer)
+        if (address.length === 0)
+            continue
+        out.push({ id: id, label: displayHostName(peer.HostName, peer.DNSName), address: address,
+                   online: !!peer.Online, taildrop: isTaildropTarget(peer, selfUserId), origin: "tailnet" })
+    }
+    out.sort(function (a, b) {
+        if (a.online !== b.online)
+            return a.online ? -1 : 1
+        return a.label.localeCompare(b.label)
+    })
+    return out
+}
+
+function entries(peers, user) {
+    var out = []
+    var login = safeUser(user)
+    for (var i = 0; i < (peers || []).length; i++) {
+        var peer = peers[i]
+        var authority = hostForUri(peer.address)
+        if (login.length > 0)
+            authority = login + "@" + authority
+        out.push({ path: "", label: peer.label, group: "network", kind: "peer",
+                   uri: "sftp://" + authority + "/", mounted: false, glyph: "network",
+                   origin: "tailnet", health: peer.online ? "online" : "offline",
+                   address: peer.address, peerId: peer.id, taildrop: !!peer.taildrop, mac: "" })
+    }
+    return out
+}
+
+function safeUser(user) {
+    var value = String(user || "").trim()
+    return /^[A-Za-z0-9._-]+$/.test(value) ? value : ""
+}
+
+function hostForUri(host) {
+    var value = String(host || "")
+    return value.indexOf(":") >= 0 && value.charAt(0) !== "[" ? "[" + value + "]" : value
+}
+
+function cleanDnsName(name) {
+    var value = String(name || "")
+    return value.charAt(value.length - 1) === "." ? value.slice(0, -1) : value
+}
+
+function displayHostName(hostName, dnsName) {
+    var host = String(hostName || "")
+    if (host !== "" && host.toLowerCase() !== "localhost")
+        return host
+    var clean = cleanDnsName(dnsName)
+    return (clean === "" ? "" : clean.split(".")[0]) || host || "Unknown"
+}
+
+function isMullvad(peer) {
+    var dns = cleanDnsName((peer && peer.DNSName) || "").toLowerCase()
+    var host = String((peer && peer.HostName) || "").toLowerCase()
+    return endsWith(dns, ".mullvad.ts.net") || endsWith(host, ".mullvad.ts.net")
+}
+
+function endsWith(value, suffix) {
+    return value.length > suffix.length && value.lastIndexOf(suffix) === value.length - suffix.length
+}
+
+function peerAddress(peer) {
+    if (!peer)
+        return ""
+    if (peer.DNSName)
+        return cleanDnsName(peer.DNSName)
+    if (peer.HostName)
+        return String(peer.HostName)
+    var ips = peer.TailscaleIPs || []
+    for (var i = 0; i < ips.length; i++) {
+        if (/^100\./.test(String(ips[i])))
+            return String(ips[i])
+    }
+    return ""
+}
+
+function isTaildropTarget(peer, selfUserId) {
+    var target = peer && peer.TaildropTarget
+    if (typeof target === "number" && target !== 0)
+        return target === 1
+    var owner = String((peer && peer.UserID) || "")
+    return owner !== "" && owner === String(selfUserId || "")
+}

--- a/ui/qmldir
+++ b/ui/qmldir
@@ -21,6 +21,7 @@ MediaStrip 1.0 MediaStrip.qml
 MenuRow 1.0 MenuRow.qml
 RenameField 1.0 RenameField.qml
 EmptyState 1.0 EmptyState.qml
+FastScrollHandler 1.0 FastScrollHandler.qml
 DeviceMounts 1.0 DeviceMounts.qml
 DropboxMark 1.0 DropboxMark.qml
 Glyph 1.0 Glyph.qml

--- a/ui/qmldir
+++ b/ui/qmldir
@@ -35,6 +35,10 @@ LoadingState 1.0 LoadingState.qml
 NetworkDialog 1.0 NetworkDialog.qml
 NetworkForm 1.0 NetworkForm.qml
 NetworkMounts 1.0 NetworkMounts.qml
+NetworkDiscovery 1.0 NetworkDiscovery.qml
+NetworkHistory 1.0 NetworkHistory.qml
+NetworkActions 1.0 NetworkActions.qml
+NetworkRail 1.0 NetworkRail.qml
 FleaMark 1.0 FleaMark.qml
 Opener 1.0 Opener.qml
 Preview 1.0 Preview.qml

--- a/ui/shell.qml
+++ b/ui/shell.qml
@@ -155,13 +155,16 @@ ShellRoot {
                 id: networkDialog
                 // FocusScope remembers its own last-focused child, list or rail, and restores it.
                 onClosed: pane.forceActiveFocus()
-                onSaved: pane.sidebar.reloadBookmarks()
+                onSaved: function (oldUri, uri, label, mac) {
+                    pane.sidebar.rememberNetworkProfile(oldUri, uri, label, mac)
+                    pane.sidebar.reloadBookmarks()
+                }
             }
 
             Connections {
                 target: pane.sidebar
                 function onAddRequested() { networkDialog.open() }
-                function onEditRequested(uri, label) { networkDialog.openEdit(uri, label) }
+                function onEditRequested(uri, label, mac) { networkDialog.openEdit(uri, label, mac) }
                 function onSharesListed(baseUri, baseLabel, names) { shareBrowser.open(baseUri, baseLabel, names) }
             }
 

--- a/ui/shell.qml
+++ b/ui/shell.qml
@@ -161,6 +161,7 @@ ShellRoot {
             Connections {
                 target: pane.sidebar
                 function onAddRequested() { networkDialog.open() }
+                function onEditRequested(uri, label) { networkDialog.openEdit(uri, label) }
                 function onSharesListed(baseUri, baseLabel, names) { shareBrowser.open(baseUri, baseLabel, names) }
             }
 


### PR DESCRIPTION
## Dependency order

- depends on #16 for shared accelerated scrolling
- depends on #21 for editable/removable network places and safe live-unmount behavior
- depends on #31 for explicit remote-to-remote transfer reporting
- depends on #33 for fresh output from reusable QML processes
- depends on #35 for safe directory rename on rclone FUSE mounts
- includes the tested overflow follow-up proposed to #16 at https://github.com/stappmus/flea/pull/1

The branch contains those exact commits so it is testable now; GitHub's diff will shrink as the prerequisite PRs merge.

## What changes

- discovers Tailscale peers without treating Tailscale as a filesystem; file access still uses SFTP/SMB/NFS/WebDAV
- discovers bounded Avahi SSH, SMB, NFS, WebDAV, and WebDAVS services on the LAN
- adds Quick Connect for `user@host:/path`, `host/share`, bare hosts, supported URIs, IPv4, and bracketed IPv6
- persists eight sanitized successful recents plus separate Wake profiles
- exposes unknown, online, offline, connecting, mounted, and failed health states
- adds reconnect, unmount, copy address, SSH terminal, Taildrop, edit/remove, and Wake-on-LAN actions by capability
- adds native `flea --wake <mac>` validation and a 102-byte UDP magic packet
- bounds every discovery/listing child and keeps LAN/GIO usable across all Tailscale failure states

## Additional bugs fixed

- IPv6 hosts were split as ports; copy-address also lost a bracket
- custom SSH ports were rejected
- a stale Wake profile survived edits or clearing the MAC
- discovered mounted rows offered Unmount but could not execute it
- clipboard/Wake reported success before child exit
- older recents shadowed fresh discovery metadata
- delayed unmount cleared its identity before health cleanup
- bare-server `gio list` could hang forever
- Quick Connect could persist query tokens or fragments
- mixed or same-mount transfers could be mislabeled as crossing remote hosts
- a refused transfer could leak its classification into the next operation
- a quiet process run could reuse an earlier mount, share, device, or Taildrop response
- New Folder created a directory on rclone but its automatic rename failed with `EINVAL`
- #21's newer `@`-in-path and failed-live-remove fixes are retained

## Verification, repeated twice

- [x] clean debug and release builds, zero warnings
- [x] 345 Rust tests in debug and 345 in release
- [x] `./tests/run-all.sh` — 13 suites, 0 failed; final pushed head has 1,270 JS/QML checks
- [x] real `~/google` rclone rename succeeds; occupied destination remains untouched
- [x] stale-output regression mutation: removing one of the six resets makes the new suite fail
- [x] process-boundary cases for missing/empty/malformed/failed/timed-out discovery, wedged GIO, argv integrity, action exits, and secret-free persistence
- [x] `./tools/flea-qmllint-gate` — 0 regressions
- [x] `./tools/flea-file-budget` — all hard caps pass
- [x] `git diff --check`
- [x] two live Wayland loads reached `Configuration Loaded`
- [ ] pointer-driven `tests/ui.sh` cases: `omarchy-drive` is not installed, packaged, or publicly discoverable under that name on this machine; deterministic QML process tests and live loads are green

## Safety

Discovery and recovery never run `sudo`, start daemons, or change authentication. External commands are argv-direct; persisted URIs strip passwords, query strings, fragments, and control characters. rclone compatibility is limited to directories on mounts identified exactly as `fuse.rclone`; files and all other filesystems retain atomic no-clobber rename.
