### PR TITLE
fix: follow outside changes to the open folder

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -176,8 +176,12 @@ sample therefore lands later than the sleep in front of it says.
 `applyAnchor` puts the cursor back on that name when the rows return, because a file created above
 the cursor shifts every index below it and restoring by index alone would move the user onto another
 file. The listing answers from row 0, so a cursor deep in a large directory also asks for its own
-window back and the anchor stands until that window arrives. A name that is gone from both falls
-back to the clamped old index, which keeps the view where the user left it. The filter query is put
+window back and the anchor stands until that window arrives. The wait is on the window and not on a
+number of replies, because `applyAnchor` runs on every rows delivery and a counter was spent by the
+first screenful arriving twice; it ends when the listing has shrunk to that offset or below, the one
+case where the backend clamps the window to row 0 and the reply being waited for is never coming.
+A name that is gone from both falls back to the clamped old index, which keeps the view where the
+user left it. The filter query is put
 back too: it narrows the rows the pane holds rather than choosing which directory it holds.
 
 **The selection is not re-anchored; the re-read waits for it instead.** `ui/js/Selection.js` is a set

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -131,6 +131,62 @@ bytes. A key that is none of the three, `kind` and `mode` included, reaches neit
 phase: `sort.rs`'s `parse_sort_by()` refuses it with the one sentence that names the
 three it accepts.
 
+## The open directory is watched
+
+Issue 68: a folder open in Flea did not follow a create, rename or delete made by another program.
+`list` ran once when the pane arrived, and after that only Flea's own writes re-read the directory,
+so a window kept open beside a terminal drew whatever was true when it was opened.
+
+**The backend watches, the client re-reads.** `backend/watch.rs` holds one non-recursive inotify
+watch on `st.base`, moved by every successful `list` and dropped by `search` and `listpaths`, whose
+listings are not directories. Its reader thread sends the loop an `Event::Changed(wd)`, and the loop
+answers `{"t":"changed","path":"<the directory>"}` and changes nothing else: the rows, the count and
+the sort order stay exactly what they were, because the client is the only thing that knows whether
+it still wants them. See `docs/protocol.md` "changed" for the mask and the coalescing.
+
+**The descriptor is why the payload is read at all.** `inotify_rm_watch` delivers an `IN_IGNORED` for
+the watch it removed, so a reader that treated every wakeup as "something changed" answered one
+`changed` line for every navigation, for the directory the pane had just arrived in. The reader walks
+the burst for its watch descriptors and nothing else, and `Watch::is_current` drops any that is not
+the one being listed now. `tests/protocol.sh`'s "a change in the directory just left answers nothing"
+is that case.
+
+**One burst is one re-read, and it is not restarted.** `ui/PaneWire.qml` starts a 400 ms timer on the
+first `changed` after idle and lets later ones land inside it rather than restarting it: a restart
+would mean a directory under continuous writing never settled and so never refreshed at all. Worst
+case is one full re-scan per 400 ms while something is actively rewriting the folder the user is
+looking at, which is 25 to 38 ms of that on the 100,000 file fixture.
+
+**A re-read is a fresh `list`, so it renumbers every row, and that is what the anchor is for.**
+`ui/js/Nav.js`'s `refreshWatched` records the NAME under the cursor before the re-read and
+`applyAnchor` puts the cursor back on that name when the rows return, because a file created above
+the cursor shifts every index below it and restoring by index alone would move the user onto another
+file. The listing answers from row 0, so a cursor deep in a large directory also asks for its own
+window back and the anchor stands until that window arrives. A name that is gone from both falls
+back to the clamped old index, which keeps the view where the user left it. The filter query is put
+back too: it narrows the rows the pane holds rather than choosing which directory it holds.
+
+**The selection is not re-anchored; the re-read waits for it instead.** `ui/js/Selection.js` is a set
+of row indices and its own rule is that a new listing clears them, because an index into a directory
+that has changed names another file. Re-pointing a selection at other files is how a delete hits the
+wrong ones, so `PaneWire`'s `watchBusy` defers the re-read while a selection stands, and with it
+while a rename editor is open, the context menu is up, a filter is being typed, a search listing is
+showing or a list is already in flight. The debt is kept, not dropped: `onWatchBusyChanged` pays it
+the moment the last of those clears. A user holding a selection therefore sees the same stale
+listing 0.1.4 always showed, for as long as they hold it.
+
+**// corner: this is the local kernel's view of one directory.** A change another machine makes to an
+NFS or SMB share raises no inotify event here, so a network mount is exactly as live as it was
+before. So is a box whose inotify instance limit is exhausted, which says so once on stderr and then
+never sends the line. `IN_MODIFY` is deliberately not in the mask: it fires on every `write(2)` and a
+listing does not draw a partial size, so a row's size follows `IN_CLOSE_WRITE` instead.
+
+**Flea's own writes pay for one extra scan.** A rename, mkdir, trash or transfer already calls
+`pane.refresh()`, and the watch answers for the same write about 400 ms later, so the directory is
+read twice. The second read is anchored the same way and moves nothing the user can see. Suppressing
+it would mean deciding that a `changed` arriving during a listing belongs to that listing, which is
+exactly the guess that would drop a real outside change, so it is paid rather than guessed at.
+
 ## Why the listing is an arena
 
 `Listing` (`listing.rs`) holds one `String` with every entry's name written back to
@@ -935,6 +991,11 @@ this coverage needed no new entry there.
 - `backend/run.rs` the command loop, see "Thumbnail requests". stdin is read on its own
   thread and the pool answers on its own channel, and a forwarder thread joins the two, so
   client requests and worker results arrive on one `recv`, because `std` has no `select`.
+- `backend/events.rs` the `Event` those sources arrive as, and the three threads that join them
+  onto the loop's one channel. It came out of `run.rs` at 398 of the 400 hard cap, and it is one
+  job: how work reaches the loop, as against what the loop does with it.
+- `backend/watch.rs` the one inotify watch on the directory the current listing came from, its
+  reader thread and the `changed` line it answers with, see "The open directory is watched".
 - `heap.rs` pins glibc's mmap threshold for the backend, see "The listing arena returns to the OS".
 - `launcher/mod.rs` re-exports `prewarm`, nothing else.
 - `launcher/prewarm.rs` writes the listing and first screenful before the UI starts.
@@ -955,7 +1016,9 @@ this coverage needed no new entry there.
   settle timer and the row-to-thumbnail map, see "Thumbnail requests in the GUI".
 - `ui/PaneWire.qml` is where every reply from outside the window lands: the backend's, and
   those of the three foreign programs the pane runs (`ui/Opener.qml`, `ui/ShareLink.qml`,
-  `ui/Taildrop.qml`); it owns no state and writes only through the pane handed in.
+  `ui/Taildrop.qml`); it writes through the pane handed in and owns only the state a reply needs
+  before the pane has a row for it: the folder a `made` line will open an editor on, and the
+  watched re-read's debt, timer and cursor anchor, see "The open directory is watched".
 - `ui/Header.qml` renders the column header band and its rule, and owns nothing else: it
   was lifted out of `Pane.qml` at the 400-line hard cap and has no behaviour.
 - `ui/Row.qml` renders one row delegate: the icon slot, which a thumbnail replaces in

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -142,8 +142,9 @@ watch on the directory being listed, armed by `list` BEFORE the scan and dropped
 `listpaths`, whose listings are not directories. Arming after the scan lost every change the scan
 itself raced, a hole the width of one readdir: reproduced on the 100,000 file fixture, where a
 create during the scan answered no `changed` line at all and the same create a second later
-answered one. A `list` that fails to scan puts the watch back on the directory still on screen. Its reader thread sends the loop an `Event::Changed(wd)`, and the loop
-answers `{"t":"changed","path":"<the directory>"}` and changes nothing else: the rows, the count and
+answered one. A `list` that fails to scan puts the watch back on the directory still on screen.
+Its reader thread sends the loop an `Event::Changed(wd)`, and the loop answers
+`{"t":"changed","path":"<the directory>"}` and changes nothing else: the rows, the count and
 the sort order stay exactly what they were, because the client is the only thing that knows whether
 it still wants them. See `docs/protocol.md` "changed" for the mask and the coalescing.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -160,6 +160,10 @@ first `changed` after idle and lets later ones land inside it rather than restar
 would mean a directory under continuous writing never settled and so never refreshed at all. Worst
 case is one full re-scan per 400 ms while something is actively rewriting the folder the user is
 looking at, which is 25 to 38 ms of that on the 100,000 file fixture.
+**The test for this has to sample while the writing is still going**, which is what makes it a
+test: measured after the writer stops, a restarted timer and an absorbing one both show a re-read
+and the check passes either way. `tests/ui.sh watch` reads the count 1.2 s into a background writer
+and gets 27 rows against a restarting timer's 6.
 
 **A re-read is a fresh `list`, so it renumbers every row, and that is what the anchor is for.**
 `ui/js/Nav.js`'s `refreshWatched` records the NAME under the cursor before the re-read and
@@ -177,7 +181,12 @@ wrong ones, so `PaneWire`'s `watchBusy` defers the re-read while a selection sta
 while a rename editor is open, the context menu is up, a filter is being typed, a search listing is
 showing or a list is already in flight. The debt is kept, not dropped: `onWatchBusyChanged` pays it
 the moment the last of those clears. A user holding a selection therefore sees the same stale
-listing 0.1.4 always showed, for as long as they hold it.
+listing 0.1.4 always showed, for as long as they hold it. **The debt does not travel**: leaving the
+directory clears it, because the pane's own `onPathChanged` fires before the navigation clears the
+selection that was holding it, and without that a change in the folder being left was paid for by a
+full re-list of the folder being opened. `ui/Backend.qml`'s `listRequests` counter is what makes
+that assertable, the same idiom as `thumbRequests` and `dirSizeRequests`: `tests/ui.sh watch` counts
+from before the navigation and requires exactly one listing for it.
 
 **// corner: this is the local kernel's view of one directory.** A change another machine makes to an
 NFS or SMB share raises no inotify event here, so a network mount is exactly as live as it was

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -142,7 +142,11 @@ watch on the directory being listed, armed by `list` BEFORE the scan and dropped
 `listpaths`, whose listings are not directories. Arming after the scan lost every change the scan
 itself raced, a hole the width of one readdir: reproduced on the 100,000 file fixture, where a
 create during the scan answered no `changed` line at all and the same create a second later
-answered one. A `list` that fails to scan puts the watch back on the directory still on screen.
+answered one. The new watch is armed BESIDE the current one rather than in place of it, so a scan
+that fails costs the directory still on screen nothing: `commit` drops the old watch only once the
+new listing replaced it, and `abandon` drops the new one when the scan failed. Replacing it up front
+was the first fix and it was wrong, because a failed list then handed the open directory a new
+descriptor and `is_current` dropped anything still carrying the old one.
 Its reader thread sends the loop an `Event::Changed(wd)`, and the loop answers
 `{"t":"changed","path":"<the directory>"}` and changes nothing else: the rows, the count and
 the sort order stay exactly what they were, because the client is the only thing that knows whether
@@ -162,8 +166,10 @@ case is one full re-scan per 400 ms while something is actively rewriting the fo
 looking at, which is 25 to 38 ms of that on the 100,000 file fixture.
 **The test for this has to sample while the writing is still going**, which is what makes it a
 test: measured after the writer stops, a restarted timer and an absorbing one both show a re-read
-and the check passes either way. `tests/ui.sh watch` reads the count 1.2 s into a background writer
-and gets 27 rows against a restarting timer's 6.
+and the check passes either way. `tests/ui.sh watch` samples once inside a background writer's run
+and requires the count to have moved; under `restart()` it does not move at all. No number is
+quoted here on purpose, because each `omarchy-drive ipc` round trip costs 190 to 565 ms and the
+sample therefore lands later than the sleep in front of it says.
 
 **A re-read is a fresh `list`, so it renumbers every row, and that is what the anchor is for.**
 `ui/js/Nav.js`'s `refreshWatched` records the NAME under the cursor before the re-read and

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -138,8 +138,11 @@ Issue 68: a folder open in Flea did not follow a create, rename or delete made b
 so a window kept open beside a terminal drew whatever was true when it was opened.
 
 **The backend watches, the client re-reads.** `backend/watch.rs` holds one non-recursive inotify
-watch on `st.base`, moved by every successful `list` and dropped by `search` and `listpaths`, whose
-listings are not directories. Its reader thread sends the loop an `Event::Changed(wd)`, and the loop
+watch on the directory being listed, armed by `list` BEFORE the scan and dropped by `search` and
+`listpaths`, whose listings are not directories. Arming after the scan lost every change the scan
+itself raced, a hole the width of one readdir: reproduced on the 100,000 file fixture, where a
+create during the scan answered no `changed` line at all and the same create a second later
+answered one. A `list` that fails to scan puts the watch back on the directory still on screen. Its reader thread sends the loop an `Event::Changed(wd)`, and the loop
 answers `{"t":"changed","path":"<the directory>"}` and changes nothing else: the rows, the count and
 the sort order stay exactly what they were, because the client is the only thing that knows whether
 it still wants them. See `docs/protocol.md` "changed" for the mask and the coalescing.

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -903,8 +903,9 @@ The mechanism is one inotify watch on that one directory, non-recursive, with th
 which is exactly the set of events that changes what a listing says: which names are in it, and the
 size, date and mode its columns draw. Deleting the watched directory needs no bit of its own: the
 kernel removes the watch along with it and reports that removal whatever the mask holds.
-**A file growing under an open handle is not one of them.** `IN_MODIFY` fires on every `write(2)` and a listing does not draw a partial size, so
-a row's size follows the writer closing the file rather than the writer writing to it.
+**A file growing under an open handle is not one of them.** `IN_MODIFY` fires on every `write(2)`
+and a listing does not draw a partial size, so a row's size follows the writer closing the file
+rather than the writer writing to it.
 
 **One burst is one line.** The event payload is read only far enough to name its watch descriptor,
 never for which file moved, and the reader then pauses 100 ms before reading again, so a directory

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -891,15 +891,18 @@ that wants the new directory sends `list` again. `path` is the watched directory
 has navigated since the notification was written can tell it is not about the folder it is on now,
 and drop it.
 
-A successful `list` starts watching its path and stops watching the previous one. `search` and
-`listpaths` both stop watching, because a set of matches and a set of named paths are not
-directories. A failed `list` changes nothing, so the directory that is still listed is still the
-one being watched.
+A `list` starts watching its path **before it reads the directory**, not after, because a change
+landing while the read runs is missing from the rows that `list` is about to answer with and is
+therefore exactly the change the client has to be told about. A `list` that then fails to scan puts
+the watch back on the directory that is still listed, so a refused path never costs the open one its
+watch. `search` and `listpaths` both stop watching, because a set of matches and a set of named
+paths are not directories.
 
 The mechanism is one inotify watch on that one directory, non-recursive, with the mask
-`IN_ATTRIB | IN_CLOSE_WRITE | IN_MOVED_FROM | IN_MOVED_TO | IN_CREATE | IN_DELETE | IN_DELETE_SELF |
-IN_MOVE_SELF`, which is exactly the set of events that changes what a listing says: which names are
-in it, and the size, date and mode its columns draw. **A file growing under an open handle is not
+`IN_ATTRIB | IN_CLOSE_WRITE | IN_MOVED_FROM | IN_MOVED_TO | IN_CREATE | IN_DELETE | IN_MOVE_SELF`,
+which is exactly the set of events that changes what a listing says: which names are in it, and the
+size, date and mode its columns draw. Deleting the watched directory needs no bit of its own: the
+kernel removes the watch along with it and reports that removal whatever the mask holds. **A file growing under an open handle is not
 one of them.** `IN_MODIFY` fires on every `write(2)` and a listing does not draw a partial size, so
 a row's size follows the writer closing the file rather than the writer writing to it.
 
@@ -910,8 +913,10 @@ drops in that window costs nothing, because every event in a burst says the same
 that re-reads the whole directory anyway.
 
 `--backend` on a box whose inotify instance limit is exhausted prints one sentence to stderr at
