### PR TITLE
fix: a cursor row the filter hides is not a row to act on

### DIFF
--- a/tests/js/filter.js
+++ b/tests/js/filter.js
@@ -1,4 +1,6 @@
 .import "../../ui/js/Filter.js" as Filter
+.import "../../ui/js/Nav.js" as Nav
+.import "../../ui/js/Ops.js" as Ops
 .import "filterfixture.js" as Fixture
 
 // The fixtures and the stub pane live in filterfixture.js, so this file stays checks.
@@ -129,6 +131,37 @@ function run(check) {
     var none = Fixture.pane("zzz")
     Filter.moveCursor(none, 1)
     check("a filter matching nothing has no row to move to", none.cursorIndex, 0)
+
+    // That cursor stays on a row the filter hides, and the operations that fall back to the cursor
+    // row acted on it: Enter opened it, dd trashed it, y and x took it, and r set the rename guard
+    // with no delegate to draw the editor or clear it. The rule at the top of prune() is that a row
+    // nobody can see is not one to act on, and these hold the cursor row to it.
+    var blind = Fixture.pane("zzz")
+    blind.cursorIndex = 3
+    check("the cursor under a filter that hides it is not a row to act on",
+          Ops.targetIndices(blind).join(","), "")
+    var seen = Fixture.pane("scr")
+    seen.cursorIndex = 5
+    check("and a cursor row the filter shows still is", Ops.targetIndices(seen).join(","), "5")
+    check("with no filter the cursor row is the target it always was",
+          Ops.targetIndices(Fixture.pane("")).join(","), "0")
+    blind.viewMode = "list"
+    blind.renamingIndex = -1
+    blind.rowFor = function (i) { return blind.rows[i] }
+    Ops.startRename(blind)
+    check("r over a hidden cursor row opens no editor", blind.renamingIndex, -1)
+    blind.listInFlight = false
+    blind.said = []
+    blind.message = function (text) { blind.said.push(text) }
+    blind.opened = 0
+    blind.open = function () { blind.opened += 1 }
+    blind.join = function (dir, name) { return dir + "/" + name }
+    blind.path = "/tmp"
+    // Screens, a directory the filter hides: opened, it would navigate away from the filtered listing.
+    blind.cursorIndex = 0
+    Nav.openCursor(blind, null)
+    check("enter over a hidden cursor row says so and opens nothing",
+          blind.said.join("") + "|" + blind.opened, "That row is hidden by the filter.|0")
 
     // The wheel moves the viewport and the cursor follows it, in view positions on both ends.
     var wheel = Fixture.pane("2026")

--- a/ui/js/Filter.js
+++ b/ui/js/Filter.js
@@ -43,6 +43,13 @@ function viewOf(list, row) {
     return list === null ? row : list.indexOf(row)
 }
 
+// Whether the cursor is on a row the filter draws. A query that matches nothing leaves the cursor
+// where it stood, on a row nobody can see, and the operations that fall back to the cursor row read
+// this first: a dd over "Nothing matches" trashed the file under it, the accident prune() exists for.
+function cursorShown(pane) {
+    return viewOf(pane.shown === undefined ? null : pane.shown, pane.cursorIndex) >= 0
+}
+
 // The canvas's own line under the last row it left standing, States.dc.html "Filter active".
 function note(list, loaded, query) {
     if (list === null) {

--- a/ui/js/Nav.js
+++ b/ui/js/Nav.js
@@ -196,6 +196,10 @@ function openCursor(pane, opener) {
         pane.message("A directory is already loading.", false)
         return
     }
+    if (!Filter.cursorShown(pane)) {
+        pane.message("That row is hidden by the filter.", false)
+        return
+    }
     var row = pane.rowFor(pane.cursorIndex)
     if (!row) {
         pane.message("That row has not loaded yet.", false)

--- a/ui/js/Ops.js
+++ b/ui/js/Ops.js
@@ -2,6 +2,7 @@
 
 .import "Archive.js" as Archive
 .import "Convert.js" as Convert
+.import "Filter.js" as Filter
 .import "Transfer.js" as Transfer
 
 // The clipboard is entirely client-side: the backend knows about a transfer, never about a pending paste.
@@ -81,10 +82,11 @@ function copied(n, moving) {
     return (moving ? "Cut " : "Copied ") + items(n) + ", p pastes."
 }
 
-// Which rows an operation acts on: the selection when there is one, the cursor row otherwise.
+// Which rows an operation acts on: the selection when there is one, else the cursor row while the
+// filter shows it, and nothing otherwise, since the selection has already lost every hidden row.
 function targetIndices(pane) {
     var picked = pane.selectedIndices()
-    return picked.length > 0 ? picked : [pane.cursorIndex]
+    return picked.length > 0 ? picked : Filter.cursorShown(pane) ? [pane.cursorIndex] : []
 }
 
 // Only rows inside the held window can be named as a path, so the caller sends indices instead and
@@ -130,7 +132,7 @@ function startRename(pane) {
         pane.message("Rename needs the list view.", false)
         return
     }
-    if (pane.rowFor(pane.cursorIndex)) {
+    if (Filter.cursorShown(pane) && pane.rowFor(pane.cursorIndex)) {
         pane.renamingIndex = pane.cursorIndex
     }
 }


### PR DESCRIPTION
## The bug

`Filter.apply` moves the cursor onto the first row still standing only when the query left one standing. A query that matches nothing (the list shows "Nothing matches z") leaves the cursor on the row it was on, which is now hidden. `Ops.targetIndices` falls back to `[pane.cursorIndex]` once `prune` has emptied the selection, and `Nav.openCursor` and `Ops.startRename` read the same row, so over an empty filter:

- `dd` trashed the hidden row, and `y` / `x` / Move to Dropbox took it.
- Enter opened it, navigating away from the filtered listing.
- `r` set `renamingIndex` with no delegate to draw the editor. That holds `PaneWire.watchBusy` until navigation, and the editor pops open over the row when Escape clears the filter.

`prune()`'s own comment states the rule: a row you cannot see is one you can act on by accident, and trash, cut and copy take their target with no confirmation. The selection was held to that rule; the cursor fallback was not.

## The fix

`Filter.cursorShown(pane)` answers whether the cursor is on a row the filter draws (always true with no filter). `targetIndices` answers no rows for a hidden cursor, `startRename` opens no editor, and `openCursor` says "That row is hidden by the filter." rather than opening it. Nothing changes for a visible cursor or for a standing selection.

## Tests

- `tests/js/filter.js` drives all three over a `zzz` filter on the fixture: no target, no editor, no open; and the visible-cursor and no-filter cases keep their targets. On the old code the checks fail three ways, the last by opening the hidden directory.
- `./tests/js.sh`: 1,833 checks, 0 failed. qmllint gate passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AnB5YmkdfX8Yri7gSGuAWf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented actions from targeting rows hidden by an active filter.
  * Renaming no longer starts when the cursor is on a hidden row.
  * Opening a hidden cursor row now displays a message instead of navigating or opening it.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->