### PR TITLE
fix: build and run on aarch64, and two defects found doing it

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -4,7 +4,7 @@ pkgname=flea
 pkgver=0.1.3
 pkgrel=1
 pkgdesc='Fast, keyboard-first file manager for Omarchy'
-arch=('x86_64')
+arch=('x86_64' 'aarch64')
 license=('MIT')
 # omarchy owns /usr/share/omarchy/shell, which ui/Commons and ui/Ui link into; quickshell owns qs.
 # util-linux ships prlimit, which the thumbnail and archive sandboxes require alongside bubblewrap.

--- a/src/backend/copyfile.rs
+++ b/src/backend/copyfile.rs
@@ -9,8 +9,17 @@ use std::sync::atomic::{AtomicBool, Ordering};
 const CHUNK: usize = 256 * 1024;
 // rename(2) sets EXDEV when the two paths are on different filesystems, which is the one failure that means "copy instead".
 const EXDEV: i32 = 18;
-// open(2) O_NOFOLLOW on linux x86-64; declared here because this tree takes no libc crate.
+// open(2) O_NOFOLLOW; declared here because this tree takes no libc crate. The value is not the same
+// on every linux architecture: arm64 carries its own asm/fcntl.h, where 0o400000 is O_LARGEFILE and
+// therefore a no-op on 64-bit, so a single hardcoded constant drops the guard below without failing.
+#[cfg(target_arch = "x86_64")]
 const O_NOFOLLOW: i32 = 0o400000;
+#[cfg(target_arch = "aarch64")]
+const O_NOFOLLOW: i32 = 0o100000;
+// A new architecture must add its own value rather than inherit one silently: this flag is a
+// security boundary, and the wrong number disables it quietly instead of erroring.
+#[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
+compile_error!("O_NOFOLLOW is architecture specific: add this target's value from its asm/fcntl.h");
 
 // What a copy reports as it runs; a directory has no total without a sweep, so it reports 0 and renders indeterminate.
 pub struct Progress<'a> {

--- a/src/backend/fsinfo.rs
+++ b/src/backend/fsinfo.rs
@@ -10,7 +10,7 @@ pub fn dev_of(path: &Path) -> u64 {
     use std::os::unix::fs::MetadataExt;
     std::fs::metadata(path).map(|m| m.dev()).unwrap_or(0)
 }
-use std::ffi::CString;
+use std::ffi::{c_char, CString};
 use std::path::Path;
 
 // The f_type values for the filesystems this box can actually mount; anything else reports its hex.
@@ -33,7 +33,7 @@ const MAGIC: &[(i64, &str)] = &[
     (0x1CD1, "devpts"),
 ];
 
