### PR TITLE
fix: a same-directory tab switch restores only a selection nothing renumbered

### DIFF
--- a/tests/js/tabs.js
+++ b/tests/js/tabs.js
@@ -90,6 +90,39 @@ function run(check) {
           moved.tabs.pendingSelected === undefined, true)
     check("and it did re-list, which is what clears the selection", moved.listed.join(","), "/tmp/b")
 
+    // The same directory in two tabs is the one switch that re-lists nothing, and the selection was
+    // restored on the strength of that alone. Two things renumber the rows underneath a hidden tab:
+    // the other tab holding a different order, and a re-read, a dd in the other tab or the watch's
+    // own, while it was hidden. Backend.listRequests counts the second; the sort is the first.
+    function twin(order) {
+        var p = pane("/tmp/same")
+        p.backend.listRequests = 7
+        p.thumbState = "warm"
+        p.dirSizeState = "warm"
+        p.selection.toggle(2)
+        p.selection.toggle(3)
+        p.tabs = { items: [{ path: "/tmp/same", history: [], cursorIndex: 4, viewMode: "list", showHidden: false,
+                             selected: [2, 3], listed: 7, sortBy: order, sortDesc: false },
+                           { path: "/tmp/same" }],
+                   index: 1, pendingCursor: -1, pendingSortBy: "", pendingSortDesc: false }
+        return p
+    }
+    var kept = twin("name")
+    Tabs.selectAt(kept, 0)
+    check("a switch to the same directory, same order, nothing re-read, restores the selection",
+          kept.selectedIndices().join(",") + "|" + kept.listed.length, "2,3|0")
+    var reread = twin("name")
+    reread.backend.listRequests = 8
+    Tabs.selectAt(reread, 0)
+    check("but one re-read while the tab was hidden has renumbered the rows, so it carries none",
+          reread.selectedIndices().join(","), "")
+    var reordered = twin("size")
+    Tabs.selectAt(reordered, 0)
+    check("a switch that re-sorts the same directory drops the selection, as Sort.resort does",
+          reordered.selectedIndices().join(",") + "|" + reordered.sorted.join(","), "|size:false")
+    check("and the caches keyed by row index with it",
+          typeof reordered.thumbState === "string" || typeof reordered.dirSizeState === "string", false)
+
     // F3 and F4: a refusal and a background close must each cost the user nothing else.
     var full = pane("/tmp/full")
     var nine = []

--- a/ui/js/Tabs.js
+++ b/ui/js/Tabs.js
@@ -1,7 +1,9 @@
 .pragma library
 
+.import "DirSizes.js" as DirSizes
 .import "Filter.js" as Filter
 .import "Format.js" as Format
+.import "Thumbs.js" as Thumbs
 
 // Directory tabs in one window. The pane and the backend still hold one listing: a hidden tab is a
 // snapshot, not a second view, because a hidden view is not a free view. t, w and 1-9 are already
@@ -29,6 +31,8 @@ function snapshot(pane, path) {
         viewMode: pane.viewMode,
         showHidden: pane.showHidden,
         selected: elsewhere ? [] : pane.selectedIndices().slice(),
+        // Which listing those indices were made on: a re-read while the tab is hidden renumbers them.
+        listed: Number(pane.backend.listRequests) || 0,
         sortBy: pane.backend.sortBy,
         sortDesc: pane.backend.sortDesc,
         // The directory's filesystem, so a drop on this tab while another shows decides move against copy.
@@ -145,14 +149,23 @@ function apply(pane, item) {
             pane.backend.sort(item.sortBy, item.sortDesc)
             pane.backend.sortBy = item.sortBy
             pane.backend.sortDesc = item.sortDesc
+            // The reset Sort.resort runs for the same reorder: every row moves, so the caches keyed by
+            // a row index are stale and a selection of row indices would come to name other files.
+            pane.thumbState = Thumbs.empty()
+            pane.dirSizeState = DirSizes.empty()
+            pane.clearSelection()
             pane.backend.window(0, pane.windowSize)
             pane.tabs.pendingCursor = item.cursorIndex
             return
         }
-        // The one switch that re-reads nothing, so the rows behind these indices are the rows the
-        // selection was made on and restoring it is safe. Every other path below drops it.
         pane.setCursor(item.cursorIndex)
-        restoreSelection(pane, item.selected)
+        // The rows behind these indices are the rows the selection was made on only while nothing has
+        // re-read the directory since: a delete in the other tab, or the watch's own re-read, shifts
+        // every index below the change, and a selection restored over that names other files.
+        if ((Number(pane.backend.listRequests) || 0) === (Number(item.listed) || 0))
+            restoreSelection(pane, item.selected)
+        else
+            pane.clearSelection()
         return
     }
     pane.tabs.pendingCursor = item.cursorIndex


### PR DESCRIPTION
## The bug

`Tabs.apply` treats two tabs on the same directory as the one switch that re-lists nothing, and restores the snapshot's row-index selection verbatim. `ui/js/Selection.js` is a set of row indices, and its own rule is that a new listing clears them, because an index into a changed directory names another file. Two things renumber the rows under a hidden tab and neither was checked:

- **A different sort order in the other tab.** The same-path branch re-sorted (`backend.sort` + `window(0)`) but skipped the reset `Sort.resort` performs for exactly that reorder: the selection and the thumbnail and directory-size caches, all keyed by row index, stayed over a reordered listing.
- **A re-read while the tab was hidden.** Tabs A and B on `~/Downloads`; in A select rows 3 and 4; press `2`; in B press `dd` on row 0, or let another program create a file and the watch re-read; press `1`. Rows 3 and 4 are restored, which are now the files that were 4 and 5. The status bar reads "2 selected" over the wrong files, and the next `dd` would take them.

## The fix

The snapshot records `Backend.listRequests`, the counter every `list` bumps, including the watch's re-read and the refresh after a write. The restore happens only when it has not moved; otherwise the selection is cleared, which is what every other switch already does. The re-sort branch runs the same reset `Sort.resort` does: caches emptied, selection cleared.

## Tests

- `tests/js/tabs.js`: unchanged directory restores the selection; one re-read while hidden carries none; a re-sort drops it and the two caches. On the old code three checks fail, restoring `2,3` in both stale cases.
- `./tests/js.sh`: 1,832 checks, 0 failed. qmllint gate passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AnB5YmkdfX8Yri7gSGuAWf