-startup and then never sends this line; every other request answers exactly as before. A client
-must therefore treat a live listing as an improvement it may not get, not as a guarantee. A
+startup and then never sends this line, and a `list` whose directory the kernel refuses a watch on
+(`max_user_watches`, most often) prints one naming that directory; every other request answers
+exactly as before. A client must therefore treat a live listing as an improvement it may not get,
+not as a guarantee. A
 network mount is the other case: inotify sees the local kernel's own view of a directory, so a
 change another machine makes to an NFS or SMB share is not delivered, and Flea is stale there in
 exactly the way it was before this line existed.

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -13,6 +13,9 @@ escaper in `src/json.rs`, dispatched by `src/backend/run.rs`.
 2. Errors are messages, never exit statuses. `--backend` runs until it reads `quit`
    or stdin closes, and returns exit code 0 either way; every failure is an `error`
    line the client reads off stdout, not a process exit code.
+3. Exactly one line arrives unasked: `changed`, which says the listed directory was
+   altered by another program. It can land between any request and its reply, so a
+   client that counts lines rather than reading their `t` field will misread the wire.
 
 ## Requests
 
@@ -873,6 +876,45 @@ Example: `{"t":"undone","op":"move","ok":true}`
 
 `op` is the kind of operation that was reversed, one of `rename`, `duplicate`, `mkdir`, `trash`, `copy`
 or `move`, which is what lets the status bar say what it just put back.
+
+### changed
+
+`{"t":"changed","path":"<string>"}`
+
+Example: `{"t":"changed","path":"/home/gm/Downloads"}`
+
+**The one line no request asks for.** Every other response answers a request; this one says the
+directory the current listing came from is no longer what `list` answered with, because another
+program created, deleted, renamed, wrote or chmod'd something in it. Nothing the backend holds
+changes with it: the rows, the count and the sort order are exactly what they were, and a client
+that wants the new directory sends `list` again. `path` is the watched directory, so a client that
+has navigated since the notification was written can tell it is not about the folder it is on now,
+and drop it.
+
+A successful `list` starts watching its path and stops watching the previous one. `search` and
+`listpaths` both stop watching, because a set of matches and a set of named paths are not
+directories. A failed `list` changes nothing, so the directory that is still listed is still the
+one being watched.
+
+The mechanism is one inotify watch on that one directory, non-recursive, with the mask
+`IN_ATTRIB | IN_CLOSE_WRITE | IN_MOVED_FROM | IN_MOVED_TO | IN_CREATE | IN_DELETE | IN_DELETE_SELF |
+IN_MOVE_SELF`, which is exactly the set of events that changes what a listing says: which names are
+in it, and the size, date and mode its columns draw. **A file growing under an open handle is not
+one of them.** `IN_MODIFY` fires on every `write(2)` and a listing does not draw a partial size, so
+a row's size follows the writer closing the file rather than the writer writing to it.
+
+**One burst is one line.** The event payload is read only far enough to name its watch descriptor,
+never for which file moved, and the reader then pauses 100 ms before reading again, so a directory
+being rewritten costs one `changed` line per 100 ms rather than one per file. Anything the kernel
+drops in that window costs nothing, because every event in a burst says the same thing to a client
+that re-reads the whole directory anyway.
+
+`--backend` on a box whose inotify instance limit is exhausted prints one sentence to stderr at
+startup and then never sends this line; every other request answers exactly as before. A client
+must therefore treat a live listing as an improvement it may not get, not as a guarantee. A
+network mount is the other case: inotify sees the local kernel's own view of a directory, so a
+change another machine makes to an NFS or SMB share is not delivered, and Flea is stale there in
+exactly the way it was before this line existed.
 
 ### error
 

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -902,8 +902,8 @@ The mechanism is one inotify watch on that one directory, non-recursive, with th
 `IN_ATTRIB | IN_CLOSE_WRITE | IN_MOVED_FROM | IN_MOVED_TO | IN_CREATE | IN_DELETE | IN_MOVE_SELF`,
 which is exactly the set of events that changes what a listing says: which names are in it, and the
 size, date and mode its columns draw. Deleting the watched directory needs no bit of its own: the
-kernel removes the watch along with it and reports that removal whatever the mask holds. **A file growing under an open handle is not
-one of them.** `IN_MODIFY` fires on every `write(2)` and a listing does not draw a partial size, so
+kernel removes the watch along with it and reports that removal whatever the mask holds.
+**A file growing under an open handle is not one of them.** `IN_MODIFY` fires on every `write(2)` and a listing does not draw a partial size, so
 a row's size follows the writer closing the file rather than the writer writing to it.
 
 **One burst is one line.** The event payload is read only far enough to name its watch descriptor,

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -893,10 +893,11 @@ and drop it.
 
 A `list` starts watching its path **before it reads the directory**, not after, because a change
 landing while the read runs is missing from the rows that `list` is about to answer with and is
-therefore exactly the change the client has to be told about. A `list` that then fails to scan puts
-the watch back on the directory that is still listed, so a refused path never costs the open one its
-watch. `search` and `listpaths` both stop watching, because a set of matches and a set of named
-paths are not directories.
+therefore exactly the change the client has to be told about. It is armed **beside** the watch the
+client is already on rather than in place of it, so a `list` that then fails to scan costs the
+directory still listed nothing at all: its watch was never removed, and the descriptor its own
+events carry is still the current one. `search` and `listpaths` both stop watching, because a set of
+matches and a set of named paths are not directories.
 
 The mechanism is one inotify watch on that one directory, non-recursive, with the mask
 `IN_ATTRIB | IN_CLOSE_WRITE | IN_MOVED_FROM | IN_MOVED_TO | IN_CREATE | IN_DELETE | IN_MOVE_SELF`,

--- a/src/backend/events.rs
+++ b/src/backend/events.rs
@@ -1,0 +1,62 @@
+// Every source of work the read loop waits on, and the threads that join them onto its one channel.
+// std has no select, so each blocking source is a thread and the loop only ever waits on the receiver.
+use crate::backend::opsreq::OpMsg;
+use crate::backend::thumbs::Done;
+use crate::error::{from_io, FleaError};
+use std::io::{self, BufRead};
+use std::sync::mpsc::{Receiver, Sender};
+use std::thread;
+
+// std has no select, so every source of work reaches the loop as one of these.
+pub enum Event {
+    Request(String),
+    Thumb(Done),
+    // A write operation's own thread reports here, so the loop stays the only writer of stdout.
+    Op(OpMsg),
+    // The watch descriptor that saw it, so a burst belonging to the directory the client has already
+    // left is dropped rather than answered for the new one; see src/backend/watch.rs.
+    Changed(i32),
+    ReadError(FleaError),
+    Closed,
+}
+
+// stdin blocks, so reading it is a thread and the loop only ever waits on the channel.
+pub fn spawn_reader(tx: Sender<Event>) {
+    thread::spawn(move || {
+        let stdin = io::stdin();
+        for line in stdin.lock().lines() {
+            let event = match line {
+                Ok(l) => Event::Request(l),
+                // The reader has no writer, so the decode failure is handed back for the loop to report.
+                Err(e) => Event::ReadError(from_io("read", "stdin", &e)),
+            };
+            let fatal = matches!(event, Event::ReadError(_));
+            if tx.send(event).is_err() || fatal {
+                return;
+            }
+        }
+        let _ = tx.send(Event::Closed);
+    });
+}
+
+// An operation thread answers on its own channel, joined onto the loop's receiver the same way the pool's is.
+pub fn spawn_op_forwarder(results: Receiver<OpMsg>, tx: Sender<Event>) {
+    thread::spawn(move || {
+        for msg in results {
+            if tx.send(Event::Op(msg)).is_err() {
+                return;
+            }
+        }
+    });
+}
+
+// The pool answers on its own channel, so one thread joins the two onto the single receiver the loop waits on.
+pub fn spawn_forwarder(results: Receiver<Done>, tx: Sender<Event>) {
+    thread::spawn(move || {
+        for done in results {
+            if tx.send(Event::Thumb(done)).is_err() {
+                return;
+            }
+        }
+    });
+}

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -16,6 +16,7 @@ pub mod linecount;
 pub mod dirsize;
 pub mod dirsizereq;
 pub mod listpaths;
+pub mod events;
 pub mod scan;
 pub mod fuzzy;
 pub mod search;
@@ -51,6 +52,8 @@ mod mountinfo;
 mod renamecompat;
 pub mod trash;
 pub mod undo;
+// The open listing's directory, watched so an outside change reaches the client; see docs/protocol.md "changed".
+pub mod watch;
 // Test-only: hard rule 9's sandbox root, so no destructive test names a path outside one.
 #[cfg(test)]
 pub mod testdir;

