### PR TITLE
fix: rename directories on rclone mounts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2533,8 +2533,16 @@ already is, so the loop stays the only writer of stdout.
 **Every write creates its target exclusively, and this is the module's whole safety story.** A file copy
 opens with `create_new`, a directory copy and a `mkdir` use `create_dir`, a symlink copy uses `symlink`, and a rename
 or a move uses `renameat2` with `RENAME_NOREPLACE`. None of them can destroy a file that is already
-there, and none has a check-then-write window another process can slip through. `std::fs::rename`
-silently replaces its target on Unix and is never used here.
+there. The one compatibility path is a directory on a mount identified exactly as `fuse.rclone` in
+`/proc/self/mountinfo`: rclone 1.75 returns `EINVAL` for `RENAME_NOREPLACE` even though its ordinary
+directory rename works. `renamecompat.rs` then checks the target for Flea's stable collision message
+and uses `std::fs::rename`; safety at the race boundary comes from rclone's own `operations.DirMove`,
+whose interface refuses an existing destination. This exception is never used for a file—rclone's
+file move deliberately accepts an object to overwrite—or on another filesystem. Mountinfo's escaped
+mount point is decoded and the deepest enclosing mount wins, so a nested non-rclone mount cannot
+inherit the exception. The parser, scope, successful fallback, and occupied-target refusal have Rust
+tests; the original failure and both outcomes were also reproduced through the real backend on the
+operator's `~/google` mount.
 
 **The journal records only what an operation created or moved.** `undo.rs`'s `Step` has exactly four
 shapes: `Moved` (rename back), `Created` (remove it), `MadeDir` (remove it while it is still empty, because

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -44,6 +44,7 @@ pub mod copyfile;
 pub mod ops;
 pub mod opsdispatch;
 pub mod opsreq;
+mod renamecompat;
 pub mod trash;
 pub mod undo;
 // Test-only: hard rule 9's sandbox root, so no destructive test names a path outside one.

--- a/src/backend/ops.rs
+++ b/src/backend/ops.rs
@@ -1,46 +1,24 @@
 // Rename, duplicate and mkdir: the three operations that answer once, with no started or progress split.
 use crate::backend::copyfile::{copy_any, Progress};
+use crate::backend::renamecompat;
 use crate::backend::undo::Step;
 use crate::error::{from_io, FleaError};
-use std::ffi::CString;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::AtomicBool;
 
-// renameat2's dirfd argument meaning "relative to the current directory"; both paths here are absolute, so it is never consulted.
-const AT_FDCWD: i32 = -100;
-// RENAME_NOREPLACE: fail with EEXIST rather than silently destroying whatever is already at the target.
-const RENAME_NOREPLACE: u32 = 1;
 // How many " copy N" names duplicate will try before giving up rather than looping forever.
 const NAME_TRIES: usize = 999;
 // The default a nameless mkdir starts from, then "New Folder 2" and up while the name is taken.
 const NEW_FOLDER: &str = "New Folder";
-
-// std has no wrapper for the flag that makes rename refuse to clobber, so the syscall is declared here rather than taking a crate.
-extern "C" {
-    fn renameat2(olddirfd: i32, oldpath: *const i8, newdirfd: i32, newpath: *const i8, flags: u32) -> i32;
-}
 
 // A name from the client is a trust boundary: anything with a separator would move the file out of its own directory.
 pub fn valid_name(name: &str) -> bool {
     !name.is_empty() && name != "." && name != ".." && !name.contains('/') && !name.contains('\0')
 }
 
-// Rename that refuses to overwrite. std::fs::rename silently replaces the target on Unix, which for a file manager is unrecoverable data loss.
+// Rename that refuses to overwrite. std::fs::rename alone can replace a target on Unix.
 pub fn rename_noreplace(from: &Path, to: &Path) -> Result<(), FleaError> {
-    let (c_from, c_to) = match (path_c(from), path_c(to)) {
-        (Some(a), Some(b)) => (a, b),
-        // corner: a path with an interior NUL cannot reach a syscall, and no listing can produce one.
-        _ => return Err(named("rename", to, "path contains an interior NUL")),
-    };
-    let rc = unsafe { renameat2(AT_FDCWD, c_from.as_ptr(), AT_FDCWD, c_to.as_ptr(), RENAME_NOREPLACE) };
-    if rc == 0 {
-        return Ok(());
-    }
-    Err(from_io("rename", &to.to_string_lossy(), &std::io::Error::last_os_error()))
-}
-
-fn path_c(p: &Path) -> Option<CString> {
-    CString::new(p.as_os_str().as_encoded_bytes()).ok()
+    renamecompat::rename_noreplace(from, to).map_err(|e| from_io("rename", &to.to_string_lossy(), &e))
 }
 
 fn named(where_: &str, path: &Path, msg: &str) -> FleaError {

--- a/src/backend/renamecompat.rs
+++ b/src/backend/renamecompat.rs
@@ -1,0 +1,189 @@
+// Linux's atomic no-clobber rename, plus the one compatibility exception this product has measured.
+use std::ffi::{CString, OsString};
+use std::io;
+use std::os::unix::ffi::OsStringExt;
+use std::path::{Path, PathBuf};
+
+// Both paths passed here are absolute, so renameat2 never consults AT_FDCWD.
+const AT_FDCWD: i32 = -100;
+const RENAME_NOREPLACE: u32 = 1;
+const EINVAL: i32 = 22;
+const EEXIST: i32 = 17;
+
+extern "C" {
+    fn renameat2(
+        olddirfd: i32,
+        oldpath: *const i8,
+        newdirfd: i32,
+        newpath: *const i8,
+        flags: u32,
+    ) -> i32;
+}
+
+// rclone's FUSE server rejects RENAME_NOREPLACE with EINVAL, but its ordinary directory rename
+// calls operations.DirMove, whose contract refuses an existing destination. Files are excluded:
+// rclone's file move deliberately accepts a destination object to overwrite.
+pub fn rename_noreplace(from: &Path, to: &Path) -> io::Result<()> {
+    let c_from = path_c(from)?;
+    let c_to = path_c(to)?;
+    let rc = unsafe {
+        renameat2(
+            AT_FDCWD,
+            c_from.as_ptr(),
+            AT_FDCWD,
+            c_to.as_ptr(),
+            RENAME_NOREPLACE,
+        )
+    };
+    if rc == 0 {
+        return Ok(());
+    }
+    let error = io::Error::last_os_error();
+    if error.raw_os_error() == Some(EINVAL) {
+        if let Ok(body) = std::fs::read_to_string("/proc/self/mountinfo") {
+            if let Some(result) = rclone_directory_fallback(from, to, &body) {
+                return result;
+            }
+        }
+    }
+    Err(error)
+}
+
+fn rclone_directory_fallback(from: &Path, to: &Path, mountinfo: &str) -> Option<io::Result<()>> {
+    match from.symlink_metadata() {
+        Ok(meta) if meta.file_type().is_dir() => {}
+        Ok(_) => return None,
+        Err(e) => return Some(Err(e)),
+    }
+    if mount_type_in(from, mountinfo).as_deref() != Some("fuse.rclone") {
+        return None;
+    }
+    // Preserve Flea's stable collision result before entering the compatibility operation. If a
+    // destination arrives after this check, rclone's DirMove performs the authoritative refusal.
+    match to.symlink_metadata() {
+        Ok(_) => return Some(Err(io::Error::from_raw_os_error(EEXIST))),
+        Err(e) if e.kind() == io::ErrorKind::NotFound => {}
+        Err(e) => return Some(Err(e)),
+    }
+    Some(std::fs::rename(from, to))
+}
+
+fn path_c(path: &Path) -> io::Result<CString> {
+    CString::new(path.as_os_str().as_encoded_bytes())
+        .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "path contains an interior NUL"))
+}
+
+// The longest enclosing mount wins. mountinfo escapes whitespace and backslashes as octal bytes.
+fn mount_type_in(path: &Path, body: &str) -> Option<String> {
+    let mut best: Option<(usize, String)> = None;
+    for line in body.lines() {
+        let fields: Vec<&str> = line.split_whitespace().collect();
+        let split = match fields.iter().position(|field| *field == "-") {
+            Some(value) => value,
+            None => continue,
+        };
+        if fields.len() <= split + 1 || fields.len() < 5 {
+            continue;
+        }
+        let mount = PathBuf::from(OsString::from_vec(unescape(fields[4])));
+        if !path.starts_with(&mount) {
+            continue;
+        }
+        let depth = mount.components().count();
+        if best.as_ref().map(|(old, _)| depth >= *old).unwrap_or(true) {
+            best = Some((depth, fields[split + 1].to_string()));
+        }
+    }
+    best.map(|(_, kind)| kind)
+}
+
+fn unescape(field: &str) -> Vec<u8> {
+    let bytes = field.as_bytes();
+    let mut out = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'\\'
+            && i + 3 < bytes.len()
+            && bytes[i + 1..=i + 3]
+                .iter()
+                .all(|b| (b'0'..=b'7').contains(b))
+        {
+            out.push((bytes[i + 1] - b'0') * 64 + (bytes[i + 2] - b'0') * 8 + bytes[i + 3] - b'0');
+            i += 4;
+        } else {
+            out.push(bytes[i]);
+            i += 1;
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::backend::testdir::TestDir;
+
+    #[test]
+    fn deepest_mount_identifies_rclone_and_decodes_its_path() {
+        let info = "1 0 8:1 / / rw - ext4 /dev/a rw\n\
+                    2 1 0:9 / /home/pi/My\\040Drive rw - fuse.rclone remote: rw\n\
+                    3 2 0:10 / /home/pi/My\\040Drive/nested rw - tmpfs tmpfs rw\n";
+        assert_eq!(
+            mount_type_in(Path::new("/home/pi/My Drive/file"), info).as_deref(),
+            Some("fuse.rclone")
+        );
+        assert_eq!(
+            mount_type_in(Path::new("/home/pi/My Drive/nested/file"), info).as_deref(),
+            Some("tmpfs")
+        );
+        assert_eq!(
+            mount_type_in(Path::new("/elsewhere"), info).as_deref(),
+            Some("ext4")
+        );
+    }
+
+    #[test]
+    fn malformed_mountinfo_is_ignored() {
+        assert_eq!(mount_type_in(Path::new("/home/pi"), "junk\n"), None);
+    }
+
+    #[test]
+    fn rclone_directory_fallback_renames_without_replacing() {
+        let d = TestDir::new("rclonerename");
+        let source = d.dir("source");
+        let target = d.join("renamed");
+        let info = format!(
+            "1 0 0:1 / {} rw - fuse.rclone remote: rw\n",
+            d.path().display()
+        );
+        rclone_directory_fallback(&source, &target, &info)
+            .expect("the rclone directory path is eligible")
+            .expect("ordinary rclone directory rename");
+        assert!(!source.exists());
+        assert!(target.is_dir());
+
+        let source = d.dir("another");
+        let occupied = d.dir("occupied");
+        let error = rclone_directory_fallback(&source, &occupied, &info)
+            .expect("rclone directory")
+            .expect_err("an existing target must never be replaced");
+        assert_eq!(error.raw_os_error(), Some(EEXIST));
+        assert!(source.is_dir());
+        assert!(occupied.is_dir());
+    }
+
+    #[test]
+    fn fallback_is_never_used_for_files_or_other_filesystems() {
+        let d = TestDir::new("rclonerenamescope");
+        let file = d.file("file", "body");
+        let target = d.join("target");
+        let rclone = format!(
+            "1 0 0:1 / {} rw - fuse.rclone remote: rw\n",
+            d.path().display()
+        );
+        let ext4 = format!("1 0 8:1 / {} rw - ext4 /dev/a rw\n", d.path().display());
+        assert!(rclone_directory_fallback(&file, &target, &rclone).is_none());
+        assert!(rclone_directory_fallback(d.path(), &target, &ext4).is_none());
+        assert_eq!(std::fs::read_to_string(file).unwrap(), "body");
+    }
+}


### PR DESCRIPTION
## What was wrong

Creating a folder on an rclone FUSE mount succeeded, but Flea immediately opened its name editor and the submit failed with `EINVAL`. That made **New Folder** look broken and prevented **Rename** from working in mounts such as `~/google`.

Flea correctly uses Linux `renameat2(..., RENAME_NOREPLACE)` to guarantee it never overwrites an existing target. rclone 1.75 rejects that flag for directory renames even though its ordinary directory-move path works and refuses an occupied destination.

## Fix

- keep the atomic `RENAME_NOREPLACE` path as the default
- on `EINVAL`, allow the compatibility path only for a real directory on a mount identified exactly as `fuse.rclone`
- decode mountinfo paths and use the deepest enclosing mount, so a nested non-rclone mount never inherits the exception
- preserve Flea's stable `EEXIST` collision result before the fallback; rclone's own directory move is authoritative if a destination races into existence
- never use the fallback for files, symlinks, or other filesystems

## Verification

- [x] Reproduced the original backend failure on the real `~/google` rclone mount
- [x] Verified rename succeeds there after the fix
- [x] Verified an occupied target is not overwritten and both directories remain
- [x] `cargo build` and `cargo build --release`
- [x] `cargo test` and `cargo test --release` — 342 passed in each profile
- [x] `./tests/run-all.sh` twice — 10 suites, 0 failed; 1,153 JS checks each run
- [x] `./tools/flea-qmllint-gate` — 0 regressions
- [x] `./tools/flea-file-budget`
- [x] `git diff --check`

No issue filed.
