### PR TITLE
dd keeps the cursor in place, and shows what it's about to trash

### DIFF
--- a/tests/js/nav.js
+++ b/tests/js/nav.js
@@ -24,11 +24,16 @@ function pane() {
         lockedMode: 0o40750,
         filterQuery: "scr",
         filterTyping: true,
+        pendingSelect: "",
+        pendingCursor: -1,
         cleared: 0,
         said: [],
-        sent: []
+        sent: [],
+        placed: []
     }
     p.clearSelection = function () { p.cleared += 1 }
+    p.setCursor = function (index) { p.cursorIndex = index; p.placed.push(index) }
+    p.join = function (base, name) { return base + "/" + name }
     p.message = function (text, isError) { p.said.push(text) }
     p.listArea = { primeSettle: function () {} }
     p.backend = {
@@ -75,6 +80,50 @@ function run(check) {
     check("and leaves the cursor where it was", busy.cursorIndex, 7)
     check("and leaves the locked mode standing too", busy.lockedMode, 0o40750)
     check("and leaves an open rename alone, because the listing did not change", busy.renamingIndex, 4)
+
+    // A refresh re-reads the directory under the listing rather than opening another one, so the
+    // rows already drawn, their count and the cursor all stand until the new ones land: nothing
+    // paints an empty frame, and the cursor's index is what the reply puts the cursor back on.
+    var kept = pane()
+    Nav.refresh(kept, "")
+    check("a refresh leaves the rows, the count and the cursor standing",
+          kept.rows.length + "|" + kept.total + "|" + kept.held + "|" + kept.cursorIndex, "1|40|10|7")
+    check("and remembers the cursor's index for the rows reply", kept.pendingCursor, 7)
+    check("and re-reads the directory it is in", kept.sent.join(","), "list /home/gm,fsinfo")
+    check("but still forgets what is indexed by row, because the rows are about to be renumbered",
+          kept.thumbState + "|" + kept.dirSizeState + "|" + kept.trashArmedAt + "|" + kept.cleared,
+          "[object Object]|[object Object]|0|1")
+
+    // A refresh that names a path reveals that row instead, the way rename and new folder do.
+    var named = pane()
+    Nav.refresh(named, "/home/gm/new.txt")
+    check("a refresh with a target reveals the target rather than the old index",
+          named.pendingSelect + "|" + named.pendingCursor, "/home/gm/new.txt|-1")
+
+    // The rows reply applies the index once, clamped to the listing that came back: trashing the
+    // last row leaves the cursor on the new last row, not one past the end.
+    var landed = pane()
+    landed.pendingCursor = 7
+    landed.total = 5
+    Nav.applyPendingSelect(landed)
+    check("the rows reply puts the cursor back, clamped to the rows that came back",
+          landed.placed.join(","), "4")
+    check("and the pending cursor is one shot", landed.pendingCursor, -1)
+    var empty = pane()
+    empty.pendingCursor = 0
+    empty.total = 0
+    Nav.applyPendingSelect(empty)
+    check("an emptied directory asks for row 0 and no lower", empty.placed.join(","), "0")
+    var idle = pane()
+    Nav.applyPendingSelect(idle)
+    check("a reply with nothing pending moves the cursor nowhere", idle.placed.length, 0)
+
+    // A navigation is not a re-read, so a pending cursor a failed refresh left behind must not
+    // land on some row of the next directory opened.
+    var moved = pane()
+    moved.pendingCursor = 7
+    Nav.openWithoutHistory(moved, "/home/gm/Work")
+    check("a new listing forgets a pending cursor with everything else", moved.pendingCursor, -1)
 
     // A keyboard rename reveals the row it renamed; one the pointer committed keeps the row the
     // click chose instead, because a write operation targets the selection ahead of the cursor.

--- a/tests/js/trash.js
+++ b/tests/js/trash.js
@@ -51,4 +51,12 @@ function run(check) {
     picked.trashArmedAt = Date.now()
     Trash.arm(picked)
     check("the pair trashes the selection when there is one", picked.trashedIdx.join(","), "1,4")
+
+    // The rows the views tint while the pair is armed are exactly the rows the second d would take.
+    var bare = { cursorIndex: 3, selectionCount: function () { return 0 }, isSelected: function (i) { return false } }
+    check("with nothing selected the cursor row is the one marked",
+          Trash.targeted(bare, 3) + "|" + Trash.targeted(bare, 2), "true|false")
+    var chosen = { cursorIndex: 3, selectionCount: function () { return 2 }, isSelected: function (i) { return i === 1 || i === 4 } }
+    check("with a selection its members are marked and the cursor row is not",
+          Trash.targeted(chosen, 1) + "|" + Trash.targeted(chosen, 4) + "|" + Trash.targeted(chosen, 3), "true|true|false")
 }

--- a/ui/GridArea.qml
+++ b/ui/GridArea.qml
@@ -3,6 +3,7 @@ import "." as Flea
 import "js/DirSizes.js" as DirSizes
 import "js/Tap.js" as Tap
 import "js/Thumbs.js" as Thumbs
+import "js/Trash.js" as Trash
 
 // The grid view. Same rows, same marks, same thumbnails as the list; only the geometry differs, so
 // the viewport maths is the list's own with a tile row standing in for a text row.
@@ -43,6 +44,7 @@ GridView {
         hovered: hover.hovered
         selected: root.pane.isSelected(index)
         thumb: Thumbs.fileFor(root.pane.thumbState, index)
+        armed: root.pane.trashArmedAt > 0 && Trash.targeted(root.pane, index)
 
         HoverHandler {
             id: hover

--- a/ui/GridTile.qml
+++ b/ui/GridTile.qml
@@ -13,9 +13,11 @@ Item {
     property bool hovered: false
     property bool selected: false
     property string thumb: ""
+    // The first d of the pair landed and the second would take this tile; GridArea.qml's delegate binds it through Trash.targeted.
+    property bool armed: false
 
     // A lifted tile is the cursor, the pointer or a selection member, the same ladder Row.qml climbs.
-    readonly property bool lifted: root.cursor || root.hovered || root.selected
+    readonly property bool lifted: root.cursor || root.hovered || root.selected || root.armed
     // A thumbnail path is not a thumbnail: the cache file can be evicted between the pane's answer
     // and the decode, and a tile whose Image failed to load has to be marked by its kind instead.
     readonly property bool thumbDrawn: root.thumb.length > 0 && tileThumb.status !== Image.Error
@@ -26,13 +28,16 @@ Item {
     Rectangle {
         anchors.fill: parent
         anchors.margins: Theme.spacing.hairline
-        color: root.cursor ? Style.selectedFill
+        // An armed tile takes the error role over the whole ladder, the same frame Row.qml draws
+        // over an armed row: the outline is the only edge a tile has to carry it.
+        color: root.armed ? Util.alpha(Theme.color.error, Style.hoverFillAlpha)
+             : root.cursor ? Style.selectedFill
              : root.selected ? Style.selectionFill
              : root.hovered ? Style.hoverFill
              : "transparent"
         // The canvas outlines the picked tile as well as filling it, because a tile has no row edge to read.
-        border.width: root.selected || root.cursor ? Theme.spacing.hairline : 0
-        border.color: Theme.color.accent
+        border.width: root.selected || root.cursor || root.armed ? Theme.spacing.hairline : 0
+        border.color: root.armed ? Theme.color.error : Theme.color.accent
     }
 
     Item {
@@ -63,7 +68,7 @@ Item {
             anchors.fill: parent
             visible: !root.thumbDrawn
             name: root.row ? Icons.glyphFor(root.row.i) : "file"
-            color: root.cursor || root.selected ? Theme.color.accent : Theme.color.muted
+            color: root.armed ? Theme.color.error : root.cursor || root.selected ? Theme.color.accent : Theme.color.muted
         }
     }
 
@@ -80,7 +85,7 @@ Item {
         anchors.rightMargin: Theme.spacing.gap
         horizontalAlignment: Text.AlignHCenter
         text: root.row ? root.row.n : ""
-        color: root.cursor || root.selected ? Theme.color.accent : Theme.color.foreground
+        color: root.armed ? Theme.color.error : root.cursor || root.selected ? Theme.color.accent : Theme.color.foreground
         font.family: Theme.font.family
         font.pixelSize: Theme.font.caption
         textFormat: Text.PlainText

--- a/ui/List.qml
+++ b/ui/List.qml
@@ -5,6 +5,7 @@ import "js/Drag.js" as DragOps
 import "js/Filter.js" as Filter
 import "js/Tap.js" as Tap
 import "js/Thumbs.js" as Thumbs
+import "js/Trash.js" as Trash
 
 // The listing's render, scroll and settle-triggered refetch, split out of Pane.qml; reaches Pane's state through the pane reference and the context menu through menu, both handed in at instantiation.
 ListView {
@@ -65,6 +66,7 @@ ListView {
         // -1 is also what Filter.at answers for a stale delegate, so an idle list must never light one.
         dropTarget: root.dropIndex >= 0 && listingIndex === root.dropIndex
         dropCopying: root.dragCopy
+        armed: root.pane.trashArmedAt > 0 && Trash.targeted(root.pane, listingIndex)
 
         onRenameCommitted: function (newName) { root.pane.commitRename(newName) }
         onRenameAbandoned: root.pane.renamingIndex = -1

--- a/ui/Pane.qml
+++ b/ui/Pane.qml
@@ -11,6 +11,7 @@ import "js/Ops.js" as Ops
 import "js/Selection.js" as Selection
 import "js/Sort.js" as Sort
 import "js/Thumbs.js" as Thumbs
+import "js/Trash.js" as Trash
 
 FocusScope {
     id: root
@@ -20,6 +21,8 @@ FocusScope {
     property string path: ""
     // Set once by shell.qml from FLEA_SELECT; applied to the first `rows` this pane receives, then forgotten.
     property string pendingSelect: ""
+    // The listing row the next rows reply puts the cursor back on, or -1; ui/js/Nav.js's refresh sets it so a re-read lands where the operator was, not at the top.
+    property int pendingCursor: -1
     property int total: 0
     property int cursorIndex: 0
     property string listingState: "loading"
@@ -27,8 +30,9 @@ FocusScope {
     property int lockedMode: 0
     // Off by default: dotfiles stay out of every listing until the context menu or "." turns them on.
     property bool showHidden: false
-    // When the first d of the dd pair landed; ui/js/Focus.js reads it and Nav's reset clears it.
+    // When the first d of the dd pair landed; ui/js/Focus.js reads it, Nav's reset clears it, and the rows it names tint until the clock below runs out.
     property double trashArmedAt: 0
+    Timer { interval: Trash.ARM_MS; running: root.trashArmedAt > 0; onTriggered: root.trashArmedAt = 0 }
     // "" off, "typing" while the query line has the keyboard, "results" once a walk was asked for; ui/js/Search.js owns every transition.
     property string searchMode: ""
     // Where the search was started from, which a home-wide walk leaves behind; see ui/js/Search.js.

--- a/ui/PaneWire.qml
+++ b/ui/PaneWire.qml
@@ -182,9 +182,13 @@ Item {
             pane.refresh("")
         }
 
+        // The refresh keeps the cursor's index and the rows below what left shift up into it, so the
+        // cursor lands on the row after the one removed. A selection leaves as a block, so the cursor
+        // goes to its first row before the refresh reads the index: vim's dd in both cases.
         function onTrashed(ok, failed) {
             pane.sticky("")
             pane.message(Ops.trashed(ok, failed), ok === 0)
+            pane.cursorIndex = Ops.targetIndices(pane)[0]
             pane.clearSelection()
             pane.refresh("")
         }

--- a/ui/Row.qml
+++ b/ui/Row.qml
@@ -22,6 +22,8 @@ Item {
     property bool dropTarget: false
     // Whether that drop would copy, so the label can say which; the status bar says the rest.
     property bool dropCopying: false
+    // The first d of the pair landed and the second would take this row; List.qml's delegate binds it through Trash.targeted.
+    property bool armed: false
     // A directory's recursive size, resolved by index in List.qml the same way thumb already is; null until it arrives.
     property var dirSize: null
     // Non-empty while a search or filter is narrowing the listing: the run to paint, and the switch to the search column set.
@@ -51,7 +53,7 @@ Item {
     readonly property bool kindShown: !root.searching && root.cols.kind
 
     // A lifted row is the cursor, the pointer, or a selection member; all three take the same fill treatment, per qui Minimal.
-    property bool lifted: root.cursor || root.hovered || root.selected || root.dropTarget
+    property bool lifted: root.cursor || root.hovered || root.selected || root.dropTarget || root.armed
     // The zebra is the OEM normal fill, which is the lightest rung of the same ladder.
     property bool alternate: false
     // The OEM derives its secondary ink from the foreground rather than reading a separate palette key.
@@ -82,6 +84,23 @@ Item {
         width: Theme.spacing.hairline * 2
         height: parent.height
         color: Theme.color.accent
+    }
+
+    // The armed frame, the drop frame's shape in the error role: shows what the second d will
+    // remove, for as long as the pair stays armed.
+    Rectangle {
+        visible: root.armed
+        anchors.fill: parent
+        color: Util.alpha(Theme.color.error, Style.hoverFillAlpha)
+        border.width: Theme.spacing.hairline
+        border.color: Theme.color.error
+    }
+
+    Rectangle {
+        visible: root.armed
+        width: Theme.spacing.hairline * 2
+        height: parent.height
+        color: Theme.color.error
     }
 
     // The drop frame: the board's hairline of accent inset in the row over a faint accent wash, the

--- a/ui/js/Nav.js
+++ b/ui/js/Nav.js
@@ -27,8 +27,10 @@ function back(pane) {
 }
 
 // Everything a fresh listing has to forget. Called by open, by refresh and by the hidden toggle, so
-// the reset is written once and no caller can half-do it.
-function openWithoutHistory(pane, newPath) {
+// the reset is written once and no caller can half-do it. A refresh passes keep, which leaves the
+// rows, their count and the cursor standing until the new ones land, so nothing paints an empty
+// frame. Anything indexed by row is still forgotten: the rows about to arrive are numbered differently.
+function openWithoutHistory(pane, newPath, keep) {
     if (pane.listInFlight) {
         pane.message("A directory is already loading.", false)
         return
@@ -36,13 +38,17 @@ function openWithoutHistory(pane, newPath) {
     pane.listInFlight = true
     pane.listedSeen = false
     pane.path = newPath
-    pane.total = 0
-    pane.held = 0
-    pane.rows = []
-    pane.kindNames = []
+    if (!keep) {
+        pane.total = 0
+        pane.held = 0
+        pane.rows = []
+        pane.kindNames = []
+        pane.cursorIndex = 0
+        // A navigation is not a re-read, so a cursor a failed refresh left pending must not land here.
+        pane.pendingCursor = -1
+    }
     pane.thumbState = Thumbs.empty()
     pane.dirSizeState = DirSizes.empty()
-    pane.cursorIndex = 0
     pane.trashArmedAt = 0
     // The row the editor sat on belongs to the listing being replaced, so the rename goes with it:
     // leaving the index set opened an empty editor over whatever file arrived at that row instead.
@@ -71,16 +77,25 @@ function renameRefreshTarget(pane, path) {
 }
 
 // An operation changed the directory under the listing, so it is read again. Passing the path the
-// operation produced re-selects that row through pendingSelect instead of dropping the cursor to the
-// top. It is not a navigation, so it never touches the history.
+// operation produced re-selects that row through pendingSelect; passing nothing keeps the cursor on
+// the index it held, which after a trash is the row that shifted up into the removed one's place,
+// the row vim's dd lands on. It is not a navigation, so it never touches the history.
 function refresh(pane, selectPath) {
     pane.pendingSelect = selectPath ? selectPath : ""
-    pane.openWithoutHistory(pane.path)
+    pane.pendingCursor = selectPath ? -1 : pane.cursorIndex
+    openWithoutHistory(pane, pane.path, true)
 }
 
 // Only the first rows response looks for the target, then it is forgotten either way, so a later
 // directory change never re-reveals it. The target is a full path, which is what --select carries.
+// A pending cursor is applied the same way, clamped to the listing that came back: trashing the last
+// row leaves the cursor on the new last row rather than one past the end.
 function applyPendingSelect(pane) {
+    if (pane.pendingCursor >= 0) {
+        var row = Math.min(pane.pendingCursor, Math.max(0, pane.total - 1))
+        pane.pendingCursor = -1
+        pane.setCursor(row)
+    }
     if (pane.pendingSelect.length === 0) {
         return
     }

--- a/ui/js/Trash.js
+++ b/ui/js/Trash.js
@@ -7,8 +7,16 @@
 // letters and still go on one press, through Ops.trash directly.
 
 // How long the first d stays armed. Long enough to be a deliberate pair, short enough that an arm
-// nobody finished cannot be completed by a d typed minutes later.
+// nobody finished cannot be completed by a d typed minutes later. ui/Pane.qml runs a Timer on the
+// same figure that clears the stamp, so the rows' armed tint and the pair's window expire together.
 var ARM_MS = 1500
+
+// Whether the second d would take this row: the selection when there is one, else the cursor row,
+// the rule Ops.targetIndices keeps for every write. The views tint exactly these while the pair is
+// armed, so what a d will remove is on screen before it is pressed.
+function targeted(pane, index) {
+    return pane.selectionCount() > 0 ? pane.isSelected(index) : index === pane.cursorIndex
+}
 
 // ui/js/Focus.js clears pane.trashArmedAt for every other action, so an arm never survives the key
 // after it; this reads the stamp before it writes one, which is what makes the second press the pair.


### PR DESCRIPTION
Two things that bugged me when trashing with dd.

1. After the trash, the whole list reloaded and the cursor jumped back to the top. Now the rows stay on screen and the cursor stays where it was, on whatever slid up into the gap, same as vim. If you trashed a selection it lands on the first row of the block. Paste and undo get the same treatment since they go through the same refresh.

2. The first d only showed a status line. Now it also tints the rows the second d will remove, using the theme's urgent color, so you can see what's about to go before you commit. The tint clears after the same 1.5s window the pair already used, or on any other key. Works in the list and grid views.

No backend changes. tests/js.sh is green and I added checks to nav.js and trash.js. I couldn't run tests/ui.sh here (no omarchy-drive), but I drove the window by hand and checked single row, last row, selection, emptying the directory, and undo.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added clear visual indicators for rows and tiles targeted by the two-step trash action.
  * Trash-targeted items use error-colored highlights, borders, and markers.
  * Directory rows now show clearer names, links, dates, sizes, and icons.
  * Archive files open Flea’s preview when activated; directories continue navigating normally.

* **Bug Fixes**
  * Refreshing directories preserves cursor placement and applies pending selections safely.
  * Cursor placement remains consistent after deleting files or selections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->