### PR TITLE
fix: a search row's kind is read from its name, not its path

### DIFF
--- a/src/backend/mime.rs
+++ b/src/backend/mime.rs
@@ -70,8 +70,12 @@ impl Db {
         Db { by_suffix_cs, by_suffix, by_name_cs, by_name }
     }
 
-    // Takes a file name, never a path: a directory component must not be read as an extension.
+    // Answers for the last component alone. A search or listpaths row is a path relative to the listing's
+    // base, and looked up whole the by-name tables never matched it: src/Makefile listed as Data and
+    // src/CMakeLists.txt as Plain text document, while a directory component's dot could offer a suffix
+    // of its own and a hidden file below the base could stop reading as hidden.
     pub fn lookup(&self, name: &str) -> Option<&str> {
+        let name = name.rsplit('/').next().unwrap_or(name);
         let lower = name.to_lowercase();
         if let Some((_, mime)) = self.by_name_cs.get(name) {
             return Some(mime);
@@ -135,6 +139,17 @@ mod tests {
         assert_eq!(d.lookup("notes.txt"), Some("text/plain"));
         assert_eq!(d.lookup("clip.mp4"), Some("video/mp4"));
         assert_eq!(d.lookup("paper.pdf"), Some("application/pdf"));
+    }
+
+    // A search row is "src/Makefile" and a listpaths row "home/gm/notes.txt": the name is the last component.
+    #[test]
+    fn a_relative_path_is_looked_up_by_its_last_component() {
+        let d = db();
+        assert_eq!(d.lookup("src/makefile"), Some("text/x-makefile"), "the by-name table sees the name");
+        assert_eq!(d.lookup("deep/er/holiday.jpg"), Some("image/jpeg"));
+        assert_eq!(d.lookup("v1.2/noextension"), None, "a directory's dot is not an extension");
+        assert_eq!(d.lookup("src/.jpg"), None, "a hidden file below the base is still hidden");
+        assert_eq!(d.lookup("photos.jpg/readme"), None);
     }
 
     #[test]

--- a/tests/protocol.sh
+++ b/tests/protocol.sh
@@ -70,6 +70,18 @@ check "listpaths reports no sort pass" "0.000" "$(echo "$out" | head -1 | grep -
 out=$(printf '{"c":"listpaths","paths":["etc/hostname","/",""],"first":10}\n{"c":"quit"}\n' | $BIN --backend)
 check "listpaths refuses a path that is not absolute" "0" "$(echo "$out" | head -1 | grep -oE '"n":[0-9]+' | cut -d: -f2)"
 
+# A search row is a path relative to the base, and its kind is read from the name at the end of it.
+# The lookup took the whole path and its by-name table never matched one: sub/Makefile answered Data
+# where list answered Makefile build file for the same file, so the two listings are held to one answer.
+: > "$D/sub/Makefile"
+listed_kind=$(printf '{"c":"list","path":"%s/sub","first":10}\n{"c":"quit"}\n' "$D" | $BIN --backend | sed -n 2p | grep -o '"kinds":\[[^]]*\]')
+searched_kind=$( ( printf '{"c":"search","path":"%s","query":"makefile","hidden":false}\n' "$D"
+                   sleep 0.6
+                   printf '{"c":"window","start":0,"count":10}\n{"c":"quit"}\n' ) | $BIN --backend | grep -o '"n":"sub/Makefile".*"kinds":\[[^]]*\]' | grep -o '"kinds":\[[^]]*\]')
+check "list gives the nested Makefile a kind of its own, not Data" "0" "$(echo "$listed_kind" | grep -c '"Data"')"
+check "a search row carries the kind list gives the same file" "$listed_kind" "$searched_kind"
+rm -f "$D/sub/Makefile"
+
 # Task 11: rows carries a per-response Kind dictionary, read against the box's real freedesktop tables, see docs/protocol.md "rows".
 kind_out=$(printf '{"c":"list","path":"%s","first":10}\n{"c":"quit"}\n' "$D" | $BIN --backend)
 kind_row=$(echo "$kind_out" | sed -n 2p)


### PR DESCRIPTION
## The bug

`mime::Db::lookup` is documented as taking a file name, never a path. `rows_line` and `thumb_rows` pass it `listing.name(i)` verbatim, which for a `search` or `listpaths` listing is the path relative to the base (`docs/protocol.md`: "each match is pushed as its path relative to `path`"). The by-name globs (`makefile`, `cmakelists.txt`, `meson.build`, `dockerfile`, ...) are keyed on bare names, so they never matched a nested row.

Driven against the backend on a tree holding `Makefile`, `src/Makefile` and `src/CMakeLists.txt`, a search answered:

```
"kinds":["Makefile build file","Data","Plain text document"]
```

with `src/Makefile` as "Data" and `src/CMakeLists.txt` as "Plain text document" via the `.txt` suffix. The same files listed directly answer "Makefile build file" and "CMake source code". The picker's Recent (`listpaths`) has the same defect, and two smaller ones ride along: a directory component's dot could offer a suffix of its own (`v1.2/notes`), and a hidden file below the base (`src/.jpg`) no longer read as hidden because its dot was not at offset 0.

## The fix

`lookup` takes the last `/`-separated component itself, so every caller is covered with one change: the rows line, the thumbnail request's declared-MIME check, and `peek`'s icon.

## Tests

- Unit test in `mime.rs` for the nested by-name hit, a nested suffix, a directory's dot, a hidden file below the base, and a name with no extension under a directory that has one.
- `tests/protocol.sh` holds a search row to the kind `list` gives the same nested Makefile. On the old binary it fails with `expected "kinds":["Makefile build file"]`, `actual "kinds":["Data"]`.
- `cargo test`: 442 passed, zero warnings in debug and release. `tests/ops.sh` passes. The three `protocol.sh` thumbnail checks that need the 4.7 GB media fixture were not runnable on this box, before or after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AnB5YmkdfX8Yri7gSGuAWf
