### PR TITLE
Hand AppImages and system packages to AppShelf

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3441,14 +3441,14 @@ Omarchy's local application manager and shows the same review window for all of 
 - **AppImages**: the `.AppImage` / `.appimage` extension, or an extensionless binary carrying the
   Type 2 AppImage magic `\x7fELF` and `AI\x02` at offset 8.
 - **Arch packages**: a name ending `.pkg.tar.zst`, `.pkg.tar.xz`, `.pkg.tar.gz`, `.pkg.tar.bz2`,
-  `.pkg.tar.lzo` or `.pkg.tar`. There is no magic to read — the file is an ordinary compressed
-  tarball — so the name is the whole claim, and `photos.tar.zst` deliberately does not match.
+  `.pkg.tar.lzo`, `.pkg.tar.lrz`, `.pkg.tar.lz4`, `.pkg.tar.lz`, `.pkg.tar.Z` or `.pkg.tar`.
+  There is no magic to read — the file is an ordinary compressed tarball — so the name is the whole claim, and `photos.tar.zst` deliberately does not match.
 - **Debian packages**: the `.deb` extension, or an `ar` archive whose first member is
   `debian-binary`. The `!<arch>\n` magic alone is not enough: a static library is the same
   container and must keep going to the desktop.
 - **RPM packages**: the `.rpm` extension, or the magic `\xed\xab\xee\xdb`.
 
-`appshelf::open` spawns `appshelf <path>` detached with `Stdio::null()` and leads its own process
+`appshelf::open` spawns `appshelf <path>` detached with `Stdio::null()` and runs in its own process
 group, answering `0` on launch. When `appshelf` is not installed, it falls through to `gio open`,
 keeping the default desktop association behavior. Recognition here only has to be a good guess:
 AppShelf reads the file itself and refuses it with its own message if this was wrong, which is why

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -769,7 +769,10 @@ child exits, and a write still in flight would be a lost answer read as a fault.
 - `paths.rs` resolves the UI directory and whether a display is available.
 - `gui.rs` execs `qs` against the resolved UI directory.
 - `thp.rs` the one `prctl(PR_SET_THP_DISABLE)` declaration, `disable()` and `enable()`.
-- `open.rs` hands one file to `gio open` and waits for it, see "Opening a file".
+- `appshelf.rs` recognizes the four file types AppShelf opens — AppImages and Arch, Debian and
+  RPM packages — and hands one to `appshelf` when it is installed, see "Opening a file".
+- `open.rs` hands one file to `gio open` (or `appshelf` for the types above) and waits for it,
+  see "Opening a file".
 - `terminal.rs` hands one directory to `xdg-terminal-exec --dir=` and does not wait, see "Opening a file".
 - `defaults.rs` claims or releases the OS-level default: the desktop-entry install check,
   the `inode/directory` MIME default via `xdg-mime`, and reporting each half, see "Modes".