--- a/src/backend/run.rs
+++ b/src/backend/run.rs
@@ -35,7 +35,7 @@ use crate::heap;
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::io::{self, BufWriter, Write};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::mpsc::{channel, Receiver, TryRecvError};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -162,20 +162,28 @@ fn handle_line(
             if finish_search(out, st, true) {
                 forget_rows(st, pool);
             }
+            // Before the scan and not after it: a change landing while readdir runs is missing from the
+            // rows this answers with, so it is exactly the change the client has to be told about.
+            watch.follow(Path::new(&path));
             match scan(&path, hidden) {
                 Ok((mut l, read_ms)) => {
                     let sort_ms = sort_by_name(&mut l, false);
                     // base and listing only move together, so a failed list cannot mix them.
                     st.base = PathBuf::from(&path);
                     st.listing = l;
-                    // The listing moved, so the watch moves with it, before any reply names it.
-                    watch.follow(&st.base);
                     forget_rows(st, pool);
+                    // Said once per listing that got one, because a directory nobody can watch is a
+                    // directory that goes stale in silence; see docs/protocol.md "changed".
+                    if !watch.watching() {
+                        eprintln!("flea: {} will not follow outside changes, inotify refused a watch on it", path);
+                    }
                     writeln!(out, "{}", listed_line(st.listing.len(), read_ms, sort_ms, dev_of(&st.base))).ok();
                     // Rides along unasked: asking costs a 60 ms round trip at first paint.
                     write_window(out, st, 0, first, tb);
                 }
                 Err(e) => {
+                    // The listing did not move, so the watch goes back to the directory still on screen.
+                    watch.follow(&st.base);
                     // A typed path reaches the denial with no parent row to remember the mode from,
                     // so the stat that survives the refused read is the pane's only source for it.
                     writeln!(out, "{}", error_line_with_mode(&e, mode_of(&path))).ok();

--- a/src/backend/run.rs
+++ b/src/backend/run.rs
@@ -162,19 +162,21 @@ fn handle_line(
             if finish_search(out, st, true) {
                 forget_rows(st, pool);
             }
-            // Before the scan and not after it: a change landing while readdir runs is missing from the
-            // rows this answers with, so it is exactly the change the client has to be told about.
-            watch.follow(Path::new(&path));
+            // Before the scan and beside the current watch, not in place of it: a change landing while
+            // readdir runs is missing from the rows this answers with, and a scan that fails must not
+            // cost the directory still on screen the descriptor its own events carry.
+            watch.begin(Path::new(&path));
             match scan(&path, hidden) {
                 Ok((mut l, read_ms)) => {
                     let sort_ms = sort_by_name(&mut l, false);
                     // base and listing only move together, so a failed list cannot mix them.
                     st.base = PathBuf::from(&path);
                     st.listing = l;
+                    watch.commit();
                     forget_rows(st, pool);
-                    // Said once per listing that got one, because a directory nobody can watch is a
-                    // directory that goes stale in silence; see docs/protocol.md "changed".
-                    if !watch.watching() {
+                    // Said once per listing, because a directory nobody can watch goes stale in
+                    // silence; see docs/protocol.md "changed".
+                    if watch.refused() {
                         eprintln!("flea: {} will not follow outside changes, inotify refused a watch on it", path);
                     }
                     writeln!(out, "{}", listed_line(st.listing.len(), read_ms, sort_ms, dev_of(&st.base))).ok();
@@ -182,8 +184,8 @@ fn handle_line(
                     write_window(out, st, 0, first, tb);
                 }
                 Err(e) => {
-                    // The listing did not move, so the watch goes back to the directory still on screen.
-                    watch.follow(&st.base);
+                    // The listing did not move, so neither does its watch.
+                    watch.abandon();
                     // A typed path reaches the denial with no parent row to remember the mode from,
                     // so the stat that survives the refused read is the pane's only source for it.
                     writeln!(out, "{}", error_line_with_mode(&e, mode_of(&path))).ok();

--- a/src/backend/run.rs
+++ b/src/backend/run.rs
@@ -162,8 +162,7 @@ fn handle_line(
             if finish_search(out, st, true) {
                 forget_rows(st, pool);
             }
-            // Beside the current watch and before the scan: a change readdir raced is missing from the
-            // rows this answers with, and a failed scan must not cost the open folder its descriptor.
+            // Before the scan, because a change readdir raced is missing from the rows this answers with.
             watch.begin(Path::new(&path));
             match scan(&path, hidden) {
                 Ok((mut l, read_ms)) => {
@@ -173,8 +172,7 @@ fn handle_line(
                     st.listing = l;
                     watch.commit();
                     forget_rows(st, pool);
-                    // Said once per listing, because a directory nobody can watch goes stale in
-                    // silence; see docs/protocol.md "changed".
+                    // Said once per listing, because a folder nobody can watch goes stale in silence.
                     if watch.refused() {
                         eprintln!("flea: {} will not follow outside changes, inotify refused a watch on it", path);
                     }

--- a/src/backend/run.rs
+++ b/src/backend/run.rs
@@ -11,6 +11,7 @@ use crate::backend::opsdispatch::{cancel_transfer, do_mkdir, do_rename, do_undo,
 use crate::backend::opsreq::OpMsg;
 use crate::backend::mime::Db;
 use crate::backend::dirsizereq::{queue_dirsizes, walk_one_dirsize};
+use crate::backend::events::{spawn_forwarder, spawn_op_forwarder, spawn_reader, Event};
 use crate::backend::fsinfo::{fsinfo_line, read as read_fsinfo};
 use crate::backend::fsinfo::dev_of;
 use crate::backend::listpaths;
@@ -27,16 +28,16 @@ use crate::backend::thumbcache::{default_root, Cache};
 use crate::backend::thumbreq::{cancel_row, forget_one, report_done, thumb_rows};
 use crate::backend::thumbs::{Done, Pool};
 use crate::backend::thumbwrite::sweep_own_temps;
+use crate::backend::watch::{changed_line, Watch};
 use crate::backend::thumbspec::Thumbnailers;
-use crate::error::{from_io, FleaError};
+use crate::error::FleaError;
 use crate::heap;
 use std::cell::RefCell;
 use std::collections::HashMap;
-use std::io::{self, BufRead, BufWriter, Write};
+use std::io::{self, BufWriter, Write};
 use std::path::PathBuf;
-use std::sync::mpsc::{channel, Receiver, Sender, TryRecvError};
+use std::sync::mpsc::{channel, Receiver, TryRecvError};
 use std::sync::Arc;
-use std::thread;
 use std::time::{Duration, Instant};
 
 // Wider pools settle sooner and answer input later, and 4 is the widest that costs neither the first thumbnail nor the scroll; see AGENTS.md "Thumbnail requests".
@@ -44,62 +45,11 @@ const THUMB_WORKERS: usize = 4;
 // The whole shutdown budget: a running job is killed at the pool's own 20 s deadline, so waiting longer than that can never cut one short.
 const DRAIN_LIMIT: Duration = Duration::from_secs(25);
 
-// std has no select, so every source of work reaches the loop as one of these.
-enum Event {
-    Request(String),
-    Thumb(Done),
-    // A write operation's own thread reports here, so the loop stays the only writer of stdout.
-    Op(OpMsg),
-    ReadError(FleaError),
-    Closed,
-}
-
 // The loop stops on Quit; every other request continues it, because errors are responses.
 #[derive(PartialEq)]
 enum Control {
     Continue,
     Quit,
-}
-
-// stdin blocks, so reading it is a thread and the loop only ever waits on the channel.
-fn spawn_reader(tx: Sender<Event>) {
-    thread::spawn(move || {
-        let stdin = io::stdin();
-        for line in stdin.lock().lines() {
-            let event = match line {
-                Ok(l) => Event::Request(l),
-                // The reader has no writer, so the decode failure is handed back for the loop to report.
-                Err(e) => Event::ReadError(from_io("read", "stdin", &e)),
-            };
-            let fatal = matches!(event, Event::ReadError(_));
-            if tx.send(event).is_err() || fatal {
-                return;
-            }
-        }
-        let _ = tx.send(Event::Closed);
-    });
-}
-
-// An operation thread answers on its own channel, joined onto the loop's receiver the same way the pool's is.
-fn spawn_op_forwarder(results: Receiver<OpMsg>, tx: Sender<Event>) {
-    thread::spawn(move || {
-        for msg in results {
-            if tx.send(Event::Op(msg)).is_err() {
-                return;
-            }
-        }
-    });
-}
-
-// The pool answers on its own channel, so one thread joins the two onto the single receiver the loop waits on.
-fn spawn_forwarder(results: Receiver<Done>, tx: Sender<Event>) {
-    thread::spawn(move || {
-        for done in results {
-            if tx.send(Event::Thumb(done)).is_err() {
-                return;
-            }
-        }
-    });
 }
 
 // Errors are responses, so the loop never exits on a bad request.
@@ -142,7 +92,9 @@ pub fn run() -> i32 {
     // The workers hold senders too, so no exit can come from a disconnect and every exit is an explicit event; see AGENTS.md "Thumbnail requests".
     spawn_forwarder(done, tx.clone());
     spawn_op_forwarder(op_rx, tx.clone());
-    spawn_reader(tx);
+    spawn_reader(tx.clone());
+    // Armed before the first request, so no listing is ever answered with nothing watching it.
+    let mut watch = Watch::start(tx);
     loop {
         // Idle (nothing queued and no walk running) this is exactly the old blocking recv, see docs/protocol.md "dirsize".
         let event = if st.dirsize_queue.is_empty() && st.search.is_none() {
@@ -163,11 +115,17 @@ pub fn run() -> i32 {
         };
         match event {
             Event::Request(line) => {
-                if handle_line(&line, &mut out, &mut st, &tb, &pool, &cache, &mut ops) == Control::Quit {
+                if handle_line(&line, &mut out, &mut st, &tb, &pool, &cache, &mut ops, &mut watch) == Control::Quit {
                     break;
                 }
             }
             Event::Thumb(d) => report_done(&mut out, &mut st, d),
+            // The one line no client asked for, and only ever for the directory being listed now.
+            Event::Changed(wd) => {
+                if watch.is_current(wd) {
+                    say(&mut out, &changed_line(&st.base));
+                }
+            }
             Event::Op(m) => report_op(&mut out, &mut ops, m),
             Event::ReadError(e) => {
                 // The framing cannot be trusted past a decode failure, so this reports and stops, as before.
@@ -196,6 +154,7 @@ fn handle_line(
     pool: &Pool,
     cache: &Cache,
     ops: &mut Ops,
+    watch: &mut Watch,
 ) -> Control {
     match parse_request(line) {
         Request::List { path, first, hidden } => {
@@ -209,6 +168,8 @@ fn handle_line(
                     // base and listing only move together, so a failed list cannot mix them.
                     st.base = PathBuf::from(&path);
                     st.listing = l;
+                    // The listing moved, so the watch moves with it, before any reply names it.
+                    watch.follow(&st.base);
                     forget_rows(st, pool);
                     writeln!(out, "{}", listed_line(st.listing.len(), read_ms, sort_ms, dev_of(&st.base))).ok();
                     // Rides along unasked: asking costs a 60 ms round trip at first paint.
@@ -222,8 +183,11 @@ fn handle_line(
             }
             out.flush().ok();
         }
-        Request::ListPaths { paths, first } =>
-            listpaths::answer(out, st, pool, tb, &paths, first),
+        // A set of named paths is not a directory, so the watch stops rather than following its base.
+        Request::ListPaths { paths, first } => {
+            watch.stop();
+            listpaths::answer(out, st, pool, tb, &paths, first)
+        }
         Request::Window { start, count } => {
             write_window(out, st, start, count, tb);
             out.flush().ok();
@@ -234,6 +198,8 @@ fn handle_line(
             }
             st.base = PathBuf::from(&path);
             st.listing = Listing::new();
+            // A walk's matches are not a directory either, so nothing is watched until list asks again.
+            watch.stop();
             forget_rows(st, pool);
             // The client is told at once that its old rows are gone, then the count grows as matches arrive.
             writeln!(out, "{}", listed_line(0, 0.0, 0.0, dev_of(&st.base))).ok();

--- a/src/backend/run.rs
+++ b/src/backend/run.rs
@@ -162,9 +162,8 @@ fn handle_line(
             if finish_search(out, st, true) {
                 forget_rows(st, pool);
             }
-            // Before the scan and beside the current watch, not in place of it: a change landing while
-            // readdir runs is missing from the rows this answers with, and a scan that fails must not
-            // cost the directory still on screen the descriptor its own events carry.
+            // Beside the current watch and before the scan: a change readdir raced is missing from the
+            // rows this answers with, and a failed scan must not cost the open folder its descriptor.
             watch.begin(Path::new(&path));
             match scan(&path, hidden) {
                 Ok((mut l, read_ms)) => {

--- a/src/backend/watch.rs
+++ b/src/backend/watch.rs
@@ -3,6 +3,7 @@
 // poll because a poll wakes this process forever to learn that nothing happened.
 use crate::backend::events::Event;
 use crate::json::escape;
+use std::io;
 use std::ffi::{c_char, c_int, c_void, CString};
 use std::path::Path;
 use std::sync::mpsc::Sender;
@@ -17,7 +18,8 @@ const IN_MOVED_FROM: u32 = 0x0000_0040;
 const IN_MOVED_TO: u32 = 0x0000_0080;
 const IN_CREATE: u32 = 0x0000_0100;
 const IN_DELETE: u32 = 0x0000_0200;
-const IN_DELETE_SELF: u32 = 0x0000_0400;
+// Not IN_DELETE_SELF: the kernel removes the watch with the directory and sends IN_IGNORED whatever
+// the mask says, so the bit was measured to change nothing and the removal is the event.
 const IN_MOVE_SELF: u32 = 0x0000_0800;
 const MASK: u32 = IN_ATTRIB
     | IN_CLOSE_WRITE
@@ -25,7 +27,6 @@ const MASK: u32 = IN_ATTRIB
     | IN_MOVED_TO
     | IN_CREATE
     | IN_DELETE
-    | IN_DELETE_SELF
     | IN_MOVE_SELF;
 
 // IN_CLOEXEC is O_CLOEXEC, so no thumbnailer child inherits this descriptor.
@@ -35,8 +36,8 @@ const EVENT_HEADER: usize = 16;
 // Every event in one burst says the same thing to a client that re-reads the whole directory, so the
 // thread pauses after a burst and a thousand writes cost one line instead of a thousand.
 const COALESCE: Duration = Duration::from_millis(100);
-// A burst larger than this overflows in the kernel, which costs nothing here: the payload is only
-// ever read for its watch descriptor, never for which file moved.
+// A batch size and not a limit: one read takes whole events only and leaves the rest queued for the
+// next one, and the kernel's own drop happens at max_queued_events, which this does not bound.
 const BUF: usize = 8192;
 
 extern "C" {
@@ -88,6 +89,12 @@ impl Watch {
         self.wd = -1;
     }
 
+    // Whether a directory is being followed right now, which src/backend/run.rs reports on once the
+    // listing it belongs to succeeded; a refusal before that belongs to a path that was never listed.
+    pub fn watching(&self) -> bool {
+        self.wd >= 0
+    }
+
     // A removed watch's own IN_IGNORED is delivered after inotify_rm_watch returns, so a burst is
     // this directory's only while its descriptor still matches; without this every navigation would
     // answer one changed line for the directory it had just arrived in.
@@ -102,8 +109,16 @@ fn pump(fd: c_int, tx: Sender<Event>) {
     let mut buf = [0u8; BUF];
     loop {
         let n = unsafe { read(fd, buf.as_mut_ptr() as *mut c_void, BUF) };
-        // A closed or broken descriptor ends the thread; the loop keeps running without a watch.
-        if n <= 0 {
+        if n < 0 {
+            // A signal can cut a blocking read short, which is not the descriptor going away.
+            if io::Error::last_os_error().kind() == io::ErrorKind::Interrupted {
+                continue;
+            }
+            eprintln!("flea: the open folder stopped following outside changes, the inotify read failed");
+            return;
+        }
+        // A closed descriptor ends the thread; the loop keeps running without a watch.
+        if n == 0 {
             return;
         }
         for wd in descriptors(&buf[..n as usize]) {
@@ -126,12 +141,9 @@ fn descriptors(buf: &[u8]) -> Vec<i32> {
         if !out.contains(&wd) {
             out.push(wd);
         }
-        let step = EVENT_HEADER + len;
-        // A truncated tail is not a header, so it ends the walk rather than being read past the end.
-        if step > buf.len() - at {
-            break;
-        }
-        at += step;
+        // A tail too short to hold another header ends the walk, which is also what stops a truncated
+        // one being read past the end: at overshoots and the condition above is what refuses it.
+        at += EVENT_HEADER + len;
     }
     out
 }
@@ -171,7 +183,7 @@ mod tests {
         assert_eq!(descriptors(&buf), vec![3, 4]);
     }
 
-    // A read can end mid-event; the walk stops there rather than reading a length past the buffer.
+    // A read can end mid-event: the last complete header is still named and nothing is read past the end.
     #[test]
     fn a_truncated_tail_ends_the_walk() {
         let mut buf = event(3, b"a.txt\0\0\0");

--- a/src/backend/watch.rs
+++ b/src/backend/watch.rs
@@ -1,6 +1,4 @@
-// The directory the current listing came from, watched so a change another program makes reaches the
-// client without the user leaving the folder; see docs/protocol.md "changed". inotify rather than a
-// poll because a poll wakes this process forever to learn that nothing happened.
+// The listed directory, watched so an outside change reaches the client; see docs/protocol.md.
 use crate::backend::events::Event;
 use crate::json::escape;
 use std::io;
@@ -10,16 +8,14 @@ use std::sync::mpsc::Sender;
 use std::thread;
 use std::time::Duration;
 
-// Exactly the events that change what a listing says: which names are in it, and the size, date and
-// mode its columns draw. A file growing under an open handle is not one of them, see AGENTS.md.
+// Exactly the events that change what a listing draws; a file still being written is not one.
 const IN_ATTRIB: u32 = 0x0000_0004;
 const IN_CLOSE_WRITE: u32 = 0x0000_0008;
 const IN_MOVED_FROM: u32 = 0x0000_0040;
 const IN_MOVED_TO: u32 = 0x0000_0080;
 const IN_CREATE: u32 = 0x0000_0100;
 const IN_DELETE: u32 = 0x0000_0200;
-// Not IN_DELETE_SELF: the kernel removes the watch with the directory and sends IN_IGNORED whatever
-// the mask says, so the bit was measured to change nothing and the removal is the event.
+// Not IN_DELETE_SELF: the watch's own removal is reported whatever the mask holds, measured.
 const IN_MOVE_SELF: u32 = 0x0000_0800;
 const MASK: u32 = IN_ATTRIB
     | IN_CLOSE_WRITE
@@ -33,11 +29,9 @@ const MASK: u32 = IN_ATTRIB
 const IN_CLOEXEC: c_int = 0x0008_0000;
 // One inotify_event is a watch descriptor, a mask, a cookie and a name length, then the name.
 const EVENT_HEADER: usize = 16;
-// Every event in one burst says the same thing to a client that re-reads the whole directory, so the
-// thread pauses after a burst and a thousand writes cost one line instead of a thousand.
+// One burst says one thing to a client that re-reads it all, so a thousand writes cost one line.
 const COALESCE: Duration = Duration::from_millis(100);
-// A batch size and not a limit: a read takes whole events only and leaves the rest queued for the
-// next one, and the kernel's own drop happens at max_queued_events, which this does not bound.
+// A batch size and not a limit: the kernel's own drop is at max_queued_events, which this misses.
 const BUF: usize = 8192;
 
 extern "C" {
@@ -47,8 +41,7 @@ extern "C" {
     fn read(fd: c_int, buf: *mut c_void, count: usize) -> isize;
 }
 
-// One directory at a time, plus the one a scan is currently reading. A negative fd is a box with no
-// inotify left to give, and a negative descriptor is nothing watched.
+// One directory at a time plus the one a scan is reading; a negative descriptor is nothing watched.
 pub struct Watch {
     fd: c_int,
     wd: c_int,
@@ -56,8 +49,7 @@ pub struct Watch {
 }
 
 impl Watch {
-    // A box that cannot hand out an inotify descriptor still gets a file manager: this reports no
-    // watch on stderr rather than refusing to start, and the listing is then as live as 0.1.4's was.
+    // A box with no inotify still gets a file manager, as live as 0.1.4's was, and is told once.
     pub fn start(tx: Sender<Event>) -> Watch {
         let fd = unsafe { inotify_init1(IN_CLOEXEC) };
         if fd < 0 {
@@ -68,16 +60,13 @@ impl Watch {
         Watch { fd, wd: -1, incoming: -1 }
     }
 
-    // Armed before a scan, alongside the watch the client is still on rather than in place of it, so
-    // a scan that fails costs that directory nothing and a change during the scan is still seen.
+    // Armed beside the current watch, so a scan that fails costs the open folder nothing.
     pub fn begin(&mut self, path: &Path) {
         self.drop_one(self.incoming);
         self.incoming = self.add(path);
     }
 
-    // The new listing replaced the old, so the directory it replaced stops being watched. A re-list of
-    // the SAME directory answers the descriptor it already had, so dropping it here would remove the
-    // watch this just re-armed and leave the folder followed by nothing.
+    // A re-list answers the descriptor the folder already had, so dropping it would unwatch it.
     pub fn commit(&mut self) {
         if self.incoming != self.wd {
             self.drop_one(self.wd);
@@ -86,9 +75,11 @@ impl Watch {
         self.incoming = -1;
     }
 
-    // The scan failed, so the listing did not move and neither did its watch.
+    // The scan failed, so the listing did not move and neither does its watch, aliased or not.
     pub fn abandon(&mut self) {
-        self.drop_one(self.incoming);
+        if self.incoming != self.wd {
+            self.drop_one(self.incoming);
+        }
         self.incoming = -1;
     }
 
@@ -101,8 +92,7 @@ impl Watch {
         self.incoming = -1;
     }
 
-    // A directory that cannot be watched is not an error the client can act on: it listed fine, and
-    // the only consequence is the listing this build shipped before the watch existed.
+    // A directory that cannot be watched is not an error the client can act on: it listed fine.
     fn add(&self, path: &Path) -> c_int {
         if self.fd < 0 {
             return -1;
@@ -119,22 +109,18 @@ impl Watch {
         }
     }
 
-    // A directory this box could have watched and did not, which is the only case worth a sentence
-    // per listing: with no inotify instance at all, Watch::start already said so once at startup.
+    // A directory this box could have watched and did not; no inotify at all is said once at startup.
     pub fn refused(&self) -> bool {
         self.fd >= 0 && self.wd < 0
     }
 
-    // A removed watch's own IN_IGNORED is delivered after inotify_rm_watch returns, so a burst is
-    // this directory's only while its descriptor still matches; without this every navigation would
-    // answer one changed line for the directory it had just arrived in.
+    // A removed watch's own IN_IGNORED arrives late, so only a matching descriptor is this folder's.
     pub fn is_current(&self, wd: i32) -> bool {
         self.wd >= 0 && wd == self.wd
     }
 }
 
-// Sample input: one 16 byte header then the name, wd 1, mask 0x00000100 (IN_CREATE), cookie 0,
-// len 16, "NEWFILE.txt\0\0\0\0\0".
+// Sample input: wd 1, mask 0x00000100, cookie 0, len 16, then "NEWFILE.txt\0\0\0\0\0".
 fn pump(fd: c_int, tx: Sender<Event>) {
     let mut buf = [0u8; BUF];
     loop {
@@ -161,8 +147,7 @@ fn pump(fd: c_int, tx: Sender<Event>) {
     }
 }
 
-// Which watches this burst touched, each named once. Nothing past the descriptor is read, because
-// the loop only has to know whether the burst belongs to the directory it is listing now.
+// Which watches this burst touched, each once; nothing past the descriptor is ever read.
 fn descriptors(buf: &[u8]) -> Vec<i32> {
     let mut out: Vec<i32> = Vec::new();
     let mut at = 0;
@@ -172,16 +157,13 @@ fn descriptors(buf: &[u8]) -> Vec<i32> {
         if !out.contains(&wd) {
             out.push(wd);
         }
-        // inotify hands back whole events only, so this can only overshoot on a buffer that did not
-        // come from one; the condition above is the bound that keeps the indexing inside the slice.
+        // The condition above is the bound that keeps this indexing inside the slice.
         at += EVENT_HEADER + len;
     }
     out
 }
 
-// The one unsolicited line on the wire: the client asked for a listing, and this says the directory
-// that listing came from is no longer what it answered with. path is that directory, so a client
-// that has since moved can tell whose notification it is holding.
+// The one unsolicited line: the listed directory is no longer what the listing answered with.
 pub fn changed_line(path: &Path) -> String {
     format!(r#"{{"t":"changed","path":"{}"}}"#, escape(&path.to_string_lossy()))
 }
@@ -235,8 +217,7 @@ mod tests {
         assert!(!w.is_current(1));
     }
 
-    // These build a Watch with no descriptor, so add and drop_one are no-ops: what they pin is which
-    // descriptor the bookkeeping calls current, and tests/protocol.sh pins what the syscalls do.
+    // No descriptor here, so these pin the bookkeeping alone; tests/protocol.sh pins the syscalls.
     #[test]
     fn an_abandoned_scan_leaves_the_current_watch_alone() {
         let mut w = Watch { fd: -1, wd: 7, incoming: -1 };

--- a/src/backend/watch.rs
+++ b/src/backend/watch.rs
@@ -217,7 +217,99 @@ mod tests {
         assert!(!w.is_current(1));
     }
 
-    // No descriptor here, so these pin the bookkeeping alone; tests/protocol.sh pins the syscalls.
+    // O_NONBLOCK, so a watch this test killed fails it by answering nothing rather than by hanging.
+    const IN_NONBLOCK: c_int = 0x800;
+
+    // Made with create_dir, which fails rather than adopting a directory that was already there, so the
+    // removal below can only ever reach a path that did not exist a moment earlier; see AGENTS.md.
+    struct Sandbox(std::path::PathBuf);
+
+    impl Sandbox {
+        fn new(name: &str) -> Sandbox {
+            let unique = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_nanos())
+                .unwrap_or(0);
+            let dir = std::env::temp_dir()
+                .join(format!("flea-watch-{}-{}-{}", std::process::id(), name, unique));
+            std::fs::create_dir(&dir).expect("a directory no other run already held");
+            Sandbox(dir)
+        }
+    }
+
+    impl Drop for Sandbox {
+        fn drop(&mut self) {
+            // Checked in the test and not in the reviewer's head: absolute, under the temp root, named.
+            let ours = self.0.is_absolute()
+                && self.0.starts_with(std::env::temp_dir())
+                && self.0.file_name().map_or(false, |n| n.to_string_lossy().starts_with("flea-watch-"));
+            if !ours {
+                eprintln!("flea test: refusing to remove {}", self.0.display());
+                return;
+            }
+            // Not a panic: this runs while a failing test is already unwinding, and two would abort.
+            if let Err(e) = std::fs::remove_dir_all(&self.0) {
+                eprintln!("flea test: {} was left behind: {}", self.0.display(), e);
+            }
+        }
+    }
+
+    // Sample input: wd 1, mask 0x00000100, cookie 0, len 16, then "NEWFILE.txt\0\0\0\0\0".
+    fn carries_a_create(buf: &[u8], wd: c_int) -> bool {
+        let mut at = 0;
+        while at + EVENT_HEADER <= buf.len() {
+            let this = i32::from_ne_bytes([buf[at], buf[at + 1], buf[at + 2], buf[at + 3]]);
+            let mask = u32::from_ne_bytes([buf[at + 4], buf[at + 5], buf[at + 6], buf[at + 7]]);
+            let len = u32::from_ne_bytes([buf[at + 12], buf[at + 13], buf[at + 14], buf[at + 15]]) as usize;
+            // The mask and not the descriptor, because a removed watch's own IN_IGNORED carries it too.
+            if this == wd && (mask & IN_CREATE) != 0 {
+                return true;
+            }
+            at += EVENT_HEADER + len;
+        }
+        false
+    }
+
+    // Two seconds all told, which is the kernel queueing being slow rather than the watch being gone.
+    const TRIES: usize = 200;
+    const BETWEEN_TRIES: Duration = Duration::from_millis(10);
+
+    // The kernel queues on its own schedule, so this reads until the create lands or the tries run out.
+    fn saw_a_create(fd: c_int, wd: c_int) -> bool {
+        let mut buf = [0u8; BUF];
+        for _ in 0..TRIES {
+            let n = unsafe { read(fd, buf.as_mut_ptr() as *mut c_void, BUF) };
+            if n > 0 && carries_a_create(&buf[..n as usize], wd) {
+                return true;
+            }
+            thread::sleep(BETWEEN_TRIES);
+        }
+        false
+    }
+
+    // inotify_add_watch answers the descriptor the folder already holds, so an abandoned re-list of the
+    // directory on screen must not remove it. This one carries a real descriptor because the two below
+    // run at fd -1, where drop_one makes no syscall and the guard therefore has nothing to show.
+    #[test]
+    fn an_abandoned_re_list_of_the_same_folder_keeps_its_watch() {
+        let sandbox = Sandbox::new("abandon");
+        let fd = unsafe { inotify_init1(IN_CLOEXEC | IN_NONBLOCK) };
+        assert!(fd >= 0, "this box has no inotify to test with");
+        let mut w = Watch { fd, wd: -1, incoming: -1 };
+        w.begin(&sandbox.0);
+        w.commit();
+        let live = w.wd;
+        assert!(live >= 0, "the sandbox could not be watched");
+
+        w.begin(&sandbox.0);
+        assert_eq!(w.incoming, live, "a re-list of one inode aliases onto the descriptor it has");
+        w.abandon();
+
+        std::fs::write(sandbox.0.join("after-an-abandoned-relist.txt"), b"x").expect("a file in the sandbox");
+        assert!(saw_a_create(fd, live), "the abandoned re-list took the open folder's watch with it");
+    }
+
+    // No descriptor in these two, so they pin the bookkeeping alone; the one above pins the syscall.
     #[test]
     fn an_abandoned_scan_leaves_the_current_watch_alone() {
         let mut w = Watch { fd: -1, wd: 7, incoming: -1 };

--- a/src/backend/watch.rs
+++ b/src/backend/watch.rs
@@ -36,7 +36,7 @@ const EVENT_HEADER: usize = 16;
 // Every event in one burst says the same thing to a client that re-reads the whole directory, so the
 // thread pauses after a burst and a thousand writes cost one line instead of a thousand.
 const COALESCE: Duration = Duration::from_millis(100);
-// A batch size and not a limit: one read takes whole events only and leaves the rest queued for the
+// A batch size and not a limit: a read takes whole events only and leaves the rest queued for the
 // next one, and the kernel's own drop happens at max_queued_events, which this does not bound.
 const BUF: usize = 8192;
 
@@ -47,11 +47,12 @@ extern "C" {
     fn read(fd: c_int, buf: *mut c_void, count: usize) -> isize;
 }
 
-// One directory at a time, because the backend holds one listing at a time. A negative fd is a box
-// with no inotify left to give, and a negative wd is nothing watched right now.
+// One directory at a time, plus the one a scan is currently reading. A negative fd is a box with no
+// inotify left to give, and a negative descriptor is nothing watched.
 pub struct Watch {
     fd: c_int,
     wd: c_int,
+    incoming: c_int,
 }
 
 impl Watch {
@@ -61,38 +62,61 @@ impl Watch {
         let fd = unsafe { inotify_init1(IN_CLOEXEC) };
         if fd < 0 {
             eprintln!("flea: the open folder will not follow outside changes, inotify is unavailable");
-            return Watch { fd: -1, wd: -1 };
+            return Watch { fd: -1, wd: -1, incoming: -1 };
         }
         thread::spawn(move || pump(fd, tx));
-        Watch { fd, wd: -1 }
+        Watch { fd, wd: -1, incoming: -1 }
     }
 
-    // The listing moved, so the old watch goes before the new one is added.
-    pub fn follow(&mut self, path: &Path) {
-        self.stop();
-        if self.fd < 0 {
-            return;
-        }
-        let c = match CString::new(path.as_os_str().as_encoded_bytes()) {
-            Ok(c) => c,
-            Err(_) => return,
-        };
-        // A directory that cannot be watched is not an error the client can act on: it listed fine,
-        // and the only consequence is the listing this build shipped before the watch existed.
-        self.wd = unsafe { inotify_add_watch(self.fd, c.as_ptr(), MASK) };
+    // Armed before a scan, alongside the watch the client is still on rather than in place of it, so
+    // a scan that fails costs that directory nothing and a change during the scan is still seen.
+    pub fn begin(&mut self, path: &Path) {
+        self.drop_one(self.incoming);
+        self.incoming = self.add(path);
+    }
+
+    // The new listing replaced the old, so the directory it replaced stops being watched.
+    pub fn commit(&mut self) {
+        self.drop_one(self.wd);
+        self.wd = self.incoming;
+        self.incoming = -1;
+    }
+
+    // The scan failed, so the listing did not move and neither did its watch.
+    pub fn abandon(&mut self) {
+        self.drop_one(self.incoming);
+        self.incoming = -1;
     }
 
     pub fn stop(&mut self) {
-        if self.fd >= 0 && self.wd >= 0 {
-            unsafe { inotify_rm_watch(self.fd, self.wd) };
-        }
+        self.drop_one(self.wd);
+        self.drop_one(self.incoming);
         self.wd = -1;
+        self.incoming = -1;
     }
 
-    // Whether a directory is being followed right now, which src/backend/run.rs reports on once the
-    // listing it belongs to succeeded; a refusal before that belongs to a path that was never listed.
-    pub fn watching(&self) -> bool {
-        self.wd >= 0
+    // A directory that cannot be watched is not an error the client can act on: it listed fine, and
+    // the only consequence is the listing this build shipped before the watch existed.
+    fn add(&self, path: &Path) -> c_int {
+        if self.fd < 0 {
+            return -1;
+        }
+        match CString::new(path.as_os_str().as_encoded_bytes()) {
+            Ok(c) => unsafe { inotify_add_watch(self.fd, c.as_ptr(), MASK) },
+            Err(_) => -1,
+        }
+    }
+
+    fn drop_one(&self, wd: c_int) {
+        if self.fd >= 0 && wd >= 0 {
+            unsafe { inotify_rm_watch(self.fd, wd) };
+        }
+    }
+
+    // A directory this box could have watched and did not, which is the only case worth a sentence
+    // per listing: with no inotify instance at all, Watch::start already said so once at startup.
+    pub fn refused(&self) -> bool {
+        self.fd >= 0 && self.wd < 0
     }
 
     // A removed watch's own IN_IGNORED is delivered after inotify_rm_watch returns, so a burst is
@@ -110,11 +134,12 @@ fn pump(fd: c_int, tx: Sender<Event>) {
     loop {
         let n = unsafe { read(fd, buf.as_mut_ptr() as *mut c_void, BUF) };
         if n < 0 {
+            let failure = io::Error::last_os_error();
             // A signal can cut a blocking read short, which is not the descriptor going away.
-            if io::Error::last_os_error().kind() == io::ErrorKind::Interrupted {
+            if failure.kind() == io::ErrorKind::Interrupted {
                 continue;
             }
-            eprintln!("flea: the open folder stopped following outside changes, the inotify read failed");
+            eprintln!("flea: the open folder stopped following outside changes, the inotify read failed: {}", failure);
             return;
         }
         // A closed descriptor ends the thread; the loop keeps running without a watch.
@@ -141,8 +166,8 @@ fn descriptors(buf: &[u8]) -> Vec<i32> {
         if !out.contains(&wd) {
             out.push(wd);
         }
-        // A tail too short to hold another header ends the walk, which is also what stops a truncated
-        // one being read past the end: at overshoots and the condition above is what refuses it.
+        // inotify hands back whole events only, so this can only overshoot on a buffer that did not
+        // come from one; the condition above is the bound that keeps the indexing inside the slice.
         at += EVENT_HEADER + len;
     }
     out
@@ -183,7 +208,7 @@ mod tests {
         assert_eq!(descriptors(&buf), vec![3, 4]);
     }
 
-    // A read can end mid-event: the last complete header is still named and nothing is read past the end.
+    // Not a shape inotify produces: it pins the bound, so a length running past the slice cannot panic.
     #[test]
     fn a_truncated_tail_ends_the_walk() {
         let mut buf = event(3, b"a.txt\0\0\0");
@@ -199,9 +224,29 @@ mod tests {
 
     #[test]
     fn nothing_is_current_before_a_directory_is_followed() {
-        let w = Watch { fd: -1, wd: -1 };
+        let w = Watch { fd: -1, wd: -1, incoming: -1 };
         assert!(!w.is_current(-1));
         assert!(!w.is_current(1));
+    }
+
+    // A scan that fails leaves the listed directory on the descriptor it already had, which is the
+    // whole point of arming the next one beside it rather than in place of it.
+    #[test]
+    fn an_abandoned_scan_leaves_the_current_watch_alone() {
+        let mut w = Watch { fd: -1, wd: 7, incoming: -1 };
+        w.begin(Path::new("/tmp"));
+        w.abandon();
+        assert!(w.is_current(7));
+        assert!(!w.refused());
+    }
+
+    // And one that succeeds hands the listing over to the descriptor the scan was armed with.
+    #[test]
+    fn a_committed_scan_takes_over_from_the_old_watch() {
+        let mut w = Watch { fd: -1, wd: 7, incoming: 9 };
+        w.commit();
+        assert!(w.is_current(9));
+        assert!(!w.is_current(7));
     }
 
     #[test]

--- a/src/backend/watch.rs
+++ b/src/backend/watch.rs
@@ -75,9 +75,13 @@ impl Watch {
         self.incoming = self.add(path);
     }
 
-    // The new listing replaced the old, so the directory it replaced stops being watched.
+    // The new listing replaced the old, so the directory it replaced stops being watched. A re-list of
+    // the SAME directory answers the descriptor it already had, so dropping it here would remove the
+    // watch this just re-armed and leave the folder followed by nothing.
     pub fn commit(&mut self) {
-        self.drop_one(self.wd);
+        if self.incoming != self.wd {
+            self.drop_one(self.wd);
+        }
         self.wd = self.incoming;
         self.incoming = -1;
     }
@@ -90,7 +94,9 @@ impl Watch {
 
     pub fn stop(&mut self) {
         self.drop_one(self.wd);
-        self.drop_one(self.incoming);
+        if self.incoming != self.wd {
+            self.drop_one(self.incoming);
+        }
         self.wd = -1;
         self.incoming = -1;
     }
@@ -229,15 +235,14 @@ mod tests {
         assert!(!w.is_current(1));
     }
 
-    // A scan that fails leaves the listed directory on the descriptor it already had, which is the
-    // whole point of arming the next one beside it rather than in place of it.
+    // These build a Watch with no descriptor, so add and drop_one are no-ops: what they pin is which
+    // descriptor the bookkeeping calls current, and tests/protocol.sh pins what the syscalls do.
     #[test]
     fn an_abandoned_scan_leaves_the_current_watch_alone() {
         let mut w = Watch { fd: -1, wd: 7, incoming: -1 };
         w.begin(Path::new("/tmp"));
         w.abandon();
         assert!(w.is_current(7));
-        assert!(!w.refused());
     }
 
     // And one that succeeds hands the listing over to the descriptor the scan was armed with.

--- a/src/backend/watch.rs
+++ b/src/backend/watch.rs
@@ -1,0 +1,202 @@
+// The directory the current listing came from, watched so a change another program makes reaches the
+// client without the user leaving the folder; see docs/protocol.md "changed". inotify rather than a
+// poll because a poll wakes this process forever to learn that nothing happened.
+use crate::backend::events::Event;
+use crate::json::escape;
+use std::ffi::{c_char, c_int, c_void, CString};
+use std::path::Path;
+use std::sync::mpsc::Sender;
+use std::thread;
+use std::time::Duration;
+
+// Exactly the events that change what a listing says: which names are in it, and the size, date and
+// mode its columns draw. A file growing under an open handle is not one of them, see AGENTS.md.
+const IN_ATTRIB: u32 = 0x0000_0004;
+const IN_CLOSE_WRITE: u32 = 0x0000_0008;
+const IN_MOVED_FROM: u32 = 0x0000_0040;
+const IN_MOVED_TO: u32 = 0x0000_0080;
+const IN_CREATE: u32 = 0x0000_0100;
+const IN_DELETE: u32 = 0x0000_0200;
+const IN_DELETE_SELF: u32 = 0x0000_0400;
+const IN_MOVE_SELF: u32 = 0x0000_0800;
+const MASK: u32 = IN_ATTRIB
+    | IN_CLOSE_WRITE
+    | IN_MOVED_FROM
+    | IN_MOVED_TO
+    | IN_CREATE
+    | IN_DELETE
+    | IN_DELETE_SELF
+    | IN_MOVE_SELF;
+
+// IN_CLOEXEC is O_CLOEXEC, so no thumbnailer child inherits this descriptor.
+const IN_CLOEXEC: c_int = 0x0008_0000;
+// One inotify_event is a watch descriptor, a mask, a cookie and a name length, then the name.
+const EVENT_HEADER: usize = 16;
+// Every event in one burst says the same thing to a client that re-reads the whole directory, so the
+// thread pauses after a burst and a thousand writes cost one line instead of a thousand.
+const COALESCE: Duration = Duration::from_millis(100);
+// A burst larger than this overflows in the kernel, which costs nothing here: the payload is only
+// ever read for its watch descriptor, never for which file moved.
+const BUF: usize = 8192;
+
+extern "C" {
+    fn inotify_init1(flags: c_int) -> c_int;
+    fn inotify_add_watch(fd: c_int, path: *const c_char, mask: u32) -> c_int;
+    fn inotify_rm_watch(fd: c_int, wd: c_int) -> c_int;
+    fn read(fd: c_int, buf: *mut c_void, count: usize) -> isize;
+}
+
+// One directory at a time, because the backend holds one listing at a time. A negative fd is a box
+// with no inotify left to give, and a negative wd is nothing watched right now.
+pub struct Watch {
+    fd: c_int,
+    wd: c_int,
+}
+
+impl Watch {
+    // A box that cannot hand out an inotify descriptor still gets a file manager: this reports no
+    // watch on stderr rather than refusing to start, and the listing is then as live as 0.1.4's was.
+    pub fn start(tx: Sender<Event>) -> Watch {
+        let fd = unsafe { inotify_init1(IN_CLOEXEC) };
+        if fd < 0 {
+            eprintln!("flea: the open folder will not follow outside changes, inotify is unavailable");
+            return Watch { fd: -1, wd: -1 };
+        }
+        thread::spawn(move || pump(fd, tx));
+        Watch { fd, wd: -1 }
+    }
+
+    // The listing moved, so the old watch goes before the new one is added.
+    pub fn follow(&mut self, path: &Path) {
+        self.stop();
+        if self.fd < 0 {
+            return;
+        }
+        let c = match CString::new(path.as_os_str().as_encoded_bytes()) {
+            Ok(c) => c,
+            Err(_) => return,
+        };
+        // A directory that cannot be watched is not an error the client can act on: it listed fine,
+        // and the only consequence is the listing this build shipped before the watch existed.
+        self.wd = unsafe { inotify_add_watch(self.fd, c.as_ptr(), MASK) };
+    }
+
+    pub fn stop(&mut self) {
+        if self.fd >= 0 && self.wd >= 0 {
+            unsafe { inotify_rm_watch(self.fd, self.wd) };
+        }
+        self.wd = -1;
+    }
+
+    // A removed watch's own IN_IGNORED is delivered after inotify_rm_watch returns, so a burst is
+    // this directory's only while its descriptor still matches; without this every navigation would
+    // answer one changed line for the directory it had just arrived in.
+    pub fn is_current(&self, wd: i32) -> bool {
+        self.wd >= 0 && wd == self.wd
+    }
+}
+
+// Sample input: one 16 byte header then the name, wd 1, mask 0x00000100 (IN_CREATE), cookie 0,
+// len 16, "NEWFILE.txt\0\0\0\0\0".
+fn pump(fd: c_int, tx: Sender<Event>) {
+    let mut buf = [0u8; BUF];
+    loop {
+        let n = unsafe { read(fd, buf.as_mut_ptr() as *mut c_void, BUF) };
+        // A closed or broken descriptor ends the thread; the loop keeps running without a watch.
+        if n <= 0 {
+            return;
+        }
+        for wd in descriptors(&buf[..n as usize]) {
+            if tx.send(Event::Changed(wd)).is_err() {
+                return;
+            }
+        }
+        thread::sleep(COALESCE);
+    }
+}
+
+// Which watches this burst touched, each named once. Nothing past the descriptor is read, because
+// the loop only has to know whether the burst belongs to the directory it is listing now.
+fn descriptors(buf: &[u8]) -> Vec<i32> {
+    let mut out: Vec<i32> = Vec::new();
+    let mut at = 0;
+    while at + EVENT_HEADER <= buf.len() {
+        let wd = i32::from_ne_bytes([buf[at], buf[at + 1], buf[at + 2], buf[at + 3]]);
+        let len = u32::from_ne_bytes([buf[at + 12], buf[at + 13], buf[at + 14], buf[at + 15]]) as usize;
+        if !out.contains(&wd) {
+            out.push(wd);
+        }
+        let step = EVENT_HEADER + len;
+        // A truncated tail is not a header, so it ends the walk rather than being read past the end.
+        if step > buf.len() - at {
+            break;
+        }
+        at += step;
+    }
+    out
+}
+
+// The one unsolicited line on the wire: the client asked for a listing, and this says the directory
+// that listing came from is no longer what it answered with. path is that directory, so a client
+// that has since moved can tell whose notification it is holding.
+pub fn changed_line(path: &Path) -> String {
+    format!(r#"{{"t":"changed","path":"{}"}}"#, escape(&path.to_string_lossy()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Sample input: two events on watch 3, one carrying a 16 byte name and one carrying none.
+    fn event(wd: i32, name: &[u8]) -> Vec<u8> {
+        let mut out = Vec::new();
+        out.extend_from_slice(&wd.to_ne_bytes());
+        out.extend_from_slice(&IN_CREATE.to_ne_bytes());
+        out.extend_from_slice(&0u32.to_ne_bytes());
+        out.extend_from_slice(&(name.len() as u32).to_ne_bytes());
+        out.extend_from_slice(name);
+        out
+    }
+
+    #[test]
+    fn one_event_names_its_watch() {
+        assert_eq!(descriptors(&event(3, b"a.txt\0\0\0")), vec![3]);
+    }
+
+    #[test]
+    fn a_burst_names_each_watch_once() {
+        let mut buf = event(3, b"a.txt\0\0\0");
+        buf.extend(event(3, b""));
+        buf.extend(event(4, b"b.txt\0\0\0"));
+        assert_eq!(descriptors(&buf), vec![3, 4]);
+    }
+
+    // A read can end mid-event; the walk stops there rather than reading a length past the buffer.
+    #[test]
+    fn a_truncated_tail_ends_the_walk() {
+        let mut buf = event(3, b"a.txt\0\0\0");
+        buf.extend(event(4, b"this name did not fit"));
+        buf.truncate(buf.len() - 4);
+        assert_eq!(descriptors(&buf), vec![3, 4]);
+    }
+
+    #[test]
+    fn a_short_buffer_names_nothing() {
+        assert_eq!(descriptors(&[0u8; 8]), Vec::<i32>::new());
+    }
+
+    #[test]
+    fn nothing_is_current_before_a_directory_is_followed() {
+        let w = Watch { fd: -1, wd: -1 };
+        assert!(!w.is_current(-1));
+        assert!(!w.is_current(1));
+    }
+
+    #[test]
+    fn the_changed_line_names_its_directory() {
+        assert_eq!(
+            changed_line(Path::new("/tmp/a \"b\"")),
+            r#"{"t":"changed","path":"/tmp/a \"b\""}"#
+        );
+    }
+}

--- a/tests/js/harness.qml
+++ b/tests/js/harness.qml
@@ -40,6 +40,7 @@ import "tap.js" as TapSuite
 import "tabs.js" as TabsSuite
 import "thumbs.js" as ThumbsSuite
 import "uistate.js" as UiStateSuite
+import "watch.js" as WatchSuite
 
 Item {
     Component.onCompleted: {
@@ -74,7 +75,8 @@ Item {
             ["selection", SelectionSuite], ["settings", SettingsSuite],
             ["sort", SortSuite], ["taildrop", TaildropSuite], ["textsize", TextSizeSuite],
             ["trash", TrashSuite], ["tap", TapSuite], ["tabs", TabsSuite],
-            ["thumbs", ThumbsSuite], ["uistate", UiStateSuite]
+            ["thumbs", ThumbsSuite], ["uistate", UiStateSuite],
+            ["watch", WatchSuite]
         ]
         var argv = Qt.application.arguments
         var only = ""

--- a/tests/js/watch.js
+++ b/tests/js/watch.js
@@ -97,22 +97,36 @@ function run(check) {
     var deepAnchor = Nav.refreshWatched(deep)
     check("a re-read below the first window asks for the window the cursor was in",
           deep.sent.join(","), "list /home/gm,fsinfo,window 4000")
+    // onRows returns until onListed has run, so a reply always carries its total; see ui/PaneWire.qml.
     deep.held = 0
     deep.rows = [{ n: "a" }, { n: "b" }]
+    deep.total = 100000
     check("and the first window, which cannot hold that name, does not resolve the anchor",
           Nav.applyAnchor(deep, deepAnchor) === deepAnchor, true)
     check("and moves no cursor while it waits", deep.cursorSetTo, -1)
-    // One reply's grace and no more: a listing that shrank below that offset comes back clamped to
-    // row 0, and waiting on it for ever would leave the cursor unrestored and the anchor leaking.
-    var clamped = watched(4000, [{ n: "m" }], 4001, 100000)
+    // The wait is on the window arriving, not on a number of replies, so more of the first window
+    // in between does not give up on it; the anchor leaks for good if this ever stops holding.
+    check("more replies at the first window do not give up on the window asked for",
+          Nav.applyAnchor(deep, deepAnchor) === deepAnchor, true)
+    check("and still move no cursor", deep.cursorSetTo, -1)
+    // A listing that shrank past that offset comes back clamped to row 0, so the window asked for is
+    // never coming; waiting on it for ever would leave the cursor unrestored and the anchor leaking.
+    var clamped = watched(4000, [{ n: "m" }, { n: "n" }], 4001, 100000)
     var clampedAnchor = Nav.refreshWatched(clamped)
     clamped.held = 0
-    clamped.rows = [{ n: "a" }]
-    clamped.total = 1
-    check("a window clamped to row 0 is given one reply's grace",
-          Nav.applyAnchor(clamped, clampedAnchor) === clampedAnchor, true)
-    check("and then resolves against the clamp rather than waiting for ever",
-          Nav.applyAnchor(clamped, clampedAnchor) + "|" + clamped.cursorSetTo, "null|0")
+    clamped.rows = [{ n: "a" }, { n: "b" }]
+    clamped.total = 2
+    check("a listing that shrank past the window asked for resolves against the clamp",
+          Nav.applyAnchor(clamped, clampedAnchor) + "|" + clamped.cursorSetTo, "null|1")
+    // A listing of exactly start rows holds 0 to start-1, so window(start) is clamped here too: this is
+    // the offset the comparison has to exclude, and a >= would wait on that reply for ever.
+    var exact = watched(4000, [{ n: "m" }, { n: "n" }], 4001, 100000)
+    var exactAnchor = Nav.refreshWatched(exact)
+    exact.held = 0
+    exact.rows = [{ n: "a" }, { n: "b" }]
+    exact.total = 4000
+    check("a listing of exactly the offset asked for is clamped too, and resolves",
+          Nav.applyAnchor(exact, exactAnchor) + "|" + exact.cursorSetTo, "null|3999")
     deep.held = 4000
     deep.rows = [{ n: "m" }, { n: "n" }]
     check("the window it asked for is what puts the cursor back",

--- a/tests/js/watch.js
+++ b/tests/js/watch.js
@@ -102,6 +102,17 @@ function run(check) {
     check("and the first window, which cannot hold that name, does not resolve the anchor",
           Nav.applyAnchor(deep, deepAnchor) === deepAnchor, true)
     check("and moves no cursor while it waits", deep.cursorSetTo, -1)
+    // One reply's grace and no more: a listing that shrank below that offset comes back clamped to
+    // row 0, and waiting on it for ever would leave the cursor unrestored and the anchor leaking.
+    var clamped = watched(4000, [{ n: "m" }], 4001, 100000)
+    var clampedAnchor = Nav.refreshWatched(clamped)
+    clamped.held = 0
+    clamped.rows = [{ n: "a" }]
+    clamped.total = 1
+    check("a window clamped to row 0 is given one reply's grace",
+          Nav.applyAnchor(clamped, clampedAnchor) === clampedAnchor, true)
+    check("and then resolves against the clamp rather than waiting for ever",
+          Nav.applyAnchor(clamped, clampedAnchor) + "|" + clamped.cursorSetTo, "null|0")
     deep.held = 4000
     deep.rows = [{ n: "m" }, { n: "n" }]
     check("the window it asked for is what puts the cursor back",

--- a/tests/js/watch.js
+++ b/tests/js/watch.js
@@ -1,0 +1,132 @@
+.import "../../ui/js/Nav.js" as Nav
+
+// Issue 68's watched re-read: a change another program made under the open listing is read again
+// without moving the user off the file they were on. Its own suite because tests/js/nav.js sits at
+// the 300-line JS hard cap, and because this is one behaviour rather than another navigation.
+
+// Only the members openWithoutHistory writes, so the check is what a new listing forgets.
+function pane() {
+    var p = {
+        listInFlight: false,
+        listedSeen: true,
+        path: "/home/gm",
+        total: 40,
+        held: 10,
+        rows: [{ n: "a" }],
+        kindNames: ["Plain text document"],
+        thumbState: "stale",
+        dirSizeState: "stale",
+        cursorIndex: 7,
+        renamingIndex: 4,
+        trashArmedAt: 12345,
+        listingState: "ready",
+        stateMessage: "something",
+        lockedMode: 0o40750,
+        filterQuery: "scr",
+        filterTyping: true,
+        cleared: 0,
+        said: [],
+        sent: []
+    }
+    p.clearSelection = function () { p.cleared += 1 }
+    p.message = function (text, isError) { p.said.push(text) }
+    p.listArea = { primeSettle: function () {} }
+    p.backend = {
+        list: function (path, first, hidden) { p.sent.push("list " + path) },
+        askFsInfo: function () { p.sent.push("fsinfo") },
+        window: function (start, count) { p.sent.push("window " + start) }
+    }
+    return p
+}
+
+// Issue 68's re-read, which unlike a navigation puts the user back where they were. windowSize and
+// setCursor are the two members only this path uses; rowFor is the pane's own held-window lookup.
+function watched(held, rows, cursorIndex, total) {
+    var p = pane()
+    p.held = held
+    p.rows = rows
+    p.cursorIndex = cursorIndex
+    p.total = total === undefined ? 40 : total
+    p.windowSize = 350
+    p.cursorSetTo = -1
+    p.rowFor = function (index) {
+        var offset = index - p.held
+        return offset < 0 || offset >= p.rows.length ? null : p.rows[offset]
+    }
+    p.setCursor = function (index) { p.cursorSetTo = index }
+    // The same wrapper ui/Pane.qml carries, so the re-read takes the one route that can refuse.
+    p.openWithoutHistory = function (target) { Nav.openWithoutHistory(p, target) }
+    return p
+}
+
+
+function run(check) {
+    // Issue 68: a change another program made under the listing is re-read in place. The cursor goes
+    // back on the file it was on by name, because a create above it renumbers every row below.
+    var seen = watched(0, [{ n: "a" }, { n: "b" }, { n: "c" }], 1)
+    var anchor = Nav.refreshWatched(seen)
+    check("a watched re-read asks for the same directory again",
+          seen.sent.join(","), "list /home/gm,fsinfo")
+    check("and anchors on the name the cursor was on, not on its index",
+          anchor.name + "|" + anchor.index, "b|1")
+    check("and keeps the filter, which narrows rows rather than choosing the directory",
+          seen.filterQuery, "scr")
+
+    // The name moved down a row, which is exactly what a create above the cursor does.
+    seen.held = 0
+    seen.rows = [{ n: "NEW" }, { n: "a" }, { n: "b" }, { n: "c" }]
+    seen.total = 41
+    check("the cursor lands on the anchored name at its new index",
+          Nav.applyAnchor(seen, anchor) + "|" + seen.cursorSetTo, "null|2")
+
+    // A name that is gone leaves the old index, which keeps the view where the user left it rather
+    // than throwing them back to the top of the directory.
+    var deleted = watched(0, [{ n: "a" }, { n: "c" }], 1, 2)
+    check("a deleted anchor falls back to the index it had",
+          Nav.applyAnchor(deleted, { name: "b", index: 1, start: 0, path: "/home/gm" }) + "|" + deleted.cursorSetTo, "null|1")
+    var shrunk = watched(0, [{ n: "a" }], 7, 1)
+    check("and that index is clamped to what the directory now holds",
+          Nav.applyAnchor(shrunk, { name: "gone", index: 7, start: 0, path: "/home/gm" }) + "|" + shrunk.cursorSetTo, "null|0")
+    var emptied = watched(0, [], 3, 0)
+    check("a directory that emptied moves no cursor at all",
+          Nav.applyAnchor(emptied, { name: "gone", index: 3, start: 0, path: "/home/gm" }) + "|" + emptied.cursorSetTo, "null|-1")
+
+    // A cursor deep in a large directory: the re-read answers from row 0, so its own window is asked
+    // for and the anchor stands until that window arrives rather than giving up on the first reply.
+    var deep = watched(4000, [{ n: "m" }, { n: "n" }], 4001, 100000)
+    var deepAnchor = Nav.refreshWatched(deep)
+    check("a re-read below the first window asks for the window the cursor was in",
+          deep.sent.join(","), "list /home/gm,fsinfo,window 4000")
+    deep.held = 0
+    deep.rows = [{ n: "a" }, { n: "b" }]
+    check("and the first window, which cannot hold that name, does not resolve the anchor",
+          Nav.applyAnchor(deep, deepAnchor) === deepAnchor, true)
+    check("and moves no cursor while it waits", deep.cursorSetTo, -1)
+    deep.held = 4000
+    deep.rows = [{ n: "m" }, { n: "n" }]
+    check("the window it asked for is what puts the cursor back",
+          Nav.applyAnchor(deep, deepAnchor) + "|" + deep.cursorSetTo, "null|4001")
+
+    // Nothing under the cursor is not a reason to refuse the re-read; the index still stands.
+    var unloaded = watched(500, [{ n: "x" }], 3)
+    var noRow = Nav.refreshWatched(unloaded)
+    check("a cursor over a row the pane does not hold anchors on no name", noRow.name, "")
+
+    // The anchor can outlive one rows reply, so a navigation in between drops it rather than putting
+    // this directory's cursor row onto the next directory's listing.
+    var left = watched(0, [{ n: "a" }, { n: "b" }], 1)
+    var leftAnchor = Nav.refreshWatched(left)
+    left.path = "/home/gm/Work"
+    left.rows = [{ n: "b" }]
+    left.total = 1
+    check("an anchor from another directory is dropped, not applied",
+          Nav.applyAnchor(left, leftAnchor) + "|" + left.cursorSetTo, "null|-1")
+
+    // A re-read while a listing is already running would queue a second one behind it.
+    var loading = watched(0, [{ n: "a" }], 0)
+    loading.listInFlight = true
+    check("a re-read is refused while a list is in flight",
+          Nav.refreshWatched(loading) === null && loading.sent.length === 0, true)
+    check("and an absent anchor resolves to nothing", Nav.applyAnchor(loading, null), null)
+
+}

--- a/tests/protocol.sh
+++ b/tests/protocol.sh
@@ -560,16 +560,19 @@ mkdir -p "$SELFDEL"
 out=$(watch_run "$SELFDEL" rmdir "$SELFDEL")
 check_changed "deleting the watched directory answers a changed line, from the watch's own removal" "$out" 1 3
 
-# A failed list answers its error and the directory still on screen keeps answering changed.
+# A failed list answers its error and the directory still on screen keeps answering changed. Two changes
+# a burst apart, because a watch the failure took away answers the one line its own removal made.
 out=$( ( printf '{"c":"list","path":"%s","first":10}\n' "$WT"
          sleep 0.4
          printf '{"c":"list","path":"/no/such/directory","first":10}\n'
          sleep 0.4
-         touch "$WT/after-a-failed-list.txt"
-         sleep 0.6
+         touch "$WT/after-a-failed-list-one.txt"
+         sleep 1.0
+         touch "$WT/after-a-failed-list-two.txt"
+         sleep 0.8
          printf '{"c":"quit"}\n' ) | $BIN --backend)
 check "a failed list still answers its error" "1" "$(echo "$out" | grep -c '"t":"error"')"
-check_changed "and the directory still on screen is still watched after it" "$out" 1 3
+check_changed "and the directory still on screen is still watched after it" "$out" 2 4
 
 # inotify answers the descriptor it already holds, so a commit that dropped it would unwatch the folder.
 out=$( ( printf '{"c":"list","path":"%s","first":10}\n' "$WT"

--- a/tests/protocol.sh
+++ b/tests/protocol.sh
@@ -560,9 +560,8 @@ mkdir -p "$SELFDEL"
 out=$(watch_run "$SELFDEL" rmdir "$SELFDEL")
 check_changed "deleting the watched directory answers a changed line, from the watch's own removal" "$out" 1 3
 
-# A list that fails leaves the pane on the directory it was already showing, and that directory keeps
-# the watch it already had. Arming the new watch in place of it instead of beside it reddens here,
-# because the failed attempt then hands the listed directory a descriptor its own events do not carry.
+# A failed list answers its error and leaves the watch on the directory still being shown; deleting
+# the Err arm's abandon, so the failure takes that watch away, reddens the change that follows.
 out=$( ( printf '{"c":"list","path":"%s","first":10}\n' "$WT"
          sleep 0.4
          printf '{"c":"list","path":"/no/such/directory","first":10}\n'
@@ -572,6 +571,24 @@ out=$( ( printf '{"c":"list","path":"%s","first":10}\n' "$WT"
          printf '{"c":"quit"}\n' ) | $BIN --backend)
 check "a failed list still answers its error" "1" "$(echo "$out" | grep -c '"t":"error"')"
 check_changed "and the directory still on screen is still watched after it" "$out" 1 3
+
+# Every refresh re-lists the same directory, and inotify answers the descriptor it already holds, so
+# a commit that dropped the old one would remove the watch it just re-armed.
+out=$( ( printf '{"c":"list","path":"%s","first":10}\n' "$WT"
+         sleep 0.5
+         printf '{"c":"list","path":"%s","first":10}\n' "$WT"
+         sleep 1.5
+         printf '{"c":"quit"}\n' ) | $BIN --backend)
+check_changed "re-listing the same directory answers nothing on its own" "$out" 0 0
+
+out=$( ( printf '{"c":"list","path":"%s","first":10}\n' "$WT"
+         sleep 0.5
+         printf '{"c":"list","path":"%s","first":10}\n' "$WT"
+         sleep 0.5
+         touch "$WT/after-a-relist.txt"
+         sleep 0.8
+         printf '{"c":"quit"}\n' ) | $BIN --backend)
+check_changed "and a change after that re-list is still answered" "$out" 1 3
 
 # A burst is coalesced by the reader, so a hundred creates cost a handful of lines, not a hundred.
 out=$(watch_run "$WT" burst_of_creates)

--- a/tests/protocol.sh
+++ b/tests/protocol.sh
@@ -444,6 +444,99 @@ check "an archive op that names neither is refused by name" "op must be compress
 check "and the refusal names the op it was given" "bogus" "$(echo "$out" | grep -oE '"path":"[^"]*"' | head -1 | cut -d'"' -f4)"
 check "and no job was started for it" "0" "$(echo "$out" | grep -c '"t":"archivestarted"')"
 
+# Issue 68: the listed directory is watched, so a change made from outside answers a changed line.
+# The only unsolicited line on the wire, so every case here is driven by a real create, rename or
+# delete landing between two requests rather than by a request asking for it.
+WT_SB="$FIXTURE_ROOT/flea-watch-test-$$"
+WT="$WT_SB/tree"
+OTHER="$WT_SB/other"
+sandbox_make "$WT_SB"
+mkdir -p "$WT" "$OTHER"
+printf 'a' > "$WT/alpha.txt"
+
+# The change runs argv-direct between the list and the quit, which is where an outside write lands.
+watch_run() {
+  local dir="$1"
+  shift
+  ( printf '{"c":"list","path":"%s","first":10}\n' "$dir"
+    sleep 0.4
+    "$@"
+    sleep 0.6
+    printf '{"c":"quit"}\n'
+  ) | $BIN --backend
+}
+
+# One create can wake the reader once or twice (the create, then the close and the timestamp), so
+# the assertion is that the wire said something and did not say it per event, never an exact count.
+check_changed() {
+  local label="$1" out="$2" low="$3" high="$4"
+  local n
+  n=$(echo "$out" | grep -c '"t":"changed"')
+  [ "$n" -ge "$low" ] && [ "$n" -le "$high" ]
+  check "$label (saw $n)" "0" "$?"
+}
+
+burst_of_creates() {
+  local i
+  for i in $(seq 1 100); do
+    : > "$WT/burst-$i.txt"
+  done
+}
+
+out=$(watch_run "$WT" touch "$WT/created.txt")
+check_changed "a create from outside answers a changed line" "$out" 1 3
+check "and that line names the directory being listed" "$WT" "$(echo "$out" | grep '"t":"changed"' | head -1 | grep -oE '"path":"[^"]*"' | cut -d'"' -f4)"
+check "and the listing itself is not re-sent, because the client asks for that" "1" "$(echo "$out" | grep -c '"t":"listed"')"
+
+out=$(watch_run "$WT" mv "$WT/created.txt" "$WT/renamed.txt")
+check_changed "a rename from outside answers a changed line" "$out" 1 3
+
+out=$(watch_run "$WT" rm -f "$WT/renamed.txt")
+check_changed "a delete from outside answers a changed line" "$out" 1 3
+
+out=$(watch_run "$WT" mkdir "$WT/made")
+check_changed "a new directory from outside answers a changed line" "$out" 1 3
+rmdir "$WT/made"
+
+# The negative control, which is what proves the watch is on the listed directory and not on the box.
+out=$(watch_run "$WT" touch "$OTHER/elsewhere.txt")
+check_changed "a change in a directory that is not listed answers nothing" "$out" 0 0
+
+# Navigating drops the old watch. Without the descriptor check in src/backend/watch.rs the removal's
+# own IN_IGNORED would answer here, so this case reddens on exactly the bug it was written for.
+out=$( ( printf '{"c":"list","path":"%s","first":10}\n' "$WT"
+         sleep 0.4
+         printf '{"c":"list","path":"%s","first":10}\n' "$OTHER"
+         sleep 0.6
+         touch "$WT/after-leaving.txt"
+         sleep 0.6
+         printf '{"c":"quit"}\n' ) | $BIN --backend)
+check_changed "a change in the directory just left answers nothing" "$out" 0 0
+check "and moving to a new directory answers nothing on its own" "2" "$(echo "$out" | grep -c '"t":"listed"')"
+
+# A search replaces the listing with matches, which are not a directory, so nothing is watched.
+out=$( ( printf '{"c":"search","path":"%s","query":"alpha"}\n' "$WT"
+         sleep 0.6
+         touch "$WT/during-search.txt"
+         sleep 0.6
+         printf '{"c":"quit"}\n' ) | $BIN --backend)
+check_changed "a change under a search answers nothing, because matches are not a directory" "$out" 0 0
+
+# listpaths lists a set the client named, whose base is the root; watching that would be a lie.
+out=$( ( printf '{"c":"list","path":"%s","first":10}\n' "$WT"
+         sleep 0.4
+         printf '{"c":"listpaths","paths":["%s/alpha.txt"],"first":10}\n' "$WT"
+         sleep 0.6
+         touch "$WT/during-listpaths.txt"
+         sleep 0.6
+         printf '{"c":"quit"}\n' ) | $BIN --backend)
+check_changed "a change under listpaths answers nothing, because named paths are not a directory" "$out" 0 0
+
+# A burst is coalesced by the reader, so a hundred creates cost a handful of lines, not a hundred.
+out=$(watch_run "$WT" burst_of_creates)
+check_changed "a hundred creates answer a handful of changed lines, not a hundred" "$out" 1 10
+sandbox_remove "$WT_SB"
+
 # No per-key cleanup: the cache is inside the sandbox, so it goes when the sandbox does.
 sandbox_remove "$SB"
 exit $fail

--- a/tests/protocol.sh
+++ b/tests/protocol.sh
@@ -560,8 +560,7 @@ mkdir -p "$SELFDEL"
 out=$(watch_run "$SELFDEL" rmdir "$SELFDEL")
 check_changed "deleting the watched directory answers a changed line, from the watch's own removal" "$out" 1 3
 
-# A failed list answers its error and leaves the watch on the directory still being shown; deleting
-# the Err arm's abandon, so the failure takes that watch away, reddens the change that follows.
+# A failed list answers its error and the directory still on screen keeps answering changed.
 out=$( ( printf '{"c":"list","path":"%s","first":10}\n' "$WT"
          sleep 0.4
          printf '{"c":"list","path":"/no/such/directory","first":10}\n'
@@ -572,8 +571,7 @@ out=$( ( printf '{"c":"list","path":"%s","first":10}\n' "$WT"
 check "a failed list still answers its error" "1" "$(echo "$out" | grep -c '"t":"error"')"
 check_changed "and the directory still on screen is still watched after it" "$out" 1 3
 
-# Every refresh re-lists the same directory, and inotify answers the descriptor it already holds, so
-# a commit that dropped the old one would remove the watch it just re-armed.
+# inotify answers the descriptor it already holds, so a commit that dropped it would unwatch the folder.
 out=$( ( printf '{"c":"list","path":"%s","first":10}\n' "$WT"
          sleep 0.5
          printf '{"c":"list","path":"%s","first":10}\n' "$WT"
@@ -581,14 +579,18 @@ out=$( ( printf '{"c":"list","path":"%s","first":10}\n' "$WT"
          printf '{"c":"quit"}\n' ) | $BIN --backend)
 check_changed "re-listing the same directory answers nothing on its own" "$out" 0 0
 
+# Two changes, a second apart so each is its own burst: a dead watch answers the one spurious line
+# its own removal made and nothing else, which one change alone could not be told apart from.
 out=$( ( printf '{"c":"list","path":"%s","first":10}\n' "$WT"
          sleep 0.5
          printf '{"c":"list","path":"%s","first":10}\n' "$WT"
          sleep 0.5
-         touch "$WT/after-a-relist.txt"
+         touch "$WT/after-a-relist-one.txt"
+         sleep 1.0
+         touch "$WT/after-a-relist-two.txt"
          sleep 0.8
          printf '{"c":"quit"}\n' ) | $BIN --backend)
-check_changed "and a change after that re-list is still answered" "$out" 1 3
+check_changed "and two changes after that re-list are both answered" "$out" 2 4
 
 # A burst is coalesced by the reader, so a hundred creates cost a handful of lines, not a hundred.
 out=$(watch_run "$WT" burst_of_creates)

--- a/tests/protocol.sh
+++ b/tests/protocol.sh
@@ -514,8 +514,11 @@ out=$( ( printf '{"c":"list","path":"%s","first":10}\n' "$WT"
 check_changed "a change in the directory just left answers nothing" "$out" 0 0
 check "and moving to a new directory answers nothing on its own" "2" "$(echo "$out" | grep -c '"t":"listed"')"
 
-# A search replaces the listing with matches, which are not a directory, so nothing is watched.
-out=$( ( printf '{"c":"search","path":"%s","query":"alpha"}\n' "$WT"
+# A search replaces the listing with matches, which are not a directory, so nothing is watched. The
+# list comes first on purpose: without a watch to stop, this case passes with the stop deleted.
+out=$( ( printf '{"c":"list","path":"%s","first":10}\n' "$WT"
+         sleep 0.4
+         printf '{"c":"search","path":"%s","query":"alpha"}\n' "$WT"
          sleep 0.6
          touch "$WT/during-search.txt"
          sleep 0.6
@@ -531,6 +534,31 @@ out=$( ( printf '{"c":"list","path":"%s","first":10}\n' "$WT"
          sleep 0.6
          printf '{"c":"quit"}\n' ) | $BIN --backend)
 check_changed "a change under listpaths answers nothing, because named paths are not a directory" "$out" 0 0
+
+# One bit of MASK each, isolated: a chmod is IN_ATTRIB alone, and appending to a file that already
+# exists is IN_CLOSE_WRITE alone, since IN_MODIFY is deliberately not in the mask.
+append_to_alpha() {
+  printf 'x' >> "$WT/alpha.txt"
+}
+
+out=$(watch_run "$WT" chmod 0640 "$WT/alpha.txt")
+check_changed "a chmod from outside answers a changed line" "$out" 1 3
+chmod 0644 "$WT/alpha.txt"
+
+out=$(watch_run "$WT" append_to_alpha)
+check_changed "a writer closing a file it appended to answers a changed line" "$out" 1 3
+
+# The watched directory itself: a move keeps the watch, which IN_MOVE_SELF is what reports, and a
+# delete takes the watch with it, which the kernel reports as IN_IGNORED whatever the mask holds.
+SELFDIR="$WT_SB/self-move"
+mkdir -p "$SELFDIR"
+out=$(watch_run "$SELFDIR" mv "$SELFDIR" "$WT_SB/self-moved")
+check_changed "moving the watched directory itself answers a changed line" "$out" 1 3
+
+SELFDEL="$WT_SB/self-delete"
+mkdir -p "$SELFDEL"
+out=$(watch_run "$SELFDEL" rmdir "$SELFDEL")
+check_changed "deleting the watched directory answers a changed line, from the watch's own removal" "$out" 1 3
 
 # A burst is coalesced by the reader, so a hundred creates cost a handful of lines, not a hundred.
 out=$(watch_run "$WT" burst_of_creates)

--- a/tests/protocol.sh
+++ b/tests/protocol.sh
@@ -560,6 +560,19 @@ mkdir -p "$SELFDEL"
 out=$(watch_run "$SELFDEL" rmdir "$SELFDEL")
 check_changed "deleting the watched directory answers a changed line, from the watch's own removal" "$out" 1 3
 
+# A list that fails leaves the pane on the directory it was already showing, and that directory keeps
+# the watch it already had. Arming the new watch in place of it instead of beside it reddens here,
+# because the failed attempt then hands the listed directory a descriptor its own events do not carry.
+out=$( ( printf '{"c":"list","path":"%s","first":10}\n' "$WT"
+         sleep 0.4
+         printf '{"c":"list","path":"/no/such/directory","first":10}\n'
+         sleep 0.4
+         touch "$WT/after-a-failed-list.txt"
+         sleep 0.6
+         printf '{"c":"quit"}\n' ) | $BIN --backend)
+check "a failed list still answers its error" "1" "$(echo "$out" | grep -c '"t":"error"')"
+check_changed "and the directory still on screen is still watched after it" "$out" 1 3
+
 # A burst is coalesced by the reader, so a hundred creates cost a handful of lines, not a hundred.
 out=$(watch_run "$WT" burst_of_creates)
 check_changed "a hundred creates answer a handful of changed lines, not a hundred" "$out" 1 10

--- a/tests/ui.sh
+++ b/tests/ui.sh
@@ -1904,6 +1904,74 @@ case_selection() {
     kill_flea
 }
 
+# Issue 68, driven exactly as it was reported: the reporter's own four changes made from outside
+# the window, with nothing clicked and no folder left. Catches deleting the watch from
+# src/backend/watch.rs, the changed branch from ui/Backend.qml, or the re-read from ui/PaneWire.qml.
+case_watch() {
+    local dir="$fixture_root/watch"
+    sandbox_scratch "$dir"
+    printf 'a\n' > "$dir/alpha.txt"
+    printf 'b\n' > "$dir/beta.txt"
+    printf 'p\n' > "$dir/preview-me.txt"
+    launch "$dir"
+    wait_listing 3
+    [[ "$(ipc rowAt 0)" == alpha.txt\|* ]] || fail "watch: row 0 is $(ipc rowAt 0), not alpha.txt"
+
+    # The reporter's four changes, from another process, while the window sits on the folder.
+    printf 'new\n' > "$dir/NEWFILE-appeared.txt"
+    mv "$dir/alpha.txt" "$dir/alpha-RENAMED.txt"
+    rm "$dir/beta.txt"
+    mkdir "$dir/brand-new-folder"
+    # The 400 ms settle plus the re-read; the reporter waited several seconds and saw nothing move.
+    # Four rows now: brand-new-folder, NEWFILE-appeared.txt, alpha-RENAMED.txt, preview-me.txt.
+    omarchy-drive wait ipc -p "$flea_ui" flea total 4 --timeout 15 >/dev/null \
+        || fail "watch: the listing stayed at $(ipc total) rows after four outside changes"
+    settle
+    printf 'WATCH total=%s row0=%q row1=%q row2=%q\n' \
+        "$(ipc total)" "$(ipc rowAt 0)" "$(ipc rowAt 1)" "$(ipc rowAt 2)"
+    shot watch-after-outside-changes
+    # Directories first, then name ascending and case-insensitive: brand-new-folder,
+    # alpha-RENAMED.txt, NEWFILE-appeared.txt, preview-me.txt.
+    [[ "$(ipc rowAt 0)" == brand-new-folder\|dir\|* ]] \
+        || fail "watch: the new directory is not row 0, got $(ipc rowAt 0)"
+    [[ "$(ipc rowAt 1)" == alpha-RENAMED.txt\|* ]] \
+        || fail "watch: the renamed file is not row 1, got $(ipc rowAt 1)"
+    [[ "$(ipc rowAt 2)" == NEWFILE-appeared.txt\|* ]] \
+        || fail "watch: the created file is not row 2, got $(ipc rowAt 2)"
+    [[ "$(ipc rowAt 3)" == preview-me.txt\|* ]] \
+        || fail "watch: the untouched file is not row 3, got $(ipc rowAt 3)"
+
+    # The cursor is put back on the file it was on, not on the row that index now names: without the
+    # anchor the create above it leaves the cursor on brand-new-folder.
+    goto_row 3
+    [[ "$(ipc rowAt "$(ipc cursor)")" == preview-me.txt\|* ]] \
+        || fail "watch: the cursor did not start on preview-me.txt"
+    printf 'z\n' > "$dir/AAA-above-the-cursor.txt"
+    omarchy-drive wait ipc -p "$flea_ui" flea total 5 --timeout 15 >/dev/null \
+        || fail "watch: the second outside create left the listing at $(ipc total) rows"
+    settle
+    printf 'WATCH cursor=%s row=%q\n' "$(ipc cursor)" "$(ipc rowAt "$(ipc cursor)")"
+    [[ "$(ipc rowAt "$(ipc cursor)")" == preview-me.txt\|* ]] \
+        || fail "watch: a create above the cursor moved it to $(ipc rowAt "$(ipc cursor)")"
+
+    # A selection names rows by index, so the re-read waits for it rather than re-pointing it.
+    key v >/dev/null
+    settle
+    [[ "$(ipc selectionCount)" == "1" ]] || fail "watch: v did not select the cursor row"
+    printf 'held\n' > "$dir/BBB-while-selected.txt"
+    sleep 2
+    [[ "$(ipc total)" == "5" ]] \
+        || fail "watch: the listing re-read to $(ipc total) rows while a selection stood"
+    [[ "$(ipc selectionCount)" == "1" ]] || fail "watch: the held selection was cleared anyway"
+    # Clearing the selection is what pays the debt the notification left standing.
+    key -k Escape >/dev/null
+    omarchy-drive wait ipc -p "$flea_ui" flea total 6 --timeout 15 >/dev/null \
+        || fail "watch: clearing the selection did not run the owed re-read, total is $(ipc total)"
+    printf 'WATCH deferred=ok paid=ok total=%s\n' "$(ipc total)"
+    assert_window
+    kill_flea
+}
+
 # Mirrors the two env vars src/gui.rs sets from a resolved --select; tests/modes.sh covers the resolution itself.
 case_select() {
     local dir="$fixture_root/select"
@@ -5904,7 +5972,7 @@ cache_snapshot
 trap cleanup EXIT
 
 declare -a wanted=("$@")
-[[ ${#wanted[@]} -eq 0 ]] && wanted=(cursor terminal open rows click menu background hidden selection select colour lifted icons thumbs hashcache stale nosweep oem header overflow focus preview network netmark networkauth networktimeout gvfs sharebrowser unmount eject rename renamelife taildrop grid columns operations tabs openterminal renderer settings hangshare)
+[[ ${#wanted[@]} -eq 0 ]] && wanted=(cursor terminal open rows click menu background hidden selection watch select colour lifted icons thumbs hashcache stale nosweep oem header overflow focus preview network netmark networkauth networktimeout gvfs sharebrowser unmount eject rename renamelife taildrop grid columns operations tabs openterminal renderer settings hangshare)
 
 : > "$run_log"
 : > "$flea_log"

--- a/tests/ui.sh
+++ b/tests/ui.sh
@@ -1301,7 +1301,9 @@ case_click() {
     printf 'alpha\n' > "$dir/alpha.txt"
     printf 'beta\n' > "$dir/beta.txt"
     printf 'gamma\n' > "$dir/gamma.txt"
-    local opened="$dir/opened.log"
+    # Outside the directory under test on purpose: the stub appends to it on every open, and a write
+    # inside the listed folder is an outside change that re-reads it under the clicks below.
+    local opened="$fixture_root/click-opened.log"
     : > "$opened"
     # Only the open subcommand is intercepted, so stubbing the opener leaves the gio mount calls
     # ui/NetworkMounts.qml makes on every launch answering from the real gio. That name is the mount
@@ -1317,8 +1319,8 @@ case_click() {
     export PATH="$dir/bin:$PATH"
     launch "$dir"
     export PATH="$saved_path"
-    # Measured row order: bin, subdir, alpha.txt, beta.txt, gamma.txt, opened.log.
-    wait_listing 6
+    # Measured row order: bin, subdir, alpha.txt, beta.txt, gamma.txt.
+    wait_listing 5
     local alpha=2
 
     # The list view. One tap selects the row and opens nothing at all.
@@ -1361,7 +1363,7 @@ case_click() {
 
     # A plain click replaces the selection, so the next shift+click extends from the row the cursor
     # is visibly on and a write operation cannot reach rows the user thinks they dropped.
-    click_row 5 left
+    click_row 4 left
     settle
     [[ "$(ipc selectionCount)" == "0" ]] \
         || fail "click: a plain click left $(ipc selectionCount) rows selected, so the selection is stale"
@@ -1382,7 +1384,7 @@ case_click() {
     wait_path "$dir/subdir"
     key -k BackSpace >/dev/null
     wait_path "$dir"
-    wait_listing 6
+    wait_listing 5
 
     # The grid, a different delegate in a different file carrying the same contract.
     click_chrome grid

--- a/tests/ui.sh
+++ b/tests/ui.sh
@@ -1923,7 +1923,6 @@ case_watch() {
     rm "$dir/beta.txt"
     mkdir "$dir/brand-new-folder"
     # The 400 ms settle plus the re-read; the reporter waited several seconds and saw nothing move.
-    # Four rows now: brand-new-folder, NEWFILE-appeared.txt, alpha-RENAMED.txt, preview-me.txt.
     omarchy-drive wait ipc -p "$flea_ui" flea total 4 --timeout 15 >/dev/null \
         || fail "watch: the listing stayed at $(ipc total) rows after four outside changes"
     settle
@@ -1968,6 +1967,46 @@ case_watch() {
     omarchy-drive wait ipc -p "$flea_ui" flea total 6 --timeout 15 >/dev/null \
         || fail "watch: clearing the selection did not run the owed re-read, total is $(ipc total)"
     printf 'WATCH deferred=ok paid=ok total=%s\n' "$(ipc total)"
+
+    # A directory under continuous writing still has to settle. The timer absorbs notifications rather
+    # than being restarted by them, so the sample that matters is taken WHILE the writing is still
+    # going: a restart() is pushed forward by every notification and re-reads nothing until the writer
+    # stops, which a sample taken afterwards cannot tell apart from a timer that fired all along.
+    local before during writer n
+    before=$(ipc total)
+    ( for n in $(seq 1 40); do
+          printf 'x\n' > "$dir/stream-$n.txt"
+          sleep 0.1
+      done ) &
+    writer=$!
+    sleep 1.2
+    during=$(ipc total)
+    wait "$writer"
+    printf 'WATCH stream before=%s during=%s after=%s\n' "$before" "$during" "$(ipc total)"
+    (( during > before )) \
+        || fail "watch: nothing re-read while the directory was still being written, total stayed $before"
+
+    # A debt owed by this directory must not be paid by re-listing the next one. The selection is what
+    # holds the debt, and leaving clears that selection, so without the guard the owed re-read fires
+    # against whatever the pane has just opened.
+    key v >/dev/null
+    settle
+    printf 'owed\n' > "$dir/CCC-owed-on-leaving.txt"
+    sleep 0.5
+    # Counted from before the navigation, not from after it: the owed re-read lands about 400 ms after
+    # the selection clears, which is inside wait_path's own polling, so a sample taken on arrival has
+    # already counted it and could never tell the two apart.
+    local before_nav after_nav
+    before_nav=$(ipc listRequests)
+    key -k Backspace >/dev/null
+    wait_path "$fixture_root"
+    sleep 1.5
+    after_nav=$(ipc listRequests)
+    printf 'WATCH carried lists %s to %s, one navigation and nothing else\n' "$before_nav" "$after_nav"
+    (( after_nav == before_nav + 1 )) \
+        || fail "watch: leaving cost $(( after_nav - before_nav )) listings, so a debt owed for the directory just left was paid by the one the pane moved to"
+    key -k Escape >/dev/null
+    settle
     assert_window
     kill_flea
 }

--- a/tests/ui.sh
+++ b/tests/ui.sh
@@ -5964,21 +5964,26 @@ settings_menu_lacks() {
         || fail "settings: $label is still in the menu, got $(ipc contextMenuEntries)"
 }
 
-# The Mac/Windows toggle, proved by the keys themselves: a chord one preset binds and the other
+# The Default/Windows toggle, proved by the keys themselves: a chord one preset binds and the other
 # does not, driven through the real window in both states.
 settings_keys() {
     key , >/dev/null
     settle
     settings_section keys
-    [[ "$(ipc settingsRows)" == *"choice|Keybinding preset|Mac"* ]] \
-        || fail "settings: the preset row does not start on Mac, got $(ipc settingsRows)"
-    [[ "$(ipc settingsRows)" == *"fact|connect to server|ctrl-k"* ]] \
-        || fail "settings: the Mac preset lists none of its own chords"
+    # The shipped preset is "default", which ui/js/Settings.js labels Default and PRESET_KEYS gives
+    # ctrl-1 to ctrl-3; a window that starts anywhere else is not the one this checks the toggle on.
+    [[ "$(ipc settingsRows)" == *"choice|Keybinding preset|Default"* ]] \
+        || fail "settings: the preset row does not start on Default, got $(ipc settingsRows)"
+    [[ "$(ipc settingsRows)" == *"fact|list view|ctrl-1"* ]] \
+        || fail "settings: the Default preset lists none of its own chords"
     shot settings-keys
+    # PRESETS is default, vim, mac, windows, so Windows is three steps along and not one.
+    key l >/dev/null
+    key l >/dev/null
     key l >/dev/null
     settle
     [[ "$(ipc settingsRows)" == *"choice|Keybinding preset|Windows"* ]] \
-        || fail "settings: l did not step the preset to Windows"
+        || fail "settings: three steps of l did not reach Windows"
     [[ "$(ipc settingsRows)" == *"fact|hidden files|ctrl-h"* ]] \
         || fail "settings: the Windows preset lists none of its own chords"
     key -k Escape >/dev/null

--- a/ui/Backend.qml
+++ b/ui/Backend.qml
@@ -29,6 +29,9 @@ Item {
     signal paths(var list)
     signal meta(int row, int w, int h, real durationMs, int sampleRate, int entries, real unpacked, bool archiveFailed, var names, real lines, bool partial, bool linesFailed, string target, bool targetDir, string owner)
     signal fsInfo(string fs, real free)
+    // The one line no request asked for: the directory the current listing came from changed under
+    // it. path is that directory, so a pane that has since moved can ignore it; see docs/protocol.md.
+    signal changed(string path)
     // readFailed tells a zero-row answer apart from an empty directory; mode is that directory's own, 0 when the stat failed too.
     // hidden is the flag the request carried, echoed by the backend: two clients peek this wire, so path alone does not say whose reply this is.
     signal peeked(string path, bool hidden, int total, var rows, bool readFailed, int mode)
@@ -238,6 +241,7 @@ Item {
     // Sample input: {"t":"rows","start":0,"rows":[{"n":"a.txt","d":false,"s":3,"m":1787790423,"p":33188,"i":"text-x-generic","t":false,"k":0}],"kinds":["Plain text document"],"ms":1.250}
     // Sample input: {"t":"thumbed","row":2,"file":"/home/gm/.cache/thumbnails/large/b98fa4.png","ms":75.823}
     // Sample input: {"t":"dirsized","row":4,"bytes":1048576,"partial":false,"ms":12.500}
+    // Sample input: {"t":"changed","path":"/home/gm/Downloads"}
     // Sample input: {"t":"searching","n":812,"scanned":41200,"ms":300.114}
     // Sample input: {"t":"transferstarted","id":12,"n":2,"moving":true}
     // Sample input: {"t":"transferprogress","id":12,"index":0,"name":"a.txt","bytes":40000000,"total":120000000}
@@ -297,6 +301,8 @@ Item {
             root.meta(message.row, message.w, message.h, message.ms, message.rate, message.entries, message.unpacked, message.afailed, message.names, message.lines, message.partial, message.lfailed === true, message.target, message.targetdir, message.owner || "")
         } else if (message.t === "fsinfo") {
             root.fsInfo(message.fs, message.free)
+        } else if (message.t === "changed") {
+            root.changed(message.path || "")
         } else if (message.t === "peeked") {
             root.peeked(message.path, message.hidden === true, message.n, message.rows || [], message.failed === true, message.mode || 0)
         } else if (message.t === "formats") {

--- a/ui/Backend.qml
+++ b/ui/Backend.qml
@@ -59,6 +59,9 @@ Item {
     property int thumbRequests: 0
     // Same gate, for dirsize: a fling must issue none of these either.
     property int dirSizeRequests: 0
+    // Same idiom again, for the watched re-read: a debt owed by the directory the pane has left must
+    // cost the one it arrived in no listing at all, which only a count can say; see tests/ui.sh watch.
+    property int listRequests: 0
 
     // A write before the child is spawned is dropped silently, so an early request waits here.
     property var pending: []
@@ -82,6 +85,7 @@ Item {
     }
 
     function list(path, first, hidden) {
+        root.listRequests += 1
         // A fresh scan is always name ascending, so every refresh after a write operation puts the
         // header's mark back rather than leaving it describing the order before the refresh.
         root.sortBy = "name"

--- a/ui/Ipc.qml
+++ b/ui/Ipc.qml
@@ -201,6 +201,7 @@ QtObject {
         function visibleRows(): int { return root.pane.visibleRows }
         function thumbRequests(): int { return root.backend.thumbRequests }
         function dirSizeRequests(): int { return root.backend.dirSizeRequests }
+        function listRequests(): int { return root.backend.listRequests }
         function thumbFile(i: int): string { return root.pane.thumbFor(i) }
         function rowCentre(i: int): string { return root.pane.rowFor(i) ? root.fleaWindow.centreOf(root.pane.visibleItemFor(i)) : "" }
         // The same lookup as rowCentre, but for the preview's own seek slider, so a test can drive

--- a/ui/PaneWire.qml
+++ b/ui/PaneWire.qml
@@ -84,6 +84,16 @@ Item {
         onTriggered: root.reread()
     }
 
+    // A debt owed for the directory the pane has left is not owed by the one it arrived in: without
+    // this, a change in A held back by a selection is paid by a full re-list of B.
+    Connections {
+        target: pane
+        function onPathChanged() {
+            root.stale = false
+            watchSettle.stop()
+        }
+    }
+
     // Only when the cursor really landed on the folder that was made: on a listing wider than the
     // window the refresh may not hold that row at all, and ui/RenameField.qml lives in ui/Row.qml
     // alone, so the other two views would arm an editor nothing draws and never disarm it.

--- a/ui/PaneWire.qml
+++ b/ui/PaneWire.qml
@@ -90,6 +90,7 @@ Item {
         target: pane
         function onPathChanged() {
             root.stale = false
+            root.anchor = null
             watchSettle.stop()
         }
     }

--- a/ui/PaneWire.qml
+++ b/ui/PaneWire.qml
@@ -19,6 +19,19 @@ Item {
     // The new folder has no row until the refresh lands, so the editor is opened on the rows reply
     // that carries it rather than on the made line that asked for it. Holds that folder's full path.
     property string renameOnArrival: ""
+    // A watched change landed while one of the states below owned the rows, so the re-read is owed.
+    property bool stale: false
+    // What the cursor sat on across a watched re-read, or null; ui/js/Nav.js owns both ends of it.
+    property var anchor: null
+    // One burst of writes is one re-read: the timer absorbs later notifications instead of being
+    // restarted by them, so a directory under continuous change settles rather than never firing.
+    readonly property int watchMs: 400
+    // A re-read replaces every row, so it waits for the states that name a row by index or hold one
+    // open: an editor, the menu over a row, a filter being typed, a search listing, a selection whose
+    // indices would name other files afterwards, and a list already in flight.
+    readonly property bool watchBusy: !pane || pane.listInFlight || pane.renamingIndex >= 0
+            || pane.menuVisible || pane.filterTyping || pane.searchMode.length > 0
+            || pane.selectionCount() > 0
     // ui/Pane.qml reaches the three through these: openCursor takes the opener, the menu reads the
     // Taildrop peers, and the two share actions call the other two.
     readonly property alias opener: opener
@@ -48,6 +61,27 @@ Item {
         // minutes, not the scale of opening a context menu, and refreshing on open would make
         // the menu's own height (and the clamp openAt applies) depend on an async reply.
         Component.onCompleted: refresh()
+    }
+
+    // The owed re-read, run when nothing is holding the rows. A refusal keeps the debt rather than
+    // dropping it, and watchBusy going false below is what pays it.
+    function reread() {
+        if (root.watchBusy)
+            return
+        root.stale = false
+        root.anchor = Nav.refreshWatched(pane)
+    }
+
+    // The owed re-read goes through the timer rather than straight out of this handler: reading
+    // watchBusy back inside its own change notification re-enters the binding, which Qt reports as a
+    // binding loop, and reread() writes listInFlight, which watchBusy reads.
+    onWatchBusyChanged: if (root.stale && !watchSettle.running) watchSettle.start()
+
+    Timer {
+        id: watchSettle
+        interval: root.watchMs
+        repeat: false
+        onTriggered: root.reread()
     }
 
     // Only when the cursor really landed on the folder that was made: on a listing wider than the
@@ -94,6 +128,7 @@ Item {
             if (pane.rowsAt === 0 && pane.inputAt > 0 && pane.rowFor(pane.cursorIndex))
                 pane.rowsAt = Date.now()
             pane.applyPendingSelect()
+            root.anchor = Nav.applyAnchor(pane, root.anchor)
             Tabs.applyPending(pane)
             root.openRenameOnArrival()
             pane.listArea.restartSettle()
@@ -133,6 +168,17 @@ Item {
             // fix that: it asks for a window only on drift, and a full held one drifts on neither edge.
             Search.ranked(pane)
             pane.listArea.restartSettle()
+        }
+
+        // Sample input: {"t":"changed","path":"/home/gm/Downloads"}
+        // Unsolicited, and the only line here that is: the listed directory changed under the pane.
+        function onChanged(path) {
+            // A notification for a directory the pane has already left says nothing about this one.
+            if (path !== pane.path)
+                return
+            root.stale = true
+            if (!watchSettle.running)
+                watchSettle.start()
         }
 
         // A thumbed line for the previous listing is still in the pipe when open() clears the map.

--- a/ui/js/Nav.js
+++ b/ui/js/Nav.js
@@ -121,7 +121,7 @@ function refreshWatched(pane) {
     var row = pane.rowFor(pane.cursorIndex)
     // The path rides along because the anchor can outlive one rows reply: a navigation between the
     // two below would otherwise put this directory's cursor row onto the next directory's listing.
-    var anchor = { name: row ? String(row.n) : "", index: pane.cursorIndex, start: pane.held, path: pane.path, waited: false }
+    var anchor = { name: row ? String(row.n) : "", index: pane.cursorIndex, start: pane.held, path: pane.path }
     var query = pane.filterQuery
     pane.openWithoutHistory(pane.path)
     // A filter narrows the rows the pane holds rather than choosing which directory it holds, so it
@@ -151,10 +151,9 @@ function applyAnchor(pane, anchor) {
             return null
         }
     }
-    // One reply's grace for the window asked for above, and no more: a listing that shrank below that
-    // offset comes back clamped to row 0, which is not the reply still being waited for.
-    if (anchor.start > 0 && pane.held === 0 && !anchor.waited) {
-        anchor.waited = true
+    // Still the first window rather than the one asked for above, so keep waiting, but only while that
+    // window can still exist: a listing that shrank past the offset comes back clamped to row 0 instead.
+    if (anchor.start > 0 && pane.held === 0 && pane.total > anchor.start) {
         return anchor
     }
     if (pane.total > 0) {

--- a/ui/js/Nav.js
+++ b/ui/js/Nav.js
@@ -121,7 +121,7 @@ function refreshWatched(pane) {
     var row = pane.rowFor(pane.cursorIndex)
     // The path rides along because the anchor can outlive one rows reply: a navigation between the
     // two below would otherwise put this directory's cursor row onto the next directory's listing.
-    var anchor = { name: row ? String(row.n) : "", index: pane.cursorIndex, start: pane.held, path: pane.path }
+    var anchor = { name: row ? String(row.n) : "", index: pane.cursorIndex, start: pane.held, path: pane.path, waited: false }
     var query = pane.filterQuery
     pane.openWithoutHistory(pane.path)
     // A filter narrows the rows the pane holds rather than choosing which directory it holds, so it
@@ -151,7 +151,10 @@ function applyAnchor(pane, anchor) {
             return null
         }
     }
-    if (anchor.start > 0 && pane.held === 0) {
+    // One reply's grace for the window asked for above, and no more: a listing that shrank below that
+    // offset comes back clamped to row 0, which is not the reply still being waited for.
+    if (anchor.start > 0 && pane.held === 0 && !anchor.waited) {
+        anchor.waited = true
         return anchor
     }
     if (pane.total > 0) {

--- a/ui/js/Nav.js
+++ b/ui/js/Nav.js
@@ -110,6 +110,56 @@ function refresh(pane, selectPath) {
     pane.openWithoutHistory(pane.path)
 }
 
+// A change another program made under the open listing, unlike refresh() above which follows Flea's
+// own write. The rows are read again and the cursor is put back on the file it was on by name,
+// because a create above it renumbers every row below and a listing that jumped back to the top
+// would move the user while they were reading it. Returns the anchor applyAnchor() resolves, or null.
+function refreshWatched(pane) {
+    if (pane.listInFlight) {
+        return null
+    }
+    var row = pane.rowFor(pane.cursorIndex)
+    // The path rides along because the anchor can outlive one rows reply: a navigation between the
+    // two below would otherwise put this directory's cursor row onto the next directory's listing.
+    var anchor = { name: row ? String(row.n) : "", index: pane.cursorIndex, start: pane.held, path: pane.path }
+    var query = pane.filterQuery
+    pane.openWithoutHistory(pane.path)
+    // A filter narrows the rows the pane holds rather than choosing which directory it holds, so it
+    // survives a re-read of the same directory; every other caller of openWithoutHistory drops it.
+    pane.filterQuery = query
+    // The re-read answers from row 0, so a cursor deep in a large directory needs its own window back
+    // before the anchor's name can be looked for anywhere near where it was.
+    if (anchor.start > 0) {
+        pane.backend.window(anchor.start, pane.windowSize)
+    }
+    return anchor
+}
+
+// Runs on each rows reply while an anchor stands. The name can arrive in the listing's own first
+// window or in the one asked for above, so a miss in the first is not yet a miss. A name that is
+// gone from both leaves the old index, which keeps the view where the user left it.
+function applyAnchor(pane, anchor) {
+    if (!anchor) {
+        return null
+    }
+    if (pane.path !== anchor.path) {
+        return null
+    }
+    for (var i = 0; i < pane.rows.length; i++) {
+        if (String(pane.rows[i].n) === anchor.name) {
+            pane.setCursor(pane.held + i)
+            return null
+        }
+    }
+    if (anchor.start > 0 && pane.held === 0) {
+        return anchor
+    }
+    if (pane.total > 0) {
+        pane.setCursor(Math.min(anchor.index, pane.total - 1))
+    }
+    return null
+}
+
 // Only the first rows response looks for the target, then it is forgotten either way, so a later
 // directory change never re-reveals it. The target is a full path, which is what --select carries.
 function applyPendingSelect(pane) {


### PR DESCRIPTION
Fixes #68, reported by @adam-lagerhausen.

**The defect.** The backend answered `list` and then stopped looking at the directory. `Nav.refresh()` existed but ran only after Flea's own writes, so a create, rename or delete by another program stayed invisible until the pane left the folder and came back. `docs/protocol.md` carried no line the backend could send unprompted, so there was nothing for the UI to react to either.

**The watch.** `src/backend/watch.rs` holds one non-recursive inotify watch on the directory last listed, and the backend answers `{"t":"changed","path":"<dir>"}` when it moves. The new watch is armed BEFORE the scan, because a change `readdir` races is missing from the rows that scan is about to answer with: on the 100,000 file fixture a create during the scan produced no `changed` line at all, and the same create a second later produced one. It is armed beside the current watch rather than in place of it, so a `list` that fails to scan costs the directory still on screen nothing. `inotify_add_watch` returns the descriptor it already holds for an inode, so re-listing the same folder aliases the new watch onto the live one; `commit()`, `abandon()` and `stop()` all compare before removing, or a refresh would unwatch the folder it had just re-armed. A folder inotify refuses is reported once per listing rather than going stale in silence.

**The re-read.** `ui/PaneWire.qml` starts a 400 ms timer on the first `changed` after idle and lets later ones land inside it rather than restarting it, so a folder under continuous writing still settles instead of never refreshing at all. It holds the re-read back while a rename editor, a context menu, a filter, a search listing or a live selection is open, and pays that debt when the pane goes idle, because a selection is a set of row indices and a new listing renames what they point at. `Nav.refreshWatched()` anchors the cursor by filename rather than index, since a create above it renumbers every row below, and asks for the window the cursor was in when it sits below the first. That wait is on the window arriving and not on a count of replies, and it ends when the listing has shrunk to that offset or below, the one case where the backend clamps the window to row 0 and the reply is never coming.

Proof on the box: `tests/run-all.sh` 23 suites 0 failed, `tests/ui.sh` 45 of 45, `cargo test` 437 passed in debug and in release, the JS suites 1780 + 4 + 9 checks 0 failed, and 0 warnings from `cargo build`, `build --release`, `test` and `test --release`. The reporter's repro is `case_watch` in `tests/ui.sh`.

Every guard was mutated on a copy of this tree and shown to redden, with the control back to 0 after each: dropping the aliasing guard from `commit()` takes `tests/protocol.sh` to 2 failures; dropping it from `abandon()` fails the new unit test in 2.06s, which opens a real inotify descriptor and checks the event mask rather than the descriptor, because a removed watch's own `IN_IGNORED` carries the same one and a descriptor-only check would pass whether the watch was alive or dead; deleting the anchor's clamp condition takes `tests/js/watch.js` to 2 failures, widening it to `>=` takes it to 1, and restoring the reply counter it replaced takes it to 3.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Directory listings now detect external file changes and refresh automatically.
  - Updates are briefly debounced during bursts of changes.
  - Active filters are preserved, and the cursor remains anchored to the same filename when possible.
  - Refreshes are deferred while selections or editing are active.

- **Documentation**
  - Documented directory-change notifications and watching behavior.

- **Tests**
  - Added coverage for filesystem changes, cursor handling, navigation, filtering, and deferred refreshes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->