### PR TITLE
fix: a tab action out of a search re-lists the search's own scope

### DIFF
--- a/tests/js/tabs.js
+++ b/tests/js/tabs.js
@@ -60,6 +60,35 @@ function run(check) {
     check("carrying no cursor from the search's own listing", searching.tabs.items[1].cursorIndex, 0)
     check("and no selection from it either", searching.tabs.items[1].selected.length, 0)
 
+    // A search begun in home walks home, so the scope IS where the user was: dropOverlay cleared the
+    // search and the path test found nothing to re-list, and the walk's rows stayed up under the new
+    // tab's ordinary header, with the watch dropped for the search so nothing ever refreshed them.
+    var scoped = pane("/home/gm")
+    scoped.searchMode = "results"
+    scoped.searchFrom = "/home/gm"
+    Tabs.openNew(scoped)
+    check("a tab opened from a search scoped to where the user was still re-lists that directory",
+          scoped.listed.join(","), "/home/gm")
+    var toScope = pane("/home/gm")
+    toScope.searchMode = "results"
+    toScope.searchFrom = "/home/gm/Downloads"
+    toScope.tabs = { items: [{ path: "/home/gm", history: [], cursorIndex: 0, viewMode: "list",
+                               showHidden: false, selected: [], sortBy: "name", sortDesc: false },
+                             { path: "/home/gm/Downloads" }],
+                     index: 1, pendingCursor: -1, pendingSortBy: "", pendingSortDesc: false }
+    Tabs.selectAt(toScope, 0)
+    check("switching to a tab on the search's own scope re-lists it rather than keeping the walk's rows",
+          toScope.listed.join(","), "/home/gm")
+    var closing = pane("/home/gm")
+    closing.searchMode = "results"
+    closing.searchFrom = "/home/gm/Downloads"
+    closing.tabs = { items: [{ path: "/home/gm", history: [], cursorIndex: 0, viewMode: "list",
+                               showHidden: false, selected: [], sortBy: "name", sortDesc: false },
+                             { path: "/home/gm/Downloads" }],
+                     index: 1, pendingCursor: -1, pendingSortBy: "", pendingSortDesc: false }
+    Tabs.closeAt(closing, 1)
+    check("and so does closing a searching tab onto one", closing.listed.join(","), "/home/gm")
+
     var plain = pane("/tmp/here")
     Tabs.openNew(plain)
     check("an ordinary listing opens its tab on its own path", plain.tabs.items[1].path, "/tmp/here")

--- a/ui/js/Tabs.js
+++ b/ui/js/Tabs.js
@@ -91,7 +91,11 @@ function currentIndex(pane) {
     return pane.tabs ? pane.tabs.index : 0
 }
 
+// Answers whether the rows on screen were a search's results, because clearing the search leaves
+// them there: every caller that then lands on the very directory the walk was scoped to has to
+// re-list it, or the walk's rows stay up under an ordinary header with nothing to ever refresh them.
 function dropOverlay(pane) {
+    var results = pane.searchMode === "results"
     if (pane.searchMode.length > 0) {
         if (pane.searchRunning)
             pane.backend.searchcancel()
@@ -103,6 +107,7 @@ function dropOverlay(pane) {
         pane.searchScanned = 0
     }
     Filter.close(pane)
+    return results
 }
 
 function closePreview(pane) {
@@ -135,8 +140,10 @@ function restoreSelection(pane, selected) {
         pane.selectionVersion++
 }
 
-function apply(pane, item) {
-    var same = pane.path === item.path && pane.showHidden === item.showHidden
+// relist forces the listing even when the tab names the path the pane is on, for a pane whose rows
+// are a search's and not that directory's.
+function apply(pane, item, relist) {
+    var same = !relist && pane.path === item.path && pane.showHidden === item.showHidden
     pane.history = item.history.slice()
     pane.viewMode = item.viewMode
     pane.showHidden = item.showHidden
@@ -200,15 +207,16 @@ function openNew(pane) {
     }
     var here = restingPath(pane)
     closePreview(pane)
-    dropOverlay(pane)
+    var searched = dropOverlay(pane)
     var items = currentItems(pane, here)
     var index = currentIndex(pane)
     items[index] = snapshot(pane, here)
     items.push(snapshot(pane, here))
     pane.tabs = pack(items, items.length - 1)
     // dropOverlay clears the search but leaves the pane on the scope it walked, so the new tab has
-    // to land on the path it just recorded; this is what Escape out of a search already does.
-    if (pane.path !== here)
+    // to land on the path it just recorded; this is what Escape out of a search already does. A
+    // walk scoped to that same path leaves its rows on the pane, so it is re-listed as well.
+    if (pane.path !== here || searched)
         pane.openWithoutHistory(here)
 }
 
@@ -225,10 +233,10 @@ function selectAt(pane, i) {
     if (i === index)
         return
     closePreview(pane)
-    dropOverlay(pane)
+    var searched = dropOverlay(pane)
     items[index] = snapshot(pane, here)
     pane.tabs = pack(items, i)
-    apply(pane, items[i])
+    apply(pane, items[i], searched)
 }
 
 function closeAt(pane, i) {
@@ -252,9 +260,9 @@ function closeAt(pane, i) {
         next = Math.min(i, items.length - 1)
     if (i === index) {
         closePreview(pane)
-        dropOverlay(pane)
+        var searched = dropOverlay(pane)
         pane.tabs = pack(items, next)
-        apply(pane, items[next])
+        apply(pane, items[next], searched)
     } else {
         pane.tabs = pack(items, next)
     }


### PR DESCRIPTION
## The bug

`Tabs.dropOverlay` clears `searchMode` but leaves `pane.path` on the scope the walk was given and `rows` / `total` on the walk's results. `openNew`, `selectAt` and `closeAt` then re-list only when the destination path differs from `pane.path`. `Search.close`, the Escape path, always re-lists.

A search begun in home walks home (`Search.scopeRoot`), so the scope is exactly where the user was:

1. Flea open at `~`, press `f`, search, Enter, then `t`: the new tab labelled Home shows rows like `Downloads/report.pdf` under the normal column header, with no search chrome.
2. Tab 1 at `~`, tab 2 at `~/Downloads`; run a home-wide search in tab 2 and press `1`: the same.
3. Close a searching tab onto one standing on the scope: the same.

The backend drops the inotify watch for a `search` (its listing is not a directory), so no `changed` line ever repairs it; only navigating away does.

## The fix

`dropOverlay` answers whether it dropped a results listing. `openNew` re-lists on that as well as on a path difference, and `selectAt` and `closeAt` pass it to `apply`, whose "same path, nothing to re-list" shortcut no longer applies when the rows on the pane are a walk's.

## Tests

- `tests/js/tabs.js` drives all three paths with the scope equal to the destination and requires the re-list. On the old code all three fail with `got ""`.
- `./tests/js.sh`: 1,831 checks, 0 failed. qmllint gate passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AnB5YmkdfX8Yri7gSGuAWf
