### PR TITLE
feat: open the default terminal in the current directory from the topbar

### DIFF
--- a/keys.toml
+++ b/keys.toml
@@ -55,6 +55,12 @@ action = "addNetwork"
 key = "L"
 action = "pathBar"
 
+# Opens the default terminal in the directory being shown, through flea --terminal
+# (xdg-terminal-exec --dir=). Ctrl+T is free and mirrors GNOME's own open-in-terminal chord.
+[[ctrl]]
+key = "T"
+action = "openTerminal"
+
 [[ctrl]]
 key = "Delete"
 action = "trash"
@@ -452,6 +458,11 @@ label = "context menu"
 keys = "^e"
 action = "eject"
 label = "eject"
+
+[[sheet]]
+keys = "^t"
+action = "openTerminal"
+label = "open terminal"
 
 [[sheet]]
 keys = "^+"

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ mod json;
 mod launcher;
 mod open;
 mod paths;
+mod terminal;
 mod thp;
 mod userfile;
 
@@ -64,6 +65,11 @@ fn main() {
     // flea --open <path>
     if args.len() == 3 && args[1] == "--open" {
         exit(open::open(&args[2]));
+    }
+
+    // flea --terminal <dir>
+    if args.len() == 3 && args[1] == "--terminal" {
+        exit(terminal::open_terminal(&args[2]));
     }
 
     // flea --default [off]: the one per-user step pacman cannot own, see docs/install.md.

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -1,0 +1,48 @@
+use crate::thp;
+use std::os::unix::process::CommandExt;
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+
+// The exit status ui/Opener.qml reads. 0 is a successful handoff and needs no name.
+pub const FAILED: i32 = 2;
+
+// Canonical, so a directory named --output=/etc/x cannot be read as a flag by the child.
+fn resolved(path: &str) -> Option<PathBuf> {
+    std::fs::canonicalize(path).ok()
+}
+
+// xdg-terminal-exec is the OEM route: `omarchy default terminal` configures what it reads,
+// and --dir= names the working directory without taking a command.
+pub fn open_terminal(path: &str) -> i32 {
+    let target = match resolved(path) {
+        Some(p) => p,
+        // The reason is elided, never shown raw, and the path is the user's own input.
+        None => {
+            eprintln!("flea: that terminal could not be opened, check that it still exists");
+            return FAILED;
+        }
+    };
+    if !target.is_dir() {
+        eprintln!("flea: that terminal could not be opened, check that it still exists");
+        return FAILED;
+    }
+    // The setting is inherited across exec, so this is the last point that can hand it back.
+    thp::enable();
+    // corner: spawn and not exec, because the terminal outlives us; see AGENTS.md "Opening a file".
+    let started = Command::new("xdg-terminal-exec")
+        .arg(format!("--dir={}", target.display()))
+        // The terminal outlives us, so an inherited pipe would kill it on its first write; see AGENTS.md "Opening a file".
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        // Its own process group, so nothing that later kills Flea's group reaches the terminal.
+        .process_group(0)
+        .spawn();
+    match started {
+        Ok(_) => 0,
+        Err(_) => {
+            eprintln!("flea: nothing on this system could be asked to open a terminal there");
+            FAILED
+        }
+    }
+}

--- a/tests/js/keymap.js
+++ b/tests/js/keymap.js
@@ -54,6 +54,7 @@ function run(check) {
     check("ctrl z undoes", Keymap.lookup(Qt.Key_Z, "\u001a", ctrl), "undo")
     check("ctrl f searches", Keymap.lookup(Qt.Key_F, "\u0006", ctrl), "search")
     check("ctrl e ejects", Keymap.lookup(Qt.Key_E, "\u0005", ctrl), "eject")
+    check("ctrl t opens a terminal here", Keymap.lookup(Qt.Key_T, "\u0014", ctrl), "openTerminal")
     check("ctrl k connects to a server", Keymap.lookup(Qt.Key_K, "\u000b", ctrl), "addNetwork")
     check("ctrl delete trashes", Keymap.lookup(Qt.Key_Delete, "", ctrl), "trash")
     check("ctrl up goes to the parent", Keymap.lookup(Qt.Key_Up, "", ctrl), "parent")
@@ -104,14 +105,14 @@ function run(check) {
           Keymap.SHEET.map(sheetAction).join("|"),
           Keymap.SHEET.map(function (row) { return row.action }).join("|"))
     check("the sheet is not empty, so the check above has a denominator",
-          Keymap.SHEET.length, 24)
+          Keymap.SHEET.length, 25)
     // A chord shares the row of the key it doubles, so every caret token must resolve to that row's
     // own action, or the sheet advertises a chord bound to something else.
     check("every chord the sheet draws is bound to the action of its own row",
           Keymap.SHEET.map(chordActions).join("|"),
           Keymap.SHEET.map(function (row) { return chordTokens(row).map(function () { return row.action }).join("+") }).join("|"))
     check("and the sheet draws chords at all, so that check has a denominator",
-          Keymap.SHEET.filter(function (row) { return chordTokens(row).length > 0 }).length, 10)
+          Keymap.SHEET.filter(function (row) { return chordTokens(row).length > 0 }).length, 11)
     check("slash filters, and the sheet now draws the row for it",
           Keymap.SHEET.filter(function (r) { return r.keys === "/" }).length, 1)
     check("and the sheet draws m, so eject and unmount are not mouse-only affordances",

--- a/ui/ChromeBar.qml
+++ b/ui/ChromeBar.qml
@@ -21,6 +21,7 @@ Item {
     signal backRequested()
     signal upRequested()
     signal searchRequested()
+    signal terminalRequested()
     signal viewChosen(string mode)
     // The path bar's four. ui/shell.qml navigates, hands the keyboard back, runs the peek behind Tab
     // and carries what the bar says to the status line, because this file draws the chrome and knows
@@ -313,6 +314,11 @@ Item {
         Flea.ChromeButton {
             glyph: "search"
             onActivated: root.searchRequested()
+        }
+
+        Flea.ChromeButton {
+            glyph: "terminal"
+            onActivated: root.terminalRequested()
         }
 
         Repeater {

--- a/ui/ChromeButton.qml
+++ b/ui/ChromeButton.qml
@@ -22,6 +22,8 @@ Item {
             return "Parent folder"
         if (root.glyph === "search")
             return "Search"
+        if (root.glyph === "terminal")
+            return "Open in terminal"
         if (root.glyph === "list")
             return "List view"
         if (root.glyph === "columns")

--- a/ui/Opener.qml
+++ b/ui/Opener.qml
@@ -14,6 +14,10 @@ Item {
     readonly property int isDirectoryStatus: 3
 
     property string current: ""
+    // The terminal launch's own path: open() and openTerminal() run on separate
+    // Processes guarded only against themselves, so sharing current let whichever
+    // started second rewrite the path the first one's onExited still reports.
+    property string terminalCurrent: ""
 
     // flea --open decides and exits in milliseconds, so one Process serves every open.
     function open(path) {
@@ -47,7 +51,7 @@ Item {
         if (terminalChild.running) {
             return
         }
-        root.current = path
+        root.terminalCurrent = path
         terminalChild.command = [Quickshell.env("FLEA_BIN") || "flea", "--terminal", path]
         terminalChild.running = true
     }
@@ -59,7 +63,7 @@ Item {
             if (exitCode === 0) {
                 return
             }
-            root.terminalFailed(root.current)
+            root.terminalFailed(root.terminalCurrent)
         }
     }
 

--- a/ui/Opener.qml
+++ b/ui/Opener.qml
@@ -8,6 +8,7 @@ Item {
 
     signal failed(string path)
     signal isDirectory(string path)
+    signal terminalFailed(string path)
 
     // The status src/open.rs returns for a directory, which the caller navigates to instead.
     readonly property int isDirectoryStatus: 3
@@ -36,6 +37,29 @@ Item {
                 return
             }
             root.failed(root.current)
+        }
+    }
+
+    // A terminal in the current directory, through flea --terminal so the huge page,
+    // process-group and stdio guards in src/terminal.rs apply. Its own Process, because
+    // flea --open decides and exits in milliseconds and one process serves every open.
+    function openTerminal(path) {
+        if (terminalChild.running) {
+            return
+        }
+        root.current = path
+        terminalChild.command = [Quickshell.env("FLEA_BIN") || "flea", "--terminal", path]
+        terminalChild.running = true
+    }
+
+    Process {
+        id: terminalChild
+
+        onExited: function (exitCode, exitStatus) {
+            if (exitCode === 0) {
+                return
+            }
+            root.terminalFailed(root.current)
         }
     }
 

--- a/ui/Pane.qml
+++ b/ui/Pane.qml
@@ -219,6 +219,9 @@ FocusScope {
     // A path the caller already resolved, for the columns view's neighbour rows, which have no cursor.
     function openFile(path) { wire.opener.open(path) }
 
+    // A terminal in the directory being shown, through ui/Opener.qml's flea --terminal.
+    function openTerminal() { wire.opener.openTerminal(root.path) }
+
     function openParent() { Nav.parent(root) }
 
     function join(base, name) {

--- a/ui/PaneWire.qml
+++ b/ui/PaneWire.qml
@@ -29,6 +29,7 @@ Item {
         id: opener
         onFailed: function (path) { pane.message("That file could not be opened; check that it still exists.", true) }
         onIsDirectory: function (path) { pane.open(path) }
+        onTerminalFailed: function (path) { pane.message("That terminal could not be opened; check that it still exists.", true) }
     }
 
     Flea.ShareLink {

--- a/ui/js/Focus.js
+++ b/ui/js/Focus.js
@@ -122,6 +122,7 @@ function act(action, root) {
     case "sortReverse": Sort.reverse(root); return
     case "addNetwork": root.sidebar.addRequested(); return
     case "eject": Eject.release(root, root.sidebar, false); return
+    case "openTerminal": root.openTerminal(); return
     // Finder's Cmd+1/2/3; the chrome's three buttons write the same property, so they follow.
     case "viewList": root.viewMode = "list"; return
     case "viewColumns": root.viewMode = "columns"; return
@@ -252,6 +253,11 @@ function handleKey(event, root, sidebar) {
     // The bar lives in the chrome above both views, so neither owns it; shell.qml holds the field.
     if (action === "pathBar") {
         root.pathBarRequested()
+        return true
+    }
+    // The terminal button lives in the same chrome, so it answers from either view too.
+    if (action === "openTerminal") {
+        root.openTerminal()
         return true
     }
     if (root.focusView === RAIL) {

--- a/ui/js/Keymap.js
+++ b/ui/js/Keymap.js
@@ -24,6 +24,7 @@ function lookup(key, text, modifiers) {
         if (key === Qt.Key_E) return "eject"
         if (key === Qt.Key_K) return "addNetwork"
         if (key === Qt.Key_L) return "pathBar"
+        if (key === Qt.Key_T) return "openTerminal"
         if (key === Qt.Key_Delete) return "trash"
         if (key === Qt.Key_Up) return "parent"
         if (key === Qt.Key_Down) return "open"
@@ -115,6 +116,7 @@ var SHEET = [
     { keys: "a", action: "addNetwork", label: "add network place" },
     { keys: "m", action: "menu", label: "context menu" },
     { keys: "^e", action: "eject", label: "eject" },
+    { keys: "^t", action: "openTerminal", label: "open terminal" },
     { keys: "^+", action: "scaleUp", label: "scale up" },
     { keys: "^-", action: "scaleDown", label: "scale down" },
     { keys: "?", action: "keymapSheet", label: "this sheet" },

--- a/ui/shell.qml
+++ b/ui/shell.qml
@@ -65,6 +65,7 @@ ShellRoot {
                 onBackRequested: pane.goBack()
                 onUpRequested: pane.openParent()
                 onSearchRequested: pane.act("search")
+                onTerminalRequested: pane.openTerminal()
                 onViewChosen: function (mode) { pane.viewMode = mode }
                 // The path bar's four. The pane navigates and answers for the keyboard exactly as it
                 // does for every other route in, so a path typed and a row opened end the same way.


### PR DESCRIPTION
Terminal button beside the search icon, opening `xdg-terminal-exec --dir=<current dir>` so `omarchy default terminal` is respected.

How it is wired, mirroring `flea --open`:
- `flea --terminal <dir>` (`src/terminal.rs`): canonicalize, refuse non-directories, `thp::enable()`, detached spawn (`process_group(0)`, `Stdio::null()`), exit 0/2 with elided sentences.
- Chrome: `terminalRequested` signal + button right after search (`ui/ChromeBar.qml`), accessible name in `ui/ChromeButton.qml`, reuses the existing `terminal` mark in `ui/js/Icons.js` (no new artwork).
- `ui/Opener.qml` gains its own `terminalChild` Process via `FLEA_BIN`; failure surfaces on the status line through `ui/PaneWire.qml`.
- `Ctrl+T` (`keys.toml` + regenerated `ui/js/Keymap.js`, routed window-globally in `ui/js/Focus.js` so it answers from list and rail), with a keymap-sheet row.

Verified:
- `cargo build`, `cargo build --release`: zero warnings; `cargo test` and `cargo test --release`: 338 passed, 0 failed.
- `--terminal` driven against a stub handler: dir hands over `--dir=<canonical>` with detached stdio/pgid and THP back on; file/missing/missing-handler refuse elided; symlink resolves; bare flag is a usage error.
- `tests/modes.sh`, `tests/protocol.sh`, `tests/js.sh` (1154 checks), `tests/keymap-gen.sh`, `tests/budget.sh`, `tools/flea-qmllint-gate`: all clean.

Live demo: screen recording attached below (terminal opening on the current directory).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an **Open in terminal** button for the currently displayed directory.
  * Added the **Ctrl+T** shortcut for opening the current directory in the default terminal.
  * Added an entry to the keymap sheet documenting the new shortcut.
  * The terminal action is available from both file views.
* **Bug Fixes**
  * Terminal launch failures now display an error message.
  * Concurrent terminal launch requests are ignored.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->