### PR TITLE
fix: PDF preview shows an empty dark frame

### DIFF
--- a/ui/PreviewPdf.qml
+++ b/ui/PreviewPdf.qml
@@ -45,6 +45,20 @@ Item {
         source: root.active && root.path.length > 0 ? Format.fileUri(root.path) : ""
     }
 
+    // The page's own paper, painted beneath the raster: on this box the rendered page can arrive
+    // with a transparent background, text drawn and paper not, and the dark frame behind showed
+    // through it (measured in the Quick Look and in the column, Vulkan and GL, with the document
+    // Ready and the page count right). The paper is the document's own, not a theme role, so the
+    // colour is a constant: every page this draws is white wherever the raster itself would be.
+    // Visible exactly when the page is, so a document still loading draws no white rectangle.
+    Rectangle {
+        anchors.centerIn: parent
+        visible: page.visible
+        width: page.width
+        height: page.height
+        color: "#ffffff"
+    }
+
     // The page is the only light surface in the app, which is exactly what the canvas draws.
     PdfPageImage {
         id: page


### PR DESCRIPTION
## The problem

Previewing a PDF — `l`/Space in the list, or the preview frame in the columns view — opens an empty dark frame. The document actually loads fine (the page count shows, the pager works), but the page itself doesn't appear, or only its text shows floating on the dark background.

<img width="1008" height="364" alt="ev-columns-pair" src="https://github.com/user-attachments/assets/ac35a27b-e450-4499-b9ac-aa19456c1bdc" />

<img width="1408" height="770" alt="ev-overlay-pair" src="https://github.com/user-attachments/assets/48b7dfc2-737d-4b3a-a924-d6b98e8488c0" />


## Why

Qt's PDF page image sometimes arrives with a transparent background: the text is there, the white paper isn't. The dark frame behind shows through, and the whole thing reads as "empty". The app can't tell — the document reports Ready — only the pixels are wrong.

## The fix

One small change in `ui/PreviewPdf.qml`: paint the paper ourselves. A white rectangle sits exactly behind the page image, visible only while a document is actually shown. If Qt delivers the paper normally, the rectangle is simply hidden behind it; if not, it *is* the paper.

Both the Quick Look and the columns preview share this file, so one change covers both.

## Screenshots

<!-- images: paste the before/after PNGs here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Added a white page background behind visible PDF pages, providing a clearer paper-like appearance during document viewing.
  * The background is sized and centered to match the displayed page and remains hidden while the document is loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->