### PR TITLE
fix: a path already gone is not trashed, and does not block undo

### DIFF
--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -837,7 +837,8 @@ Example: `{"t":"trashed","ok":1,"failed":0}`
 
 Counts only. Unlike `transferitem` there is no per-path error text, because trash is one `gio` call for
 the batch and its exit status cannot attribute a failure to a single path; a path that is still on disk
-afterwards is counted in `failed`.
+afterwards is counted in `failed`, and so is one that was not on disk before, which a stale listing can
+name: nothing this call did not do is journaled, so `undo` reverses exactly the `ok` ones.
 
 ### renamed
 

--- a/src/backend/trash.rs
+++ b/src/backend/trash.rs
@@ -46,12 +46,19 @@ pub fn list() -> Vec<Entry> {
 // The URI is captured here rather than looked up later, because gio trash --restore refuses an original
 // path outright and two files trashed from one path both list that same path, so a later lookup is ambiguous.
 pub fn trash(paths: &[PathBuf]) -> (Vec<Entry>, usize) {
-    if paths.is_empty() {
-        return (Vec::new(), 0);
+    // A path that is not on disk before the call is nothing this call trashed, so it is counted failed and
+    // never journaled: read as "gone, so it went" it became a Trashed step with no URI, and undo stopped
+    // on that step and left the rest of the batch in the trash. A stale listing is where such a path
+    // comes from, and the changed line is what refreshes it.
+    let (present, missing): (Vec<&PathBuf>, Vec<&PathBuf>) =
+        paths.iter().partition(|p| p.symlink_metadata().is_ok());
+    let mut failed = missing.len();
+    if present.is_empty() {
+        return (Vec::new(), failed);
     }
     let before = list();
     let mut argv: Vec<String> = vec!["trash".to_string(), "--".to_string()];
-    for p in paths {
+    for p in &present {
         argv.push(p.to_string_lossy().to_string());
     }
     let refs: Vec<&str> = argv.iter().map(|s| s.as_str()).collect();
@@ -59,8 +66,7 @@ pub fn trash(paths: &[PathBuf]) -> (Vec<Entry>, usize) {
     let _ = gio(&refs);
     let after = list();
     let mut ok = Vec::new();
-    let mut failed = 0;
-    for p in paths {
+    for p in present {
         if p.symlink_metadata().is_ok() {
             failed += 1;
             continue;
@@ -103,6 +109,17 @@ fn err(msg: &str) -> FleaError {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::backend::testdir::TestDir;
+
+    // No gio runs for this one, because there is nothing on disk to hand it, so the test needs no trash.
+    #[test]
+    fn a_path_that_was_already_gone_is_a_failure_and_not_a_step_to_undo() {
+        let d = TestDir::new("trashgone");
+        let gone = d.join("never-existed.txt");
+        let (entries, failed) = trash(&[gone.clone(), d.join("nor-this")]);
+        assert!(entries.is_empty(), "nothing this call did not do can be undone");
+        assert_eq!(failed, 2);
+    }
 
     #[test]
     fn a_list_line_splits_on_the_tab_and_keeps_a_path_containing_spaces() {

--- a/tests/ops.sh
+++ b/tests/ops.sh
@@ -114,6 +114,22 @@ check "undo names trash as what it reversed" "1" "$(seen '"t":"undone","op":"tra
 check "the file is back with its bytes" "trash me" "$(cat "$D/doomed.txt" 2>/dev/null)"
 stop_backend
 
+echo "--- a path already gone counts as failed, and undo still restores the rest ---"
+# The listing this batch was built from can be stale: the file another program deleted is still a row
+# until the changed line's re-read lands. Counting it as trashed journaled a step with no trash entry,
+# and undo, reversing newest first, stopped on it and left the file that really went in the trash.
+start_backend
+printf 'still here' > "$D/real.txt"
+send "{\"c\":\"trash\",\"paths\":[\"$D/real.txt\",\"$D/already-gone.txt\"]}"
+await '"t":"trashed"' || fail=1
+check "the one on disk went and the one that was not is a failure" "1" "$(seen '"t":"trashed","ok":1,"failed":1')"
+check "the real file is in the trash" "no" "$([ -e "$D/real.txt" ] && echo yes || echo no)"
+send '{"c":"undo"}'
+await '"t":"undone"' || fail=1
+check "undo reverses the trash rather than stopping on the missing path" "1" "$(seen '"t":"undone","op":"trash","ok":true')"
+check "the real file is back with its bytes" "still here" "$(cat "$D/real.txt" 2>/dev/null)"
+stop_backend
+
 echo "--- copy transfer, and undo removes what it created ---"
 start_backend
 printf 'one' > "$D/c1.txt"; printf 'two' > "$D/c2.txt"; mkdir -p "$D/dest"


### PR DESCRIPTION
## The bug

`trash::trash` decided which paths went by stat-ing each one after the `gio trash` call: still on disk means failed, anything else means trashed. A path that was already gone before the call, which a stale listing can name until the `changed` re-read lands, therefore counted as `ok` and was journaled as a `Trashed` step with an empty URI.

`Journal::undo` reverses newest first and stops on the first failure, so with `paths:["real.txt","already-gone.txt"]` the reply was `trashed ok:2 failed:0`, and the undo answered "this item was trashed without a trash entry, so it cannot be restored". `real.txt` stayed in the trash and the entry was spent, so the next undo reached an older operation. With the order reversed the real file was restored and then the error fired, so the outcome depended on row order.

## The fix

The paths are partitioned before `gio` runs. One that is not on disk is counted in `failed` and never becomes a step; a batch with nothing present never runs `gio` at all. The rule for a path still on disk after the call is unchanged, and so is the corner where a file went but `gio` listed no entry for it. `docs/protocol.md`'s `trashed` section says so.

## Tests

- Unit test in `trash.rs`: two missing paths answer no entries and `failed:2`, without running `gio`.
- `tests/ops.sh` gains a scenario trashing a real file beside a path that never existed: `ok:1 failed:1`, and the undo restores the real file with its bytes. On the unfixed binary it fails three checks: the reply reads `ok:2`, the undo answers an error, and the file stays in the trash.
- `cargo test`: 442 passed, zero warnings in debug and release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AnB5YmkdfX8Yri7gSGuAWf
