### PR TITLE
fix: clear output between reusable processes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3578,6 +3578,17 @@ reachable while a device is misbehaving. The `_streamPending` interlock is relea
 rather than in the timer, because a collector whose stream was cut off may never finish it and
 `poll()` refuses on that flag alone.
 
+**Every reusable Process starts with an empty fallback.** `StdioCollector.text` and the parallel
+`_...Output` value exist because `Process.onExited` can race the collector property update, but the
+fallback is ordinary component state and survives the next command. Before this rule, a quiet
+second run could reuse the first run's bytes: an empty `gio mount -l` retained a disconnected
+share, empty `gio info` reopened the previous share's local path, an empty server listing repeated
+another server's names, a failed mount with no stderr inherited "already mounted", empty `lsblk`
+retained removed devices, and empty Tailscale status retained old Taildrop targets. Each start
+function now clears only its own fallback after refusing any overlapping run and before setting
+`Process.running`. `tests/process-output.sh` poisons all six values, starts all six real Process
+objects, and requires every reset synchronously; removing any one reset makes the suite red.
+
 ### Closing the window quits the backend, and a copy in flight is cancelled
 
 `ui/shell.qml` answers `Quickshell.onLastWindowClosed` with `backend.quit()` and signals its own pid

--- a/tests/process-output.qml
+++ b/tests/process-output.qml
@@ -1,0 +1,66 @@
+//@ pragma ShellId flea-process-output-test
+
+import QtQuick
+import Quickshell
+
+// Each service owns a StdioCollector fallback because Process.onExited can race the collector's
+// text property. These values deliberately poison every fallback, then start a second run. The
+// reset is synchronous, so this catches stale cross-run output without depending on signal order.
+ShellRoot {
+    id: root
+
+    property bool checked: false
+
+    NetworkMounts { id: network }
+    DeviceMounts { id: devices }
+    Taildrop { id: taildrop }
+
+    function finish() {
+        Quickshell.execDetached(["kill", String(Quickshell.processId)])
+    }
+
+    Timer {
+        interval: 500
+        running: true
+        repeat: false
+        onTriggered: {
+            root.checked = true
+
+            network._mountErrOutput = "old mount error: already mounted"
+            network.openShare("smb://new-host/share", false, "New")
+
+            network._infoOutput = "local path: /old/share"
+            network.runInfo("smb://new-host/share")
+
+            network._listSharesOutput = "old-share"
+            network.listShares("smb://new-host/")
+
+            network._mountListOutput = "Mount(0): old -> smb://old/share/"
+            network.pollMounts()
+
+            devices._listOutput = '{"blockdevices":[{"name":"old"}]}'
+            devices.poll()
+
+            taildrop._statusOutput = '{"Peer":{"old":{}}}'
+            taildrop.refresh()
+
+            var fresh = network._mountErrOutput === ""
+                && network._infoOutput === ""
+                && network._listSharesOutput === ""
+                && network._mountListOutput === ""
+                && devices._listOutput === ""
+                && taildrop._statusOutput === ""
+            console.log("PROCESS_OUTPUT fresh=" + (fresh ? "yes" : "no"))
+            root.finish()
+        }
+    }
+
+    Timer {
+        interval: 5000
+        running: true
+        onTriggered: {
+            console.log("PROCESS_OUTPUT timeout checked=" + root.checked)
+            root.finish()
+        }
+    }
+}

--- a/tests/process-output.sh
+++ b/tests/process-output.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Proves reusable QML Process fallbacks are cleared before every new command.
+set -u
+. "$(dirname "$0")/../tools/flea-sandbox-guard"
+cd "$(dirname "$0")/.." || exit 1
+
+D="$FIXTURE_ROOT/flea-process-output-$$"
+cleanup() { sandbox_remove "$D"; }
+trap cleanup EXIT
+sandbox_make "$D"
+mkdir -p "$D/bin" "$D/home/.config" "$D/config"
+
+for file in NetworkMounts.qml DeviceMounts.qml Taildrop.qml; do
+  ln -s "$PWD/ui/$file" "$D/config/$file"
+done
+ln -s "$PWD/ui/js" "$D/config/js"
+ln -s "$PWD/tests/process-output.qml" "$D/config/shell.qml"
+
+cat > "$D/bin/gio" <<'EOS'
+#!/bin/sh
+[ "$1 $2" = "mount -l" ] && exit 0
+sleep 3
+EOS
+cat > "$D/bin/lsblk" <<'EOS'
+#!/bin/sh
+printf '%s\n' '{"blockdevices":[]}'
+EOS
+cat > "$D/bin/tailscale" <<'EOS'
+#!/bin/sh
+sleep 3
+EOS
+chmod +x "$D/bin/"*
+
+out=$(env HOME="$D/home" PATH="$D/bin:/usr/bin:/bin" QT_FORCE_STDERR_LOGGING=1 \
+  timeout 7 qs -p "$D/config" 2>&1)
+count=$(grep -c 'PROCESS_OUTPUT fresh=yes' <<< "$out")
+if [ "$count" -ne 1 ]; then
+  printf 'FAIL reusable Process output crossed command boundaries\n%s\n' "$out"
+  exit 1
+fi
+
+printf 'process-output: all fallbacks start fresh\n'

