### PR TITLE
feat(grid): fit thumbs and marks to the tile

### DIFF
--- a/ui/Glyph.qml
+++ b/ui/Glyph.qml
@@ -17,7 +17,9 @@ Item {
     readonly property real markSize: Math.min(root.maxSize, root.width, root.height)
     // Its own name: "scale" would shadow Item.scale, which qmllint flagged.
     readonly property real gridScale: root.markSize / root.grid
-    readonly property real strokeWidth: Theme.strokeWidth
+    // Grid units, then scaled with the path. A large slot overrides this so screen-space thickness
+    // can stay at the designed weight instead of growing with the mark.
+    property real strokeWidth: Theme.strokeWidth
 
     // The Shape is sized in grid units pre-transform; Scale's origin defaults to (0,0), so this
     // offset is what re-centers the scaled-down box in root's slot instead of pinning it top-left.

--- a/ui/GridArea.qml
+++ b/ui/GridArea.qml
@@ -22,8 +22,11 @@ GridView {
     readonly property int tileWidth: Math.max(1, Math.floor(root.width / root.columns))
     // Square thumb filling the cell width, less the tile's own gap, then a gap and the caption.
     readonly property int thumbPx: Math.max(1, root.tileWidth - 2 * Theme.spacing.gap)
+    // Two caption lines: the name wraps to maximumLineCount 2, and one line left the second
+    // painting through the tile below.
+    readonly property int captionPx: Math.round(Theme.font.caption * 1.6) * 2
     readonly property int cellHeightPx: root.thumbPx + Theme.spacing.gap
-                                        + Math.round(Theme.font.caption * 1.6)
+                                        + root.captionPx
                                         + Theme.spacing.gap
     readonly property int visibleTileRows: Math.max(1, Math.ceil(root.height / root.cellHeightPx))
 
@@ -45,6 +48,7 @@ GridView {
         hovered: hover.hovered
         selected: root.pane.isSelected(index)
         thumb: Thumbs.fileFor(root.pane.thumbState, index)
+        slotSize: root.thumbPx
 
         HoverHandler {
             id: hover

--- a/ui/GridArea.qml
+++ b/ui/GridArea.qml
@@ -19,16 +19,18 @@ GridView {
     // How many tiles fit across, which is what a cursor step down has to move by.
     readonly property int columns: Math.max(1, Math.floor(root.width / Theme.grid.minCellWidth))
     readonly property int tileRows: Math.max(1, Math.ceil(root.pane.total / root.columns))
-    // Mark, one gap, one line of caption, and the padding above and below.
-    readonly property int cellHeightPx: Theme.grid.iconSize + Theme.spacing.gap
+    readonly property int tileWidth: Math.max(1, Math.floor(root.width / root.columns))
+    // Square thumb filling the cell width, less the tile's own gap, then a gap and the caption.
+    readonly property int thumbPx: Math.max(1, root.tileWidth - 2 * Theme.spacing.gap)
+    readonly property int cellHeightPx: root.thumbPx + Theme.spacing.gap
                                         + Math.round(Theme.font.caption * 1.6)
-                                        + 2 * Theme.spacing.rowPaddingX
+                                        + Theme.spacing.gap
     readonly property int visibleTileRows: Math.max(1, Math.ceil(root.height / root.cellHeightPx))
 
     focus: true
     model: pane.total
     clip: true
-    cellWidth: Math.floor(root.width / root.columns)
+    cellWidth: root.tileWidth
     cellHeight: root.cellHeightPx
     cacheBuffer: root.cellHeightPx * 2
     boundsBehavior: Flickable.StopAtBounds

--- a/ui/GridTile.qml
+++ b/ui/GridTile.qml
@@ -4,7 +4,7 @@ import "." as Flea
 import "js/Format.js" as Format
 import "js/Icons.js" as Icons
 
-// One grid cell: the same mark the list row draws, in a larger slot, with the name under it.
+// One grid cell: a square thumb or mark filling the tile, with the name under it.
 Item {
     id: root
 
@@ -37,11 +37,11 @@ Item {
 
     Item {
         id: markSlot
-        anchors.horizontalCenter: parent.horizontalCenter
+        anchors.left: parent.left
+        anchors.right: parent.right
         anchors.top: parent.top
-        anchors.topMargin: Theme.spacing.rowPaddingX
-        width: Theme.grid.iconSize
-        height: Theme.grid.iconSize
+        anchors.margins: Theme.spacing.gap
+        height: width
 
         // A thumbnail is a decoded image and stays one; the glyph beside it is a native mark, and
         // exactly one is visible, chosen the same way ui/Row.qml chooses.
@@ -52,9 +52,10 @@ Item {
             // Format.fileUri, not a concatenation: a cache path can carry a # or a ? and either one
             // silently truncates a plain file:// URL, which is what the hashcache fixture proves.
             source: root.thumb.length > 0 ? Format.fileUri(root.thumb) : ""
+            // Longest side of the photo matches the slot; the other side letterboxes.
             fillMode: Image.PreserveAspectFit
-            sourceSize.width: Theme.grid.iconSize
-            sourceSize.height: Theme.grid.iconSize
+            sourceSize.width: Math.max(1, Math.round(width))
+            sourceSize.height: Math.max(1, Math.round(height))
             asynchronous: true
             cache: false
         }
@@ -62,6 +63,11 @@ Item {
         Flea.Glyph {
             anchors.fill: parent
             visible: !root.thumbDrawn
+            // Glyph.maxSize defaults to the list-row mark, so the slot has to lift it or the path
+            // cannot grow. Stroke is inverted against that scale so a large folder keeps the
+            // original grid-icon weight instead of thickening with the path.
+            maxSize: Math.min(width, height)
+            strokeWidth: Theme.strokeWidth * Theme.grid.iconSize / Math.max(1, Math.min(width, height))
             name: root.row ? Icons.glyphFor(root.row.i) : "file"
             color: root.cursor || root.selected ? Theme.color.accent : Theme.color.muted
         }

--- a/ui/GridTile.qml
+++ b/ui/GridTile.qml
@@ -13,6 +13,11 @@ Item {
     property bool hovered: false
     property bool selected: false
     property string thumb: ""
+    // Clamped by GridArea so a narrow cell cannot make the slot negative.
+    property int slotSize: Math.max(1, width - 2 * Theme.spacing.gap)
+
+    // A hovered tile (and its name tip) paints above later cells, or the next row covers the tip.
+    z: hover.hovered ? 1 : 0
 
     // A lifted tile is the cursor, the pointer or a selection member, the same ladder Row.qml climbs.
     readonly property bool lifted: root.cursor || root.hovered || root.selected
@@ -37,11 +42,11 @@ Item {
 
     Item {
         id: markSlot
-        anchors.left: parent.left
-        anchors.right: parent.right
+        anchors.horizontalCenter: parent.horizontalCenter
         anchors.top: parent.top
-        anchors.margins: Theme.spacing.gap
-        height: width
+        anchors.topMargin: Theme.spacing.gap
+        width: root.slotSize
+        height: root.slotSize
 
         // A thumbnail is a decoded image and stays one; the glyph beside it is a native mark, and
         // exactly one is visible, chosen the same way ui/Row.qml chooses.

--- a/ui/Theme.qml
+++ b/ui/Theme.qml
@@ -122,8 +122,8 @@ Singleton {
     // /usr/share/applications and this repo whole, and every further two buys under five points.
     readonly property int nameMinChars: 20
 
-    // The grid view's own two numbers. The canvas calls it a "48 px slot"; twice the list's own mark
-    // slot is 46 at base-size 14, and the token wins over the mock, see the icon-language spec.
+    // The grid view's designed mark size. Twice the list's own mark slot is 46 at base-size 14;
+    // tiles themselves fill the cell, and this token is the stroke-weight reference for a large glyph.
     readonly property QtObject grid: QtObject {
         readonly property int iconSize: root.iconSize * 2
         // Wide enough for a name of ordinary length under the mark; the view fits as many as this allows.


### PR DESCRIPTION
## Why

Icons and images look too small by default in grid view. The mark is a ~48px slot inside a much wider cell, so photos sit in padding and folder glyphs read as list-row leftovers.

## What

- The thumb/mark slot is the cell width, square, with `Theme.spacing.gap` inset.
- Photos `PreserveAspectFit`: longest side matches the tile, the other side letterboxes.
- Folder (and other) glyphs scale to the same square.
- Stroke is inverted against that scale so a large folder keeps the original grid-icon weight instead of fattening. `Glyph.strokeWidth` is settable for that one caller; list and rail stay on `Theme.strokeWidth`.

List and columns are unchanged.

## Files

- `ui/GridTile.qml`
- `ui/GridArea.qml`
- `ui/Glyph.qml`
- `ui/Theme.qml` (comment only: `grid.iconSize` is now the stroke-weight reference, not the painted slot)

Dogfooded on Omarchy against Pictures in grid view.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **UI Improvements**
  * Updated grid tiles to use square layouts with thumbnails that fill available tile width while preserving aspect ratio.
  * Adjusted glyph sizing and stroke weight to scale with tile dimensions.
  * Improved grid spacing and cell sizing for more consistent layouts.
  * Ensured hovered tiles and their labels appear above neighboring cells.
  * Added support for overriding the default glyph stroke width when needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->