### PR TITLE
fix(nav): parent reselects the directory you left

### DIFF
--- a/tests/js/nav.js
+++ b/tests/js/nav.js
@@ -17,6 +17,7 @@ function pane() {
         thumbState: "stale",
         dirSizeState: "stale",
         cursorIndex: 7,
+        pendingSelect: "",
         renamingIndex: 4,
         trashArmedAt: 12345,
         listingState: "ready",
@@ -86,4 +87,40 @@ function run(check) {
           Nav.renameRefreshTarget(clicked, "/d/new.txt"), "")
     check("and the flag is one shot, so the next rename reveals again",
           Nav.renameRefreshTarget(clicked, "/d/new.txt"), "/d/new.txt")
+
+    // h climbs the tree and keeps the place: the parent listing selects the directory we left.
+    var up = pane()
+    up.path = "/home/gm/Work"
+    up.opened = []
+    up.open = function (path) { up.opened.push(path) }
+    Nav.parent(up)
+    check("h opens the parent directory", up.opened.join(""), "/home/gm")
+    check("and names the directory it left, so the cursor lands on it",
+          up.pendingSelect, "/home/gm/Work")
+
+    var rootDir = pane()
+    rootDir.path = "/"
+    rootDir.opened = []
+    rootDir.open = function (path) { rootDir.opened.push(path) }
+    Nav.parent(rootDir)
+    check("the root does not climb", rootDir.opened.length, 0)
+    check("and does not plant a select on a climb that did not happen",
+          rootDir.pendingSelect, "")
+
+    var home = pane()
+    home.path = "/home"
+    home.opened = []
+    home.open = function (path) { home.opened.push(path) }
+    Nav.parent(home)
+    check("a child of the root climbs to the root", home.opened.join(""), "/")
+    check("and still names the directory it left", home.pendingSelect, "/home")
+
+    var busyUp = pane()
+    busyUp.listInFlight = true
+    busyUp.path = "/home/gm/Work"
+    busyUp.opened = []
+    busyUp.open = function (path) { busyUp.opened.push(path) }
+    Nav.parent(busyUp)
+    check("a refused climb sends nothing", busyUp.opened.length, 0)
+    check("and plants no select", busyUp.pendingSelect, "")
 }

--- a/ui/js/Nav.js
+++ b/ui/js/Nav.js
@@ -130,7 +130,9 @@ function leafOf(path) {
     return cut < 0 || cut === text.length - 1 ? text : text.substring(cut + 1)
 }
 
-// Backspace and the chrome's up arrow: the root has no parent, so it is where climbing stops.
+// Backspace, h, and the chrome's up arrow. The root has no parent, so it is where climbing stops.
+// pendingSelect is the directory we are leaving, so the parent listing puts the cursor on it
+// rather than on the first row: h then l is a round trip.
 function parent(pane) {
     if (pane.listInFlight) {
         pane.message("A directory is already loading.", false)
@@ -139,6 +141,8 @@ function parent(pane) {
     if (pane.path === "/") {
         return
     }
-    var cut = pane.path.lastIndexOf("/")
-    pane.open(cut <= 0 ? "/" : pane.path.substring(0, cut))
+    var here = pane.path
+    var cut = here.lastIndexOf("/")
+    pane.pendingSelect = here
+    pane.open(cut <= 0 ? "/" : here.substring(0, cut))
 }


### PR DESCRIPTION
## Summary

`h` and Backspace still go to the parent. The parent listing now selects the folder you left, so `h` then `l` is a round trip.

`l` as browse-forward is already on main from #25. This PR no longer touches that bind.

`pendingSelect` already re-reveals a row after a refresh. `Nav.parent` now plants it before the climb. Root and an in-flight listing still refuse, and they plant no select.

`./tests/js.sh` after the change: 1178 checks, 0 failed.