--- a/tests/run-all.sh
+++ b/tests/run-all.sh
@@ -24,7 +24,7 @@ if [ ! -x target/release/flea ]; then
     cargo build -q --release || { printf 'run-all: release build failed, nothing else was run\n' >&2; exit 1; }
 fi
 
-headless="js keymap-gen charts budget sandbox ops modes protocol archive thumbs"
+headless="js keymap-gen charts budget sandbox ops modes protocol archive thumbs process-output"
 failed=0
 ran=0
 

--- a/ui/DeviceMounts.qml
+++ b/ui/DeviceMounts.qml
@@ -74,6 +74,8 @@ Item {
         root._listTimedOut = false
         root._streamPending = true
         root._listingsStarted += 1
+        // lsblk can legitimately return an empty tree. Never rebuild from the previous poll.
+        root._listOutput = ""
         listProcess.running = true
         listTimeout.restart()
     }

--- a/ui/NetworkMounts.qml
+++ b/ui/NetworkMounts.qml
@@ -130,12 +130,17 @@ Item {
             root.runInfo(uri)
             return
         }
+        // The collector belongs to the Process, but this fallback belongs to us and survives
+        // restarts. A quiet failure must never inherit an earlier "already mounted" stderr.
+        root._mountErrOutput = ""
         mountProcess.command = ["gio", "mount", uri]
         mountProcess.running = true
         mountTimeout.restart()
     }
 
     function runInfo(uri) {
+        // An empty reply is an answer. Do not turn it into the previous share's local path.
+        root._infoOutput = ""
         infoProcess.command = ["gio", "info", uri]
         infoProcess.running = true
     }
@@ -154,6 +159,8 @@ Item {
 
     // Client-side only, never writes bookmarks; see AGENTS.md "The share browser overlay".
     function listShares(uri) {
+        // A server that now lists nothing must not reopen the prior server's rows.
+        root._listSharesOutput = ""
         listSharesProcess.command = ["gio", "list", uri]
         listSharesProcess.running = true
     }
@@ -185,6 +192,8 @@ Item {
             return
         }
         root._listTimedOut = false
+        // Successful empty output means there are no live mounts; the prior poll is not a fallback.
+        root._mountListOutput = ""
         mountListProcess.running = true
         listTimeout.restart()
     }

--- a/ui/Taildrop.qml
+++ b/ui/Taildrop.qml
@@ -18,6 +18,8 @@ Item {
     function refresh() {
         if (statusProcess.running)
             return
+        // A successful empty status means no targets, not "reuse the last non-empty status".
+        root._statusOutput = ""
         statusProcess.running = true
     }
 


### PR DESCRIPTION
## What was wrong

The QML services reuse their `Process` objects and keep a parallel `_...Output` value because `onExited` can race `StdioCollector.text`. Those fallback values were never cleared before the next command.

A quiet second command could therefore consume the first command's bytes:

- an empty mount poll retained disconnected shares
- empty `gio info` could reopen the previous share's local path
- an empty server listing could repeat another server's shares
- a mount failure with no stderr could inherit an earlier `already mounted` message
- empty `lsblk` output could retain removed devices
- empty Tailscale status could retain stale Taildrop targets

## Fix

Clear each fallback after rejecting an overlapping run and immediately before starting its reusable `Process`. Timeouts still retain the last good model intentionally; this only prevents a completed new run from borrowing an older run's raw output.

## Verification

- [x] new `tests/process-output.sh` poisons all six fallback values and starts the real QML Process objects
- [x] mutation check: removing one reset makes the new suite fail
- [x] `./tests/run-all.sh` repeated twice — 11 suites, 0 failed; 1,153 JS/QML checks
- [x] `./tools/flea-qmllint-gate` — 0 regressions
- [x] `./tools/flea-file-budget` — all hard caps pass
- [x] `git diff --check`
