### PR TITLE
fix: aarch64 support for statfs and renameat2 FFI calls

### DIFF
--- a/src/backend/fsinfo.rs
+++ b/src/backend/fsinfo.rs
@@ -65,7 +65,7 @@ pub fn read(path: &Path) -> Option<Info> {
     let c = CString::new(path.as_os_str().as_encoded_bytes()).ok()?;
     // Every field is written by the call, so the zeroed value is never read as a result.
     let mut buf: StatFs = unsafe { std::mem::zeroed() };
-    if unsafe { statfs(c.as_ptr(), &mut buf) } != 0 {
+    if unsafe { statfs(c.as_ptr() as *const i8, &mut buf) } != 0 {
         return None;
     }
     Some(Info { name: name_for(buf.f_type), free: buf.f_bavail.saturating_mul(buf.f_bsize.max(0) as u64) })

--- a/src/backend/ops.rs
+++ b/src/backend/ops.rs
@@ -32,7 +32,7 @@ pub fn rename_noreplace(from: &Path, to: &Path) -> Result<(), FleaError> {
         // corner: a path with an interior NUL cannot reach a syscall, and no listing can produce one.
         _ => return Err(named("rename", to, "path contains an interior NUL")),
     };
-    let rc = unsafe { renameat2(AT_FDCWD, c_from.as_ptr(), AT_FDCWD, c_to.as_ptr(), RENAME_NOREPLACE) };
+    let rc = unsafe { renameat2(AT_FDCWD, c_from.as_ptr() as *const i8, AT_FDCWD, c_to.as_ptr() as *const i8, RENAME_NOREPLACE) };
     if rc == 0 {
         return Ok(());
     }


### PR DESCRIPTION
Fix compilation on aarch64 by casting CString::as_ptr() to *const i8 for statfs and renameat2 FFI calls. CString::as_ptr() returns *const u8 on aarch64, but the C function signatures expect *const i8.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated low-level system call argument handling for improved compatibility with platform interfaces.
  * No user-visible behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->