### PR TITLE
fix: a tab switch spends its pending order on the first rows reply

### DIFF
--- a/tests/js/tabs.js
+++ b/tests/js/tabs.js
@@ -211,4 +211,21 @@ function run(check) {
           pending.sorted.join(",") + "|" + pending.cursorIndex, "size:true|4")
     Tabs.applyPending(pending)
     check("the next rows reply restores the cursor", pending.cursorIndex, 9)
+
+    // A switch that re-lists records the tab's order as pending, and a fresh listing is already name
+    // ascending, which is the order most tabs record: left pending because it matched, it reverted
+    // the user's next sort on the rows reply that answered it, and only the second press stuck.
+    var settled = pane("/home/gm/a")
+    Tabs.act("tabNew", settled)
+    settled.path = "/home/gm/b"
+    Tabs.act("tab1", settled)
+    check("a switch that re-lists records the tab's own order", settled.tabs.pendingSortBy, "name")
+    Tabs.applyPending(settled)
+    check("an order the fresh listing already has is spent by the first rows reply, not asked for",
+          settled.tabs.pendingSortBy + "|" + settled.sorted.join(","), "|")
+    check("and the cursor is restored on that same reply", settled.cursorIndex, 4)
+    settled.backend.sortBy = "size"
+    settled.backend.sortDesc = true
+    Tabs.applyPending(settled)
+    check("so the user's own sort survives the rows reply that answers it", settled.sorted.join(","), "")
 }

--- a/ui/js/Tabs.js
+++ b/ui/js/Tabs.js
@@ -165,17 +165,20 @@ function applyPending(pane) {
     if (!pane.tabs)
         return
     var t = pane.tabs
-    if (t.pendingSortBy && t.pendingSortBy.length > 0
-            && pane.backend
-            && (pane.backend.sortBy !== t.pendingSortBy || pane.backend.sortDesc !== t.pendingSortDesc)) {
+    // The pending order is spent on the first rows reply whether or not it has to be asked for: a
+    // fresh listing is name ascending, so a tab recorded in that order was left pending for the life
+    // of the tab, and the user's next sort was reverted to name by the rows reply that answered it.
+    if (t.pendingSortBy && t.pendingSortBy.length > 0 && pane.backend) {
         var by = t.pendingSortBy
         var desc = t.pendingSortDesc
         t.pendingSortBy = ""
-        pane.backend.sort(by, desc)
-        pane.backend.sortBy = by
-        pane.backend.sortDesc = desc
-        pane.backend.window(0, pane.windowSize)
-        return
+        if (pane.backend.sortBy !== by || pane.backend.sortDesc !== desc) {
+            pane.backend.sort(by, desc)
+            pane.backend.sortBy = by
+            pane.backend.sortDesc = desc
+            pane.backend.window(0, pane.windowSize)
+            return
+        }
     }
     if (t.pendingCursor >= 0) {
         var last = pane.total > 0 ? pane.total - 1 : 0


### PR DESCRIPTION
## The bug

`Tabs.apply` on a switch that re-lists records the tab's order in `pendingSortBy`, and `Backend.list` resets the order to name ascending, which is the order most tabs record. `Tabs.applyPending`, run by `PaneWire.onRows` on every rows reply, cleared `pendingSortBy` only inside the branch that found the order different and asked for it. A pending `"name"` that already matched was therefore never cleared and stayed pending for the life of that tab.

The next time the user sorted in that tab (`s`, `S`, or a header click), the rows reply answering their sort ran `applyPending` again, saw `"name" !== "size"`, and sent `sort("name", false)`: the header flickered and landed back on Name. The second press stuck, because the revert branch is the one that clears the field.

## The fix

The pending order is spent on the first rows reply whichever way the comparison goes. If it differs it is asked for as before; if the fresh listing already has it, nothing is sent and the pending cursor is restored on that same reply instead of the next one.

## Tests

- `tests/js/tabs.js` drives a two-tab switch: the pending order is recorded, the first rows reply spends it without a sort request and restores the cursor, and a later user sort survives the rows reply that answers it. On the old code two checks fail: `got "name|"` and `got "name:false"`.
- `./tests/js.sh`: 1,832 checks, 0 failed. qmllint gate passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AnB5YmkdfX8Yri7gSGuAWf