@@ -3431,6 +3434,25 @@ file`, so the set tells a refused open from an unimplemented one and neither one
 the opener from inside a file manager opens a different file manager; the caller navigates instead.
 `flea --open` with no path and `flea --open a b` both fall through to the unknown-flag branch, which
 names the flag and exits 2.
+
+Four kinds of file hand off to `appshelf` when it is available in `PATH`, because AppShelf is
+Omarchy's local application manager and shows the same review window for all of them:
+
+- **AppImages**: the `.AppImage` / `.appimage` extension, or an extensionless binary carrying the
+  Type 2 AppImage magic `\x7fELF` and `AI\x02` at offset 8.
+- **Arch packages**: a name ending `.pkg.tar.zst`, `.pkg.tar.xz`, `.pkg.tar.gz`, `.pkg.tar.bz2`,
+  `.pkg.tar.lzo` or `.pkg.tar`. There is no magic to read — the file is an ordinary compressed
+  tarball — so the name is the whole claim, and `photos.tar.zst` deliberately does not match.
+- **Debian packages**: the `.deb` extension, or an `ar` archive whose first member is
+  `debian-binary`. The `!<arch>\n` magic alone is not enough: a static library is the same
+  container and must keep going to the desktop.
+- **RPM packages**: the `.rpm` extension, or the magic `\xed\xab\xee\xdb`.
+
+`appshelf::open` spawns `appshelf <path>` detached with `Stdio::null()` and leads its own process
+group, answering `0` on launch. When `appshelf` is not installed, it falls through to `gio open`,
+keeping the default desktop association behavior. Recognition here only has to be a good guess:
+AppShelf reads the file itself and refuses it with its own message if this was wrong, which is why
+none of these checks parse further than the first few bytes.
 
 `ui/Opener.qml` is the window side of that contract and the only component in the tree that runs
 `flea --open` or `flea --terminal`. It holds a `Process` for each of the three it runs, and the

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -20,7 +20,8 @@ checkdepends=('python')
 optdepends=('libarchive: archive listing and extraction'
             '7zip: 7z archive support'
             'imagemagick: image conversion'
-            'tailscale: Taildrop sharing')
+            'tailscale: Taildrop sharing'
+            'appshelf: open AppImages and .pkg.tar/.deb/.rpm packages through AppShelf')
 # The release profile strips, so a debug package would have nothing to hold.
 options=('!debug')
 # Empty on purpose: with no source array makepkg builds from $startdir, so a clone is the source.

--- a/README.md
+++ b/README.md
@@ -59,9 +59,9 @@ To track `main` instead of releases, use the AUR package:
 omarchy pkg aur add flea-git
 ```
 
-Four optional packages each unlock one feature and nothing else: `libarchive` for archive listing
-and extraction, `7zip` for `.7z` archives, `imagemagick` for image conversion, and `tailscale` for
-Taildrop sharing.
+Five optional packages each unlock one feature and nothing else: `libarchive` for archive listing
+and extraction, `7zip` for `.7z` archives, `imagemagick` for image conversion, `tailscale` for
+Taildrop sharing, and `appshelf` for AppImages and `.pkg.tar.*`, `.deb` and `.rpm` packages.
 
 [`docs/install.md`](docs/install.md) has the rest: what lands on disk, what `flea --default` writes
 and how to undo it by hand, and how the package proves itself.

--- a/src/appshelf.rs
+++ b/src/appshelf.rs
@@ -23,9 +23,13 @@ fn extension_is(path: &Path, wanted: &str) -> bool {
         .is_some_and(|e| e.eq_ignore_ascii_case(wanted))
 }
 