-// struct statfs on linux x86-64: the fields this needs are f_type, f_bsize and f_bavail, and the
+// struct statfs on 64-bit linux, identical on x86-64 and arm64 (120 bytes, same offsets): the fields this needs are f_type, f_bsize and f_bavail, and the
 // rest is padding this never reads. Sizes are from man 2 statfs.
 #[repr(C)]
 struct StatFs {
@@ -52,7 +52,7 @@ struct StatFs {
 }
 
 extern "C" {
-    fn statfs(path: *const i8, buf: *mut StatFs) -> i32;
+    fn statfs(path: *const c_char, buf: *mut StatFs) -> i32;
 }
 
 pub struct Info {

--- a/src/backend/ops.rs
+++ b/src/backend/ops.rs
@@ -2,7 +2,7 @@
 use crate::backend::copyfile::{copy_any, Progress};
 use crate::backend::undo::Step;
 use crate::error::{from_io, FleaError};
-use std::ffi::CString;
+use std::ffi::{c_char, CString};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::AtomicBool;
 
@@ -17,7 +17,7 @@ const NEW_FOLDER: &str = "New Folder";
 
 // std has no wrapper for the flag that makes rename refuse to clobber, so the syscall is declared here rather than taking a crate.
 extern "C" {
-    fn renameat2(olddirfd: i32, oldpath: *const i8, newdirfd: i32, newpath: *const i8, flags: u32) -> i32;
+    fn renameat2(olddirfd: i32, oldpath: *const c_char, newdirfd: i32, newpath: *const c_char, flags: u32) -> i32;
 }
 
 // A name from the client is a trust boundary: anything with a separator would move the file out of its own directory.

--- a/src/heap.rs
+++ b/src/heap.rs
@@ -23,8 +23,16 @@ mod tests {
     const CHILD_TEST: &str = "heap::tests::a_freed_large_block_does_not_ratchet_the_mmap_threshold";
     // Larger than any threshold glibc adopts on its own, so freeing it is what would raise the threshold unpinned.
     const RATCHET_BYTES: usize = 8 * 1024 * 1024;
-    // Above the pinned 131072 and below the ratchet, so only a live pin keeps it off the heap.
-    const PROBE_BYTES: usize = 1024 * 1024;
+    // Above the pinned 131072 and below the ratchet, so only a live pin keeps it off the heap. It is
+    // also sized past the whole main arena at run time, because a request the arena can already serve
+    // from a free chunk never reaches the code that consults the threshold, and so cannot redden. A
+    // fixed 1 MiB is past the arena on a 4 KiB page box and is not on a 16 KiB one, where libtest
+    // routinely leaves ~2 MiB of [heap] behind and this read as a ratchet that had not happened.
+    const PROBE_FLOOR: usize = 1024 * 1024;
+    // Headroom over the arena, so the request cannot be met by any chunk inside it.
+    const PROBE_MARGIN: usize = 1024 * 1024;
+    // Still clearly under RATCHET_BYTES, so an unpinned threshold does route this to the heap and the check can fail.
+    const PROBE_CEILING: usize = 6 * 1024 * 1024;
     // Below the pinned threshold, so it must come from the arena that [heap] describes.
     const ARENA_BYTES: usize = 65536;
 
@@ -46,7 +54,13 @@ mod tests {
         }
     }
 
-    // The guard itself: ratchet the threshold the way a first large listing does, then read where 1 MiB landed.
+    // Bigger than the arena as it stands, so only the threshold decides where the probe lands.
+    fn probe_bytes() -> usize {
+        let arena = heap_span().map_or(0, |(lo, hi)| hi - lo);
+        arena.saturating_add(PROBE_MARGIN).clamp(PROBE_FLOOR, PROBE_CEILING)
+    }
+
+    // The guard itself: ratchet the threshold the way a first large listing does, then read where the probe landed.
     fn probe() {
         pin_mmap_threshold();
         let arena = vec![0u8; ARENA_BYTES];
@@ -58,12 +72,21 @@ mod tests {
             heap_span()
         );
         // glibc raises its mmap threshold to the size of any mmapped block it frees, unless a mallopt froze it.
-        drop(vec![0u8; RATCHET_BYTES]);
-        let probed = vec![0u8; PROBE_BYTES];
+        // black_box because this allocation is otherwise dead: the release profile check() builds with
+        // elides the pair outright, no block is ever freed, the threshold never moves, and the assert
+        // below then passes whether or not the pin is live. The hint is what keeps this test honest.
+        {
+            let mut ratchet = vec![0u8; RATCHET_BYTES];
+            std::hint::black_box(ratchet.as_mut_ptr());
+            drop(std::hint::black_box(ratchet));
+        }
+        let probe_bytes = probe_bytes();
+        let probed = vec![0u8; probe_bytes];
         assert!(
             !in_heap(probed.as_ptr() as usize),
-            "a {} byte allocation came from [heap], so the mmap threshold ratcheted past it",
-            PROBE_BYTES
+            "a {} byte allocation came from [heap] {:x?}, so the mmap threshold ratcheted past it",
+            probe_bytes,
+            heap_span()
         );
         drop(arena);
         drop(probed);


### PR DESCRIPTION
Closes #13, and carries two defects that issue does not cover — one of them a security boundary that is open in v0.1.3 today, and one that is not architecture specific at all.

Tested on an M2 Air (`Mac14,15`) running Omarchy 4.0.2 on Asahi, aarch64, 16 KiB pages, glibc 2.43, rustc 1.98.0, quickshell 0.3.1.

## The three fixes

**1. `c_char`, not `i8` — the build stops here (#13).**

`c_char` is `i8` on x86-64 and `u8` on aarch64, and `CString::as_ptr()` returns `*const c_char`, so the hardcoded `*const i8` in the `statfs` and `renameat2` declarations only type-check on one architecture. Same fix @stgomoyaa proposed.

The hand-declared `StatFs` needs no change, and I checked that rather than assuming it: `struct statfs` is byte-identical on both, 120 bytes with `f_type` at 0, `f_bsize` at 8, `f_bavail` at 32, read out of the header on this box with `offsetof`. Only its comment moves.

**2. `O_NOFOLLOW` was the x86-64 value, so the guard did nothing on arm64.**

This one is not in #13, and it is not cosmetic. `copyfile.rs` declared `O_NOFOLLOW` as `0o400000`. arm64 carries its own `asm/fcntl.h`, where `O_NOFOLLOW` is `0o100000` and `0o400000` is `O_LARGEFILE` — a no-op on 64-bit. So `open` accepted the flag and ignored it, and the same-uid race the function documents was open: a source swapped to a symlink after `copy_any`'s stat was followed, and the target's bytes were copied.

The suite already catches it. `a_source_swapped_to_a_symlink_after_the_stat_is_refused_rather_than_followed` fails on aarch64 before this commit and passes after it. #13 did not hit it because `O_NOFOLLOW` landed in b4b7ee4, after the v0.1.2 that issue was filed against — so this shipped in v0.1.3.

Because a wrong number here disables a security boundary in silence rather than erroring, an architecture with no value listed is now a `compile_error!` instead of quietly inheriting one.

**3. The heap guard has never tested anything in a release build — on any architecture.**

`drop(vec![0u8; RATCHET_BYTES])` is dead, so a release build elides the allocation and the free with it. Nothing is mmapped, nothing is freed, the threshold never ratchets, and the assert passes whether or not the pin is live. `check()` builds `--release`.

Measured rather than reasoned about, by making `pin_mmap_threshold()` conditional on an env var:

| | pin live | pin removed |
|---|---|---|
| before this PR | passes 3/3 | **passes 3/3** |
| after this PR | passes 3/3 | **fails 3/3** |

`black_box` is what holds the allocation down. This is the fix I am least sure you will want as written — if you would rather assert on `mallinfo2().hblkhd` than on `/proc/self/maps`, say so and I will redo it.

Separately, the fixed 1 MiB probe is smaller than the arena libtest leaves behind on a 16 KiB page kernel — about 1.9 MiB here — so glibc served it from a free chunk without consulting the threshold at all, and the test failed spuriously in 2 of 3 full-suite runs. The probe is now sized past the live arena, so only the threshold can decide where it lands. In C on this box, with the ratchet forced, a 1 MiB probe lands in `[heap]` even pinned, while a 3 MiB probe lands outside pinned and inside unpinned — which is the discrimination the test wants.

## Tests

On this box, at this branch:

- `cargo test --release --locked` — **338 passed, 0 failed** (6 consecutive full-suite runs, no flakes)
- `./tests/js.sh` — **1153 checks, 0 failed**
- `./tests/keymap-gen.sh` — ok, both checks
- `./tests/protocol.sh` against the installed `/usr/bin/flea` — **110 of 110**
- `makepkg -f` end to end, then `pacman -U`, then `flea --default`: `hyprctl configerrors` clean, both binds resolve to Flea and nothing is left bound to Nautilus

The GUI runs, which #13 explicitly did not claim: `flea --gui` opens the Quickshell window in ~0.25 s on Asahi, and the Vulkan path in rule 5 gives no trouble. Thumbnails work — a 512×512 JPEG through `glycin-thumbnailer` inside the bwrap sandbox in 7 ms.

## Two notes that are not defects

`tests/protocol.sh:268` copies `$FIXTURE_ROOT/flea-media-btrfs/photo_0.jpg` with no fallback, unlike line 255 which has one. Without your media fixture, `photo.jpg` stays the 1-byte `x` from that earlier fallback, no thumbnailer can read it, and three thumbnail assertions fail for a reason that has nothing to do with the code. Dropping any real JPEG at that path turns all three green. I have left it alone since it is your fixture layout, but a fallback on 268 would make the suite self-contained.

The AUR packages are `x86_64` only, so on ARM the repository's own PKGBUILD is the only route. Worth a line in `docs/install.md` if you take this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UN8dj8X3y5nQmBg1cgebXH


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added package support for 64-bit ARM systems.

* **Bug Fixes**
  * Improved filesystem compatibility across supported Linux architectures.
  * Preserved symlink protection on ARM systems and reported unsupported architectures explicitly.
  * Improved heap probing reliability by adapting checks to the live heap size and preventing optimization from skipping test allocations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->