### PR TITLE
fix: the tilde stands for home, not for a name starting with it

### DIFF
--- a/tests/js/format.js
+++ b/tests/js/format.js
@@ -10,6 +10,11 @@ function run(check) {
           Format.tilde("/usr/share/omarchy", "/home/gm"), "/usr/share/omarchy")
     check("an unknown home leaves every path alone",
           Format.tilde("/home/gm/x", ""), "/home/gm/x")
+    // Nav.crumbs already made this test on whole components and said why; the tab strip and the
+    // search scope came through here and wrote the sibling as home's.
+    check("a sibling whose name merely starts with home's is not under home",
+          Format.tilde("/home/gmx", "/home/gm"), "/home/gmx")
+    check("and neither is its child", Format.tilde("/home/gmx/Work", "/home/gm"), "/home/gmx/Work")
 
     // ui/js/Tabs.js "label" names a tab after the directory it stands in, which is this and nothing else.
     check("the leaf is the directory's own name",

--- a/ui/js/Format.js
+++ b/ui/js/Format.js
@@ -112,11 +112,14 @@ function duration(ms) {
 
 // The scope reads as the user writes it, so the home prefix comes back as a tilde. Both the search
 // strip and the window chrome draw a path through this, so the rule has one definition.
+// The test is on whole components: /home/gmx is a sibling of /home/gm and not inside it, and as a
+// bare prefix test this wrote it as "~x", so the tab strip and the search scope named it as home's.
 function tilde(path, home) {
-    if (home.length > 0 && String(path).indexOf(home) === 0) {
-        return "~" + String(path).substring(home.length)
+    var text = String(path)
+    if (home.length > 0 && (text === home || text.indexOf(home + "/") === 0)) {
+        return "~" + text.substring(home.length)
     }
-    return String(path)
+    return text
 }
 
 // A tab is named after the directory it is standing in, so the label is the path's last segment.

--- a/ui/js/Nav.js
+++ b/ui/js/Nav.js
@@ -229,8 +229,8 @@ function leafOf(path) {
 // Issue 45: the chrome's path as the pieces a click can land on. text is what is drawn, including
 // the separator that follows it, so the pieces concatenate to exactly the one line they replace;
 // path is the directory the piece names, which is what ui/ChromeBar.qml hands to pathEntered. The
-// home test is ui/js/Search.js scopeRoot's and not Format.tilde's, because Format.tilde writes
-// /home/gmx as "~x" and a crumb built on that would carry a click to /home/gm, another directory.
+// home test is on whole components, the same one Format.tilde and ui/js/Search.js scopeRoot make,
+// because a crumb built on a bare prefix would carry a click on /home/gmx to /home/gm, another directory.
 function crumbs(path, home) {
     var text = String(path)
     var base = String(home)


### PR DESCRIPTION
## The bug

`Format.tilde(path, home)` tested `path.indexOf(home) === 0`, a bare string prefix. `/home/gmx` is a sibling of `/home/gm`, not inside it, but it came back as `~x` and `/home/gmx/Work` as `~x/Work`. `Tabs.label` and the search strip's scope both go through `tilde`, so the tab strip and the header named a sibling directory as home's. `Nav.crumbs` had already worked around this for the path bar with its own whole-component test and a comment saying why.

## The fix

The test is home itself or home followed by a separator, the same test `crumbs` and `Search.scopeRoot` make. The `crumbs` comment now says the three agree rather than that `tilde` is wrong.

## Tests

- `tests/js/format.js`: the sibling and its child keep their own form. On the old code both fail with `~x`.
- `./tests/js.sh`: 1,830 checks, 0 failed. qmllint gate passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AnB5YmkdfX8Yri7gSGuAWf