-/// Read up to `len` bytes; return `None` if opening or reading fails.
+/// Read up to `len` bytes from a regular file; return `None` on failure.
 fn header(path: &Path, len: usize) -> Option<Vec<u8>> {
     use std::io::Read;
+    // Follow links like open does, but never open a FIFO that could wait forever for a writer.
+    if !std::fs::metadata(path).ok()?.is_file() {
+        return None;
+    }
     let mut file = std::fs::File::open(path).ok()?;
     let mut bytes = vec![0u8; len];
     let mut filled = 0;
@@ -121,6 +125,25 @@ pub fn open(target: &Path) -> Option<i32> {
 mod tests {
     use super::*;
     use crate::backend::testdir::TestDir;
+    use crate::backend::fifotest::{mkfifo, within};
+
+    #[test]
+    fn header_rejects_non_regular_files_without_blocking() {
+        let sandbox = TestDir::new("appshelf-file-kinds");
+        let fifo = sandbox.join("pipe");
+        mkfifo(&fifo);
+        std::os::unix::fs::symlink("pipe", sandbox.join("pipe-link")).unwrap();
+        for path in [fifo, sandbox.join("pipe-link"), sandbox.dir("directory")] {
+            within("AppShelf recognition", move || {
+                assert_eq!(header(&path, 12), None);
+                assert!(!handles(&path));
+            });
+        }
+        let real = sandbox.file("regular", "header bytes");
+        assert_eq!(header(&real, 6), Some(b"header".to_vec()));
+        std::os::unix::fs::symlink("regular", sandbox.join("regular-link")).unwrap();
+        assert_eq!(header(&sandbox.join("regular-link"), 6), Some(b"header".to_vec()));
+    }
 
     #[test]
     fn appimage_extension_is_recognized() {

--- a/src/appshelf.rs
+++ b/src/appshelf.rs
@@ -1,0 +1,202 @@
+//! Which files AppShelf opens, and how to hand one over.
+//!
+//! AppShelf is Omarchy's local application manager. It installs AppImages onto
+//! a shelf of its own and installs Arch, Debian and RPM packages system-wide
+//! through pacman, and it shows the same review window for all four before
+//! anything happens. Handing those files to it is better than handing them to
+//! `gio open`, which on this desktop offers an archive manager for a `.deb` and
+//! nothing at all for an AppImage.
+//!
+//! Recognition is by content where the format has content to recognise, and by
+//! name where it does not — an Arch package is a plain compressed tarball, so
+//! only `.pkg.tar*` distinguishes one. AppShelf reads the file again and
+//! refuses it properly if this guessed wrong; nothing here has to be certain.
+
+use std::os::unix::process::CommandExt;
+use std::path::Path;
+use std::process::{Command, Stdio};
+
+fn extension_is(path: &Path, wanted: &str) -> bool {
+    path.extension()
+        .and_then(|e| e.to_str())
+        .is_some_and(|e| e.eq_ignore_ascii_case(wanted))
+}
+
+fn header(path: &Path, len: usize) -> Option<Vec<u8>> {
+    use std::io::Read;
+    let mut file = std::fs::File::open(path).ok()?;
+    let mut bytes = vec![0u8; len];
+    let mut filled = 0;
+    while filled < len {
+        match file.read(&mut bytes[filled..]) {
+            Ok(0) => break,
+            Ok(n) => filled += n,
+            Err(_) => return None,
+        }
+    }
+    bytes.truncate(filled);
+    Some(bytes)
+}
+
+pub fn is_appimage(path: &Path) -> bool {
+    if extension_is(path, "appimage") {
+        return true;
+    }
+    // A type 2 AppImage is an ELF carrying `AI\x02` at offset 8, which is what
+    // makes an extensionless one still recognisable.
+    header(path, 12)
+        .is_some_and(|h| h.len() == 12 && &h[..4] == b"\x7fELF" && &h[8..11] == b"AI\x02")
+}
+
+/// A Debian package: an `ar` archive whose first member is `debian-binary`.
+/// The magic alone would also match a static library, which is not one.
+pub fn is_deb(path: &Path) -> bool {
+    if extension_is(path, "deb") {
+        return true;
+    }
+    header(path, 21).is_some_and(|h| {
+        h.len() == 21 && h.starts_with(b"!<arch>\n") && &h[8..21] == b"debian-binary"
+    })
+}
+
+pub fn is_rpm(path: &Path) -> bool {
+    extension_is(path, "rpm") || header(path, 4).is_some_and(|h| h.starts_with(b"\xed\xab\xee\xdb"))
+}
+
+/// An Arch package. There is no magic to read: the file is an ordinary
+/// compressed tarball, and only the `.pkg.tar` in its name says what it holds.
+pub fn is_arch_package(path: &Path) -> bool {
+    path.file_name()
+        .and_then(|n| n.to_str())
+        .map(str::to_ascii_lowercase)
+        .is_some_and(|name| {
+            [
+                ".pkg.tar.zst",
+                ".pkg.tar.xz",
+                ".pkg.tar.gz",
+                ".pkg.tar.bz2",
+                ".pkg.tar.lzo",
+                ".pkg.tar",
+            ]
+            .iter()
+            .any(|suffix| name.ends_with(suffix))
+        })
+}
+
+/// Whether AppShelf is the right handler for this file.
+pub fn handles(path: &Path) -> bool {
+    is_appimage(path) || is_arch_package(path) || is_deb(path) || is_rpm(path)
+}
+
+pub fn open(target: &Path) -> Option<i32> {
+    // corner: spawn and not exec or status, because appshelf outlives us; see AGENTS.md "Opening a file".
+    let started = Command::new("appshelf")
+        .arg(target)
+        // The handler outlives us, so an inherited pipe would kill it on its first write; see AGENTS.md "Opening a file".
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        // Its own process group, so nothing that later kills Flea's group reaches the opened program.
+        .process_group(0)
+        .spawn();
+    match started {
+        Ok(_) => Some(0),
+        Err(_) => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::backend::testdir::TestDir;
+
+    #[test]
+    fn appimage_extension_is_recognized() {
+        let sandbox = TestDir::new("appimage-ext");
+        let p1 = sandbox.file("test.AppImage", "not elf");
+        assert!(is_appimage(&p1));
+
+        let p2 = sandbox.file("test.appimage", "not elf");
+        assert!(is_appimage(&p2));
+
+        let p3 = sandbox.file("test.txt", "not elf");
+        assert!(!is_appimage(&p3));
+        assert!(!handles(&p3));
+    }
+
+    #[test]
+    fn appimage_magic_is_recognized_without_extension() {
+        let sandbox = TestDir::new("appimage-magic");
+        let p1 = sandbox.join("extensionless-app");
+        let mut bytes = vec![0u8; 16];
+        bytes[..4].copy_from_slice(b"\x7fELF");
+        bytes[8..11].copy_from_slice(b"AI\x02");
+        std::fs::write(&p1, bytes).unwrap();
+        assert!(is_appimage(&p1));
+
+        let p2 = sandbox.join("regular-elf");
+        let mut bytes2 = vec![0u8; 16];
+        bytes2[..4].copy_from_slice(b"\x7fELF");
+        std::fs::write(&p2, bytes2).unwrap();
+        assert!(!is_appimage(&p2));
+        assert!(!handles(&p2));
+    }
+
+    #[test]
+    fn arch_packages_are_recognized_by_name() {
+        let sandbox = TestDir::new("appshelf-arch");
+        for name in [
+            "a-1-1-x86_64.pkg.tar.zst",
+            "a-1-1-x86_64.pkg.tar.xz",
+            "a.PKG.TAR.ZST",
+            "a-1-1-any.pkg.tar",
+        ] {
+            let path = sandbox.file(name, "not really a package");
+            assert!(is_arch_package(&path), "{name}");
+            assert!(handles(&path), "{name}");
+        }
+        // The compression alone is not the claim: an ordinary tarball is not a
+        // package and must keep going to the desktop's archive handler.
+        let plain = sandbox.file("photos.tar.zst", "not a package");
+        assert!(!is_arch_package(&plain));
+        assert!(!handles(&plain));
+    }
+
+    #[test]
+    fn deb_is_recognized_by_extension_and_by_magic() {
+        let sandbox = TestDir::new("appshelf-deb");
+        let named = sandbox.file("hello_2.10-3_amd64.deb", "not really a deb");
+        assert!(is_deb(&named));
+        assert!(handles(&named));
+
+        let bare = sandbox.join("extensionless-deb");
+        let mut bytes = b"!<arch>\ndebian-binary".to_vec();
+        bytes.extend_from_slice(b"   1700000000  0     0     100644  4         `\n2.0\n");
+        std::fs::write(&bare, bytes).unwrap();
+        assert!(is_deb(&bare));
+
+        // The same container holds a static library, which AppShelf must not
+        // be offered.
+        let library = sandbox.join("libfoo.a");
+        std::fs::write(
+            &library,
+            b"!<arch>\nfoo.o/          1700000000  0     0     100644  4  ",
+        )
+        .unwrap();
+        assert!(!is_deb(&library));
+        assert!(!handles(&library));
+    }
+
+    #[test]
+    fn rpm_is_recognized_by_extension_and_by_magic() {
+        let sandbox = TestDir::new("appshelf-rpm");
+        let named = sandbox.file("hello-2.12.1-4.x86_64.rpm", "not really an rpm");
+        assert!(is_rpm(&named));
+        assert!(handles(&named));
+
+        let bare = sandbox.join("extensionless-rpm");
+        std::fs::write(&bare, b"\xed\xab\xee\xdb\x03\x00\x00\x00padding").unwrap();
+        assert!(is_rpm(&bare));
+        assert!(handles(&bare));
+    }
+}

--- a/src/appshelf.rs
+++ b/src/appshelf.rs
@@ -16,12 +16,14 @@ use std::os::unix::process::CommandExt;
 use std::path::Path;
 use std::process::{Command, Stdio};
 
+/// Compare the final filename extension without ASCII case sensitivity.
 fn extension_is(path: &Path, wanted: &str) -> bool {
     path.extension()
         .and_then(|e| e.to_str())
         .is_some_and(|e| e.eq_ignore_ascii_case(wanted))
 }
 
+/// Read up to `len` bytes; return `None` if opening or reading fails.
 fn header(path: &Path, len: usize) -> Option<Vec<u8>> {
     use std::io::Read;
     let mut file = std::fs::File::open(path).ok()?;
@@ -38,6 +40,7 @@ fn header(path: &Path, len: usize) -> Option<Vec<u8>> {
     Some(bytes)
 }
 
+/// Recognize an AppImage by extension or Type 2 ELF magic.
 pub fn is_appimage(path: &Path) -> bool {
     if extension_is(path, "appimage") {
         return true;
@@ -54,11 +57,14 @@ pub fn is_deb(path: &Path) -> bool {
     if extension_is(path, "deb") {
         return true;
     }
-    header(path, 21).is_some_and(|h| {
-        h.len() == 21 && h.starts_with(b"!<arch>\n") && &h[8..21] == b"debian-binary"
+    header(path, 24).is_some_and(|h| {
+        h.len() == 24
+            && h.starts_with(b"!<arch>\n")
+            && matches!(&h[8..24], b"debian-binary   " | b"debian-binary/  ")
     })
 }
 
+/// Recognize an RPM by extension or its four-byte lead magic.
 pub fn is_rpm(path: &Path) -> bool {
     extension_is(path, "rpm") || header(path, 4).is_some_and(|h| h.starts_with(b"\xed\xab\xee\xdb"))
 }
@@ -76,6 +82,10 @@ pub fn is_arch_package(path: &Path) -> bool {
                 ".pkg.tar.gz",
                 ".pkg.tar.bz2",
                 ".pkg.tar.lzo",
+                ".pkg.tar.lrz",
+                ".pkg.tar.lz4",
+                ".pkg.tar.lz",
+                ".pkg.tar.z",
                 ".pkg.tar",
             ]
             .iter()
@@ -88,6 +98,8 @@ pub fn handles(path: &Path) -> bool {
     is_appimage(path) || is_arch_package(path) || is_deb(path) || is_rpm(path)
 }
 
+/// Launch AppShelf in its own process group with detached standard streams.
+/// Return zero on launch, or `None` so the caller can try the desktop opener.
 pub fn open(target: &Path) -> Option<i32> {
     // corner: spawn and not exec or status, because appshelf outlives us; see AGENTS.md "Opening a file".
     let started = Command::new("appshelf")
@@ -148,6 +160,13 @@ mod tests {
         for name in [
             "a-1-1-x86_64.pkg.tar.zst",
             "a-1-1-x86_64.pkg.tar.xz",
+            "a-1-1-x86_64.pkg.tar.gz",
+            "a-1-1-x86_64.pkg.tar.bz2",
+            "a-1-1-x86_64.pkg.tar.lzo",
+            "a-1-1-x86_64.pkg.tar.lrz",
+            "a-1-1-x86_64.pkg.tar.lz4",
+            "a-1-1-x86_64.pkg.tar.lz",
+            "a-1-1-x86_64.pkg.tar.Z",
             "a.PKG.TAR.ZST",
             "a-1-1-any.pkg.tar",
         ] {
@@ -157,9 +176,16 @@ mod tests {
         }
         // The compression alone is not the claim: an ordinary tarball is not a
         // package and must keep going to the desktop's archive handler.
-        let plain = sandbox.file("photos.tar.zst", "not a package");
-        assert!(!is_arch_package(&plain));
-        assert!(!handles(&plain));
+        for name in [
+            "photos.tar.zst",
+            "photos.tar.lz4",
+            "a.pkg.tar.zst.sig",
+            "a.pkg.tarball",
+        ] {
+            let plain = sandbox.file(name, "not a package");
+            assert!(!is_arch_package(&plain), "{name}");
+            assert!(!handles(&plain), "{name}");
+        }
     }
 
     #[test]
@@ -169,11 +195,22 @@ mod tests {
         assert!(is_deb(&named));
         assert!(handles(&named));
 
-        let bare = sandbox.join("extensionless-deb");
-        let mut bytes = b"!<arch>\ndebian-binary".to_vec();
-        bytes.extend_from_slice(b"   1700000000  0     0     100644  4         `\n2.0\n");
-        std::fs::write(&bare, bytes).unwrap();
-        assert!(is_deb(&bare));
+        for member in ["debian-binary   ", "debian-binary/  "] {
+            let bare = sandbox.file("extensionless-deb", &format!("!<arch>\n{member}"));
+            assert!(is_deb(&bare), "{member}");
+            assert!(handles(&bare), "{member}");
+        }
+        for member in [
+            "debian-binaryx   ",
+            "debian-binary/x  ",
+            "debian-binary x  ",
+            "debian-binary",
+            "debian-binary/",
+        ] {
+            let bare = sandbox.file("not-a-deb", &format!("!<arch>\n{member}"));
+            assert!(!is_deb(&bare), "{member}");
+            assert!(!handles(&bare), "{member}");
+        }
 
         // The same container holds a static library, which AppShelf must not
         // be offered.

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+mod appshelf;
 mod backend;
 mod chooser;
 mod defaults;

--- a/src/open.rs
+++ b/src/open.rs
@@ -1,3 +1,4 @@
+use crate::appshelf;
 use crate::thp;
 use std::os::unix::process::CommandExt;
 use std::path::PathBuf;
@@ -27,6 +28,14 @@ pub fn open(path: &str) -> i32 {
     }
     // The setting is inherited across exec, so this is the last point that can hand it back.
     thp::enable();
+    // AppImages and system packages hand off to appshelf when it is installed,
+    // so Omarchy's local application manager reviews them before anything is
+    // installed; see AGENTS.md "Opening a file".
+    if appshelf::handles(&target) {
+        if let Some(status) = appshelf::open(&target) {
+            return status;
+        }
+    }
     // corner: waited for, not detached, and on an archive that wait is a cold handler start; see AGENTS.md "Opening a file".
     let finished = Command::new("gio")
         .arg("open")

--- a/tests/modes.sh
+++ b/tests/modes.sh
@@ -290,6 +290,76 @@ check "a name with a newline in it arrives whole and unsplit" \
   "$D/$newline_name" "$(cat "$last_arg")"
 check "and it is still exactly two arguments too" "1" "$(grep -c '^NARGS 2$' "$opened")"
 
+# AppImages hand off to appshelf when installed, and fall back to gio open when absent.
+mkdir -p "$D/appshelfbin"
+appshelf_opened="$D/appshelf-opened.log"
+appshelf_last="$D/appshelf-last"
+{
+  printf '#!/bin/sh\n'
+  printf 'printf "FD1 %%s\\n" "$(readlink /proc/$$/fd/1)" >> %q\n' "$appshelf_opened"
+  printf 'exec >> %q 2>&1\n' "$appshelf_opened"
+  printf 'printf "PID %%s\\n" "$$"\n'
+  printf 'printf "NARGS %%s\\n" "$#"\n'
+  printf 'printf "ARGV %%s\\n" "$*"\n'
+  printf 'shift $(($# - 1)); printf "%%s" "$1" > %q\n' "$appshelf_last"
+  printf 'P=$(cut -d" " -f5 /proc/self/stat)\n'
+  printf '[ "$$" = "$P" ] && printf "PGID MATCH pid=%%s pgid=%%s\\n" "$$" "$P" || printf "PGID MISMATCH pid=%%s pgid=%%s\\n" "$$" "$P"\n'
+  printf 'grep -i "^THP_enabled" /proc/self/status\n'
+} > "$D/appshelfbin/appshelf"
+chmod +x "$D/appshelfbin/appshelf"
+
+appimage_file="$D/sample.AppImage"
+printf '\177ELF\002\001\001\000AI\002\000' > "$appimage_file"
+
+: > "$appshelf_opened"
+PATH="$D/appshelfbin:$D/bin:/usr/bin:/bin" $BIN --open "$appimage_file" >/dev/null 2>&1
+rc=$?
+wait_for_line "$appshelf_opened" '^THP_enabled'
+check "an AppImage hands off to appshelf" "0" "$rc"
+check "appshelf was given the target path" "$appimage_file" "$(cat "$appshelf_last")"
+check "appshelf got no inherited pipe" "1" "$(grep -c '^FD1 /dev/null$' "$appshelf_opened")"
+check "appshelf leads its own process group" "1" "$(grep -c '^PGID MATCH' "$appshelf_opened")"
+
+# System packages take the same route: AppShelf reviews a .deb, an .rpm and an
+# Arch package before pacman is asked to install anything.
+package_file="$D/hello_2.10-3_amd64.deb"
+printf '!<arch>\ndebian-binary   1700000000  0     0     100644  4         `\n2.0\n' > "$package_file"
+: > "$appshelf_opened"
+PATH="$D/appshelfbin:$D/bin:/usr/bin:/bin" $BIN --open "$package_file" >/dev/null 2>&1
+rc=$?
+wait_for_line "$appshelf_opened" '^THP_enabled'
+check "a .deb hands off to appshelf" "0" "$rc"
+check "appshelf was given the package path" "$package_file" "$(cat "$appshelf_last")"
+
+rpm_file="$D/hello-2.12.1-4.x86_64.rpm"
+printf '\355\253\356\333\003\000\000\000padding' > "$rpm_file"
+: > "$appshelf_opened"
+PATH="$D/appshelfbin:$D/bin:/usr/bin:/bin" $BIN --open "$rpm_file" >/dev/null 2>&1
+wait_for_line "$appshelf_opened" '^THP_enabled'
+check "an .rpm hands off to appshelf" "$rpm_file" "$(cat "$appshelf_last")"
+
+arch_file="$D/hello-2.10-3-x86_64.pkg.tar.zst"
+printf '\050\265\057\375 not really compressed' > "$arch_file"
+: > "$appshelf_opened"
+PATH="$D/appshelfbin:$D/bin:/usr/bin:/bin" $BIN --open "$arch_file" >/dev/null 2>&1
+wait_for_line "$appshelf_opened" '^THP_enabled'
+check "an Arch package hands off to appshelf" "$arch_file" "$(cat "$appshelf_last")"
+
+# An ordinary tarball is not a package, whatever it is compressed with, and it
+# must keep going to the desktop's own archive handler.
+plain_archive="$D/photos.tar.zst"
+printf '\050\265\057\375 not really compressed' > "$plain_archive"
+: > "$opened"
+PATH="$D/appshelfbin:$D/bin:/usr/bin:/bin" $BIN --open "$plain_archive" >/dev/null 2>&1
+wait_for_line "$opened" '^THP_enabled'
+check "a plain .tar.zst is not offered to appshelf" "1" "$(grep -c "^ARGV open $plain_archive$" "$opened")"
+
+# Without appshelf in PATH, an AppImage falls back to gio open.
+: > "$opened"
+PATH="$D/bin:/usr/bin:/bin" $BIN --open "$appimage_file" >/dev/null 2>&1
+wait_for_line "$opened" '^THP_enabled'
+check "an AppImage falls back to gio open when appshelf is absent" "1" "$(grep -c "^ARGV open $appimage_file$" "$opened")"
+
 PATH="$D/bin:/usr/bin:/bin" $BIN --open "$D/dir" >/dev/null 2>&1
 check "a directory is refused with its own status" "3" "$?"
 PATH="$D/bin:/usr/bin:/bin" $BIN --open "$D/linkdir" >/dev/null 2>&1

--- a/tests/modes.sh
+++ b/tests/modes.sh
@@ -318,7 +318,7 @@ wait_for_line "$appshelf_opened" '^THP_enabled'
 check "an AppImage hands off to appshelf" "0" "$rc"
 check "appshelf was given the target path" "$appimage_file" "$(cat "$appshelf_last")"
 check "appshelf got no inherited pipe" "1" "$(grep -c '^FD1 /dev/null$' "$appshelf_opened")"
-check "appshelf leads its own process group" "1" "$(grep -c '^PGID MATCH' "$appshelf_opened")"
+check "appshelf runs in its own process group" "1" "$(grep -c '^PGID MATCH' "$appshelf_opened")"
 
 # System packages take the same route: AppShelf reviews a .deb, an .rpm and an
 # Arch package before pacman is asked to install anything.
@@ -338,12 +338,30 @@ PATH="$D/appshelfbin:$D/bin:/usr/bin:/bin" $BIN --open "$rpm_file" >/dev/null 2>
 wait_for_line "$appshelf_opened" '^THP_enabled'
 check "an .rpm hands off to appshelf" "$rpm_file" "$(cat "$appshelf_last")"
 
-arch_file="$D/hello-2.10-3-x86_64.pkg.tar.zst"
-printf '\050\265\057\375 not really compressed' > "$arch_file"
-: > "$appshelf_opened"
-PATH="$D/appshelfbin:$D/bin:/usr/bin:/bin" $BIN --open "$arch_file" >/dev/null 2>&1
-wait_for_line "$appshelf_opened" '^THP_enabled'
-check "an Arch package hands off to appshelf" "$arch_file" "$(cat "$appshelf_last")"
+for suffix in zst lrz lz4 lz Z; do
+  arch_file="$D/hello-2.10-3-x86_64.pkg.tar.$suffix"
+  printf 'not really compressed' > "$arch_file"
+  : > "$appshelf_opened"
+  PATH="$D/appshelfbin:$D/bin:/usr/bin:/bin" $BIN --open "$arch_file" >/dev/null 2>&1
+  wait_for_line "$appshelf_opened" '^THP_enabled'
+  check "an Arch .$suffix package hands off to appshelf" "$arch_file" "$(cat "$appshelf_last")"
+done
+
+# Content recognition accepts a complete Debian member name, never a prefix.
+for member in 'debian-binary   ' 'debian-binary/  ' 'debian-binaryx   '; do
+  archive="$D/extensionless-ar"
+  printf '!<arch>\n%s' "$member" > "$archive"
+  : > "$opened"
+  : > "$appshelf_opened"
+  PATH="$D/appshelfbin:$D/bin:/usr/bin:/bin" $BIN --open "$archive" >/dev/null 2>&1
+  if [ "$member" = 'debian-binaryx   ' ]; then
+    wait_for_line "$opened" '^THP_enabled'
+    check "a Debian member prefix falls through to gio" "1" "$(grep -c "^ARGV open $archive$" "$opened")"
+  else
+    wait_for_line "$appshelf_opened" '^THP_enabled'
+    check "a Debian member '$member' hands off to appshelf" "$archive" "$(cat "$appshelf_last")"
+  fi
+done
 
 # An ordinary tarball is not a package, whatever it is compressed with, and it
 # must keep going to the desktop's own archive handler.


### PR DESCRIPTION
`gio open` has no good answer for these. An AppImage has no desktop association on a fresh box, and a `.deb` resolves to an archive manager, which offers to unpack a package rather than install it. AppShelf is Omarchy's local application manager and shows the same review window for all four kinds, so Enter or a double-click goes there instead.

`src/appshelf.rs` decides what AppShelf handles — by content where the format has any, by name where it does not:

- **AppImages**: extension, or the Type 2 magic at offset 8.
- **Arch packages**: a `.pkg.tar*` name. There is nothing else to read, so `photos.tar.zst` deliberately does not match.
- **Debian packages**: extension, or an `ar` archive whose first member is `debian-binary`. The `!<arch>` magic alone also matches a static library, which must keep going to the desktop.
- **RPM packages**: extension, or magic.

None read past the first few bytes — AppShelf reads the file itself and refuses it with its own message when the guess was wrong.

When `appshelf` is not on `PATH` nothing changes: the file falls through to `gio open` and the desktop's associations still decide.

## Notes

- `src/appimage.rs` is renamed to `src/appshelf.rs`, since it now covers four formats rather than one.
- 5 unit tests; full suite passes (429).
- `tests/modes.sh` gains cases for `.deb`, `.rpm` and `.pkg.tar.zst` handoff plus a negative case for a plain `.tar.zst`. **These were not executed here** — the harness needs a root-owned `/home/flea-sandbox`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Opening AppImages and Arch, Debian, and RPM packages now hands them to AppShelf when available.
  - Unsupported files continue opening with the system default handler.
  - AppShelf is now listed as an optional package for supported file types.

- **Bug Fixes**
  - Invalid command-line argument combinations now produce clear usage errors.

- **Documentation**
  - Added documentation describing supported file types and opening behavior.

- **Tests**
  - Added coverage for AppShelf handling and fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->