### PR TITLE
Support aarch64 Linux builds

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -4,7 +4,7 @@ pkgname=flea
 pkgver=0.1.3
 pkgrel=1
 pkgdesc='Fast, keyboard-first file manager for Omarchy'
-arch=('x86_64')
+arch=('x86_64' 'aarch64')
 license=('MIT')
 # omarchy owns /usr/share/omarchy/shell, which ui/Commons and ui/Ui link into; quickshell owns qs.
 # util-linux ships prlimit, which the thumbnail and archive sandboxes require alongside bubblewrap.

--- a/src/backend/copyfile.rs
+++ b/src/backend/copyfile.rs
@@ -9,8 +9,13 @@ use std::sync::atomic::{AtomicBool, Ordering};
 const CHUNK: usize = 256 * 1024;
 // rename(2) sets EXDEV when the two paths are on different filesystems, which is the one failure that means "copy instead".
 const EXDEV: i32 = 18;
-// open(2) O_NOFOLLOW on linux x86-64; declared here because this tree takes no libc crate.
+// open(2) O_NOFOLLOW differs between the two supported Linux architectures.
+#[cfg(target_arch = "x86_64")]
 const O_NOFOLLOW: i32 = 0o400000;
+#[cfg(target_arch = "aarch64")]
+const O_NOFOLLOW: i32 = 0o100000;
+#[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
+compile_error!("O_NOFOLLOW needs a verified value for this architecture");
 
 // What a copy reports as it runs; a directory has no total without a sweep, so it reports 0 and renders indeterminate.
 pub struct Progress<'a> {

--- a/src/backend/fsinfo.rs
+++ b/src/backend/fsinfo.rs
@@ -10,7 +10,7 @@ pub fn dev_of(path: &Path) -> u64 {
     use std::os::unix::fs::MetadataExt;
     std::fs::metadata(path).map(|m| m.dev()).unwrap_or(0)
 }
-use std::ffi::CString;
+use std::ffi::{c_char, CString};
 use std::path::Path;
 
 // The f_type values for the filesystems this box can actually mount; anything else reports its hex.
@@ -52,7 +52,7 @@ struct StatFs {
 }
 
 extern "C" {
-    fn statfs(path: *const i8, buf: *mut StatFs) -> i32;
+    fn statfs(path: *const c_char, buf: *mut StatFs) -> i32;
 }
 
 pub struct Info {

--- a/src/backend/ops.rs
+++ b/src/backend/ops.rs
@@ -2,7 +2,7 @@
 use crate::backend::copyfile::{copy_any, Progress};
 use crate::backend::undo::Step;
 use crate::error::{from_io, FleaError};
-use std::ffi::CString;
+use std::ffi::{c_char, CString};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::AtomicBool;
 
@@ -17,7 +17,7 @@ const NEW_FOLDER: &str = "New Folder";
 
 // std has no wrapper for the flag that makes rename refuse to clobber, so the syscall is declared here rather than taking a crate.
 extern "C" {
-    fn renameat2(olddirfd: i32, oldpath: *const i8, newdirfd: i32, newpath: *const i8, flags: u32) -> i32;
+    fn renameat2(olddirfd: i32, oldpath: *const c_char, newdirfd: i32, newpath: *const c_char, flags: u32) -> i32;
 }
 
 // A name from the client is a trust boundary: anything with a separator would move the file out of its own directory.

--- a/src/heap.rs
+++ b/src/heap.rs
@@ -23,8 +23,10 @@ mod tests {
     const CHILD_TEST: &str = "heap::tests::a_freed_large_block_does_not_ratchet_the_mmap_threshold";
     // Larger than any threshold glibc adopts on its own, so freeing it is what would raise the threshold unpinned.
     const RATCHET_BYTES: usize = 8 * 1024 * 1024;
-    // Above the pinned 131072 and below the ratchet, so only a live pin keeps it off the heap.
-    const PROBE_BYTES: usize = 1024 * 1024;
+    // Above the pinned threshold even before the live heap size is added.
+    const PROBE_FLOOR_BYTES: usize = 1024 * 1024;
+    // Past every free chunk in the current heap, so only the threshold decides where the probe lands.
+    const PROBE_MARGIN_BYTES: usize = 1024 * 1024;
     // Below the pinned threshold, so it must come from the arena that [heap] describes.
     const ARENA_BYTES: usize = 65536;
 
@@ -46,7 +48,30 @@ mod tests {
         }
     }
 
-    // The guard itself: ratchet the threshold the way a first large listing does, then read where 1 MiB landed.
+    fn probe_bytes(heap_bytes: usize) -> usize {
+        let probe_bytes = heap_bytes
+            .checked_add(PROBE_MARGIN_BYTES)
+            .expect("the heap size must leave room for a probe")
+            .max(PROBE_FLOOR_BYTES);
+        assert!(
+            probe_bytes < RATCHET_BYTES,
+            "the {} byte heap leaves no probe size below the {} byte ratchet",
+            heap_bytes,
+            RATCHET_BYTES
+        );
+        probe_bytes
+    }
+
+    #[test]
+    fn probe_size_stays_between_the_live_heap_and_ratchet() {
+        for heap_bytes in (ARENA_BYTES..RATCHET_BYTES - PROBE_MARGIN_BYTES).step_by(PROBE_MARGIN_BYTES) {
+            let probe_bytes = probe_bytes(heap_bytes);
+            assert!(probe_bytes > heap_bytes);
+            assert!(probe_bytes < RATCHET_BYTES);
+        }
+    }
+
+    // The guard itself: ratchet the threshold the way a first large listing does, then read where the probe landed.
     fn probe() {
         pin_mmap_threshold();
         let arena = vec![0u8; ARENA_BYTES];
@@ -58,12 +83,14 @@ mod tests {
             heap_span()
         );
         // glibc raises its mmap threshold to the size of any mmapped block it frees, unless a mallopt froze it.
-        drop(vec![0u8; RATCHET_BYTES]);
-        let probed = vec![0u8; PROBE_BYTES];
+        drop(std::hint::black_box(vec![0u8; RATCHET_BYTES]));
+        let (lo, hi) = heap_span().expect("the probe needs a main heap");
+        let probe_bytes = probe_bytes(hi - lo);
+        let probed = vec![0u8; probe_bytes];
         assert!(
             !in_heap(probed.as_ptr() as usize),
             "a {} byte allocation came from [heap], so the mmap threshold ratcheted past it",
-            PROBE_BYTES
+            probe_bytes
         );
         drop(arena);
         drop(probed);


### PR DESCRIPTION
Fixes #13: adds verified aarch64 FFI, package metadata, symlink protection, and heap-probe coverage; thanks @stgomoyaa and @the2dl.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for building the `flea` package on 64-bit ARM (`aarch64`) systems in addition to `x86_64`.

- **Bug Fixes**
  - Improved filesystem operation compatibility across supported Linux architectures.
  - Updated low-level filesystem interfaces for more consistent platform behavior.
  - Improved heap probe sizing to adapt to the live heap and provide clearer failure diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->