### PR TITLE
feat: mouse back goes through history, then parent

### DIFF
--- a/tests/js/nav.js
+++ b/tests/js/nav.js
@@ -86,4 +86,35 @@ function run(check) {
           Nav.renameRefreshTarget(clicked, "/d/new.txt"), "")
     check("and the flag is one shot, so the next rename reveals again",
           Nav.renameRefreshTarget(clicked, "/d/new.txt"), "/d/new.txt")
+
+    // Mouse back is history when there is some, and parent when there is not. The pane's own open
+    // and openWithoutHistory are the same wrappers the window uses, so the two arrows stay one route.
+    function wired() {
+        var p = pane()
+        p.history = []
+        p.path = "/home/gm/Work"
+        p.openWithoutHistory = function (path) { Nav.openWithoutHistory(p, path) }
+        p.open = function (path) { Nav.open(p, path) }
+        return p
+    }
+
+    var remembered = wired()
+    remembered.history = ["/home/gm"]
+    Nav.mouseBack(remembered)
+    check("mouse back with history goes to the remembered directory", remembered.path, "/home/gm")
+    check("and pops that entry, so a second press is not the same place again",
+          remembered.history.join(","), "")
+
+    var climb = wired()
+    Nav.mouseBack(climb)
+    check("mouse back with no history climbs to the parent, the up arrow's own verb",
+          climb.path, "/home/gm")
+    check("and remembers the folder it left, because climbing is a navigation",
+          climb.history.join(","), "/home/gm/Work")
+
+    var rootDir = wired()
+    rootDir.path = "/"
+    Nav.mouseBack(rootDir)
+    check("mouse back at the root with no history stays put", rootDir.path, "/")
+    check("and sends no listing", rootDir.sent.length, 0)
 }

--- a/tests/js/nav.js
+++ b/tests/js/nav.js
@@ -117,4 +117,14 @@ function run(check) {
     Nav.mouseBack(rootDir)
     check("mouse back at the root with no history stays put", rootDir.path, "/")
     check("and sends no listing", rootDir.sent.length, 0)
+
+    var loading = wired()
+    loading.history = ["/home/gm"]
+    loading.listInFlight = true
+    Nav.mouseBack(loading)
+    check("mouse back during a load keeps the history it would have popped",
+          loading.history.join(","), "/home/gm")
+    check("and stays in the directory that is still loading", loading.path, "/home/gm/Work")
+    check("and says so", loading.said.join(""), "A directory is already loading.")
+    check("and sends no listing", loading.sent.length, 0)
 }

--- a/ui/Pane.qml
+++ b/ui/Pane.qml
@@ -137,6 +137,7 @@ FocusScope {
     property real fsFree: 0
 
     function goBack() { Nav.back(root) }
+    function mouseBack() { Nav.mouseBack(root) }
 
     // Rename lives in ui/js/Ops.js with the other write operations; ui/List.qml's editor commits through this.
     function commitRename(newName) { Ops.commitRename(root, newName) }

--- a/ui/js/Nav.js
+++ b/ui/js/Nav.js
@@ -26,6 +26,17 @@ function back(pane) {
     pane.openWithoutHistory(target)
 }
 
+// Mouse back is the chrome's left arrow when history exists, and the up arrow otherwise: Nautilus
+// and Explorer bind the button to history, and with none the same press still climbs, which is
+// issue 20. No forward stack: the canvas draws one arrow, not two.
+function mouseBack(pane) {
+    if (pane.history.length > 0) {
+        back(pane)
+        return
+    }
+    parent(pane)
+}
+
 // Everything a fresh listing has to forget. Called by open, by refresh and by the hidden toggle, so
 // the reset is written once and no caller can half-do it.
 function openWithoutHistory(pane, newPath) {

--- a/ui/js/Nav.js
+++ b/ui/js/Nav.js
@@ -20,6 +20,12 @@ function back(pane) {
     if (pane.history.length === 0) {
         return
     }
+    // The in-flight guard has to run before the pop: openWithoutHistory would refuse the
+    // listing and leave history one entry shorter, so a back during load would lose the place.
+    if (pane.listInFlight) {
+        pane.message("A directory is already loading.", false)
+        return
+    }
     var target = pane.history[pane.history.length - 1]
     // The pop happens before the open, because open() is what would otherwise push it straight back on.
     pane.history = pane.history.slice(0, pane.history.length - 1)

--- a/ui/shell.qml
+++ b/ui/shell.qml
@@ -203,6 +203,18 @@ ShellRoot {
                 onActivated: function (uri, label) { pane.sidebar.mountShare(uri, label) }
             }
 
+            // Issue 20: mouse back is history when the left arrow would fire, and parent otherwise.
+            // Dialogs keep the button, because a navigation under one would leave it describing a
+            // directory that is gone.
+            TapHandler {
+                acceptedButtons: Qt.BackButton
+                onTapped: {
+                    if (chrome.editing || convertDialog.opened || keymapSheet.opened || networkDialog.opened)
+                        return
+                    pane.mouseBack()
+                }
+            }
+
             Component.onCompleted: {
                 var start = Quickshell.env("FLEA_PATH") || Quickshell.env("HOME")
                 // Read once: Pane.applyPendingSelect() forgets it after the first rows response.


### PR DESCRIPTION
## Summary

Mouse button 8 (`Qt.BackButton`) now matches the chrome:

1. If there is history, go back (same as ←).
2. Otherwise, if we are not at `/`, go up a directory (same as ↑).

That is Nautilus/Explorer's history binding when history exists, and it still covers #20 when it does not. No forward stack: the chrome only draws one arrow.

Dialogs and the path bar keep the button so a navigation cannot happen under them.

Policy lives in `Nav.mouseBack`, driven by `tests/js/nav.js`. The window handler is a `TapHandler` on `ui/shell.qml` and is not in `keys.toml`, because extra buttons are not listing-row clicks.

Implemented with x-ai/grok-4.6.

Fixes #20

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added mouse back-button navigation for browsing history.
  - When no history is available, navigation moves to the parent directory.
  - At the root directory, the back action remains in place without triggering a listing.
  - Back-button navigation is suppressed while editing or modal dialogs are active.

- **Bug Fixes**
  - Back navigation no longer loses history entries while a directory is loading.
  - A message is shown when navigation is attempted during an in-progress directory load.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->