### PR TITLE
fix: the view the window is left on is the view the next launch opens on

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,8 @@
+# Every .js file in this tree is a QML JavaScript library: it opens with the
+# QML-only `.pragma library` directive, which Biome, a plain-JS tool, cannot
+# parse. Its run here can only report syntax errors on files that load fine
+# under qs, so the tool is turned off rather than fed files it cannot read.
+reviews:
+  tools:
+    biome:
+      enabled: false

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,8 +1,0 @@
-# Every .js file in this tree is a QML JavaScript library: it opens with the
-# QML-only `.pragma library` directive, which Biome, a plain-JS tool, cannot
-# parse. Its run here can only report syntax errors on files that load fine
-# under qs, so the tool is turned off rather than fed files it cannot read.
-reviews:
-  tools:
-    biome:
-      enabled: false

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -449,7 +449,9 @@ paths, the lock and the write.
 the merged document and writes nothing. `flea --ui-state '<json object>'` merges that patch through
 the lock and prints the result. The window reaches it from `ui/ViewState.qml` through a `Process`;
 the terminal interface is not here yet, as `flea --tui` says by exiting 2, and when it is built it
-will submit patches for `view`, `hidden` and `sort` only, because menus and places are the window's.
+will submit patches for `view`, `hidden` and `sort` only, because menus and places are the window's;
+`view` is shared between the two, and the window's own patch for it is the startup answer described
+below.
 Scale is on neither list: `src/uischema.rs` has no `scale` key at all, it stores an Omarchy text-size
 stop under `display.textSize.mode`, and the multiplier `ui/js/Scale.js` applies is a session value.
 **The streams and the status are the contract**, because
@@ -588,6 +590,15 @@ stored `["name","size","size","date"]` left one header-menu "Hide Size" click st
 `name,size,date`, because `toggleColumn` splices the first match and the second still shows the
 column. The header menu offers only the four optional keys onto an array that already carries
 `name`, so no click this window can produce is refused by the rule.
+
+**`view` stores the listing's view mode, and it is the window's own startup answer.** The chrome's
+three buttons and the ctrl-1/2/3 chords both reach `ui/Pane.qml`'s `setView`, which moves `viewMode`
+and owes the patch through `ui/ViewState.qml`'s `setView`, so the view left on screen is the view
+the next launch opens on; `owe()` sends nothing for the value the window already holds, so a
+repeated chord is not a second write. `ui/js/Tabs.js`'s per-tab snapshot restores a tab's own view
+straight onto the property without a patch, because switching tabs is not choosing a view. A stored
+word this build cannot draw falls back to the list view beside the `columns` rule above; the settle
+has usually already renamed it, and a file this window could not read is drawn as it was read.
 
 **`wrapAtEnds` is read by the window and by nothing else.** `ui/Pane.qml` exposes it off the
 document `ui/ViewState.qml` already holds, and `ui/js/Focus.js` `step` is its only reader: with the
@@ -1026,8 +1037,9 @@ this coverage needed no new entry there.
 - `ui/Backend.qml` is the only QML component that talks to the Rust child, and carries
   `thumb` and `thumbcancel` out and `thumbed` in alongside `list`, `window` and `sort`.
 - `ui/ViewState.qml` reads `ui.json` once at startup with a blocking `FileView` and writes nothing
-  itself: every change, the header menu's columns and all three settings sections alike, goes back
-  out through `flea --ui-state` as a patch naming that change alone, see "The state file".
+  itself: every change, the header menu's columns, the view mode and all three settings sections
+  alike, goes back out through `flea --ui-state` as a patch naming that change alone, see "The state
+  file".
 - `ui/js/UiState.js` is `ViewState`'s writer bookkeeping and the two pure rebuilds every writer goes
   through: the newest patch a writer landed, what the running writer carries and what waits behind
   it, and the key and group rebuilds `ViewState` runs over both the state it draws and the patch it
@@ -1270,7 +1282,9 @@ are listed in `tools/flea-file-budget` as known exceptions so the tool still fai
 else, and each prints its own line rather than being hidden. The view fixes of 2026-09-07 took
 `ui/NetworkDialog.qml`, `ui/Ipc.qml`, `ui/Pane.qml` and `ui/PreviewColumn.qml`, all already at the
 cap, 2 to 6 lines over each (overlay sinks, the column player in its frame, per-view IPC readers,
-the columns thumbnail relay); they are listed the same way, as 0.1.6 exceptions. Every count below is
+the columns thumbnail relay); they are listed the same way, as 0.1.6 exceptions. View persistence
+then took `ui/Pane.qml` to 407 on the same exception (the one `setView` seam) and `ui/ViewState.qml`
+to 265, the latter a soft-budget warning and not a cap case. Every count below is
 `wc -l` on the file, and every test-module count runs from its `#[cfg(test)]` line to
 the end of the file; run the tool rather than trusting these if the two disagree. **Three of them
 had gone stale by a whole plan and were re-derived from `wc -l` in Plan 5 Task 5a**, so when you
@@ -1409,7 +1423,9 @@ under a deadline and reports `Ran::Succeeded`, `Ran::Failed` or `Ran::NotStarted
 knows about thumbnails, which is why the pool's `JOB_TIMEOUT` stays in `thumbs.rs` and is passed
 in.
 
-`ui/Pane.qml` is 393 lines by `wc -l`, over the soft budget and 7 lines under the hard cap. It stood at
+`ui/Pane.qml` is 407 lines by `wc -l`, over the soft budget and 7 over the hard cap, a listed
+exception: the 0.1.6 view fixes put it over first, and view persistence's one seam, `setView` and
+the stored `view` beside it, took it to 407. It stood at
 exactly 400 of 400 and could not gain a line, which is why `ui/Header.qml` came out of it
 first and alone, before any behaviour was added; it then took on the settle timer, the
 thumbnail row map, the opener wiring, the input-to-rows stamps and the first-screen settle, and

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -598,7 +598,8 @@ opens on; `owe()` sends nothing for the value the window already holds, so a rep
 not a second write. A pane draws `ViewState.view`, which is `list`/`columns`/`grid` or the list
 for anything else, including the stored `dual` that `ui/shell.qml` reads as two list panes.
 `ui/js/Tabs.js`'s per-tab snapshot restores a tab's own view straight onto the property without
-a patch, because switching tabs is not choosing a view. A stored word this build cannot draw
+a patch, because switching tabs is not choosing a view, and `holdView` keeps the preferences
+timer from assigning `ViewState.view` over it once the listing lands. A stored word this build cannot draw
 falls back to the list view beside the `columns` rule above; the settle has usually already
 renamed it, and a file this window could not read is drawn as it was read.
 
@@ -1423,7 +1424,7 @@ under a deadline and reports `Ran::Succeeded`, `Ran::Failed` or `Ran::NotStarted
 knows about thumbnails, which is why the pool's `JOB_TIMEOUT` stays in `thumbs.rs` and is passed
 in.
 
-`ui/Pane.qml` is 662 lines by `wc -l`, over both budgets and a listed cap exception: dual-pane
+`ui/Pane.qml` is 665 lines by `wc -l`, over both budgets and a listed cap exception: dual-pane
 and listing preferences put it over, and this round's `ViewState.view` fallback did not add a
 second writer on the pane. It stood at
 exactly 400 of 400 and could not gain a line, which is why `ui/Header.qml` came out of it

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -592,13 +592,15 @@ column. The header menu offers only the four optional keys onto an array that al
 `name`, so no click this window can produce is refused by the rule.
 
 **`view` stores the listing's view mode, and it is the window's own startup answer.** The chrome's
-three buttons and the ctrl-1/2/3 chords both reach `ui/Pane.qml`'s `setView`, which moves `viewMode`
-and owes the patch through `ui/ViewState.qml`'s `setView`, so the view left on screen is the view
-the next launch opens on; `owe()` sends nothing for the value the window already holds, so a
-repeated chord is not a second write. `ui/js/Tabs.js`'s per-tab snapshot restores a tab's own view
-straight onto the property without a patch, because switching tabs is not choosing a view. A stored
-word this build cannot draw falls back to the list view beside the `columns` rule above; the settle
-has usually already renamed it, and a file this window could not read is drawn as it was read.
+three buttons and the ctrl-1/2/3 chords both reach `ui/ViewState.qml`'s `setView` (the chords
+through `ui/Pane.qml`'s `chooseView`), so the view left on screen is the view the next launch
+opens on; `owe()` sends nothing for the value the window already holds, so a repeated chord is
+not a second write. A pane draws `ViewState.view`, which is `list`/`columns`/`grid` or the list
+for anything else, including the stored `dual` that `ui/shell.qml` reads as two list panes.
+`ui/js/Tabs.js`'s per-tab snapshot restores a tab's own view straight onto the property without
+a patch, because switching tabs is not choosing a view. A stored word this build cannot draw
+falls back to the list view beside the `columns` rule above; the settle has usually already
+renamed it, and a file this window could not read is drawn as it was read.
 
 **`wrapAtEnds` is read by the window and by nothing else.** `ui/Pane.qml` exposes it off the
 document `ui/ViewState.qml` already holds, and `ui/js/Focus.js` `step` is its only reader: with the
@@ -1282,9 +1284,7 @@ are listed in `tools/flea-file-budget` as known exceptions so the tool still fai
 else, and each prints its own line rather than being hidden. The view fixes of 2026-09-07 took
 `ui/NetworkDialog.qml`, `ui/Ipc.qml`, `ui/Pane.qml` and `ui/PreviewColumn.qml`, all already at the
 cap, 2 to 6 lines over each (overlay sinks, the column player in its frame, per-view IPC readers,
-the columns thumbnail relay); they are listed the same way, as 0.1.6 exceptions. View persistence
-then took `ui/Pane.qml` to 407 on the same exception (the one `setView` seam) and `ui/ViewState.qml`
-to 265, the latter a soft-budget warning and not a cap case. Every count below is
+the columns thumbnail relay); they are listed the same way, as 0.1.6 exceptions. Every count below is
 `wc -l` on the file, and every test-module count runs from its `#[cfg(test)]` line to
 the end of the file; run the tool rather than trusting these if the two disagree. **Three of them
 had gone stale by a whole plan and were re-derived from `wc -l` in Plan 5 Task 5a**, so when you
@@ -1423,9 +1423,9 @@ under a deadline and reports `Ran::Succeeded`, `Ran::Failed` or `Ran::NotStarted
 knows about thumbnails, which is why the pool's `JOB_TIMEOUT` stays in `thumbs.rs` and is passed
 in.
 
-`ui/Pane.qml` is 407 lines by `wc -l`, over the soft budget and 7 over the hard cap, a listed
-exception: the 0.1.6 view fixes put it over first, and view persistence's one seam, `setView` and
-the stored `view` beside it, took it to 407. It stood at
+`ui/Pane.qml` is 662 lines by `wc -l`, over both budgets and a listed cap exception: dual-pane
+and listing preferences put it over, and this round's `ViewState.view` fallback did not add a
+second writer on the pane. It stood at
 exactly 400 of 400 and could not gain a line, which is why `ui/Header.qml` came out of it
 first and alone, before any behaviour was added; it then took on the settle timer, the
 thumbnail row map, the opener wiring, the input-to-rows stamps and the first-screen settle, and

--- a/tests/js/focus.js
+++ b/tests/js/focus.js
@@ -264,14 +264,20 @@ function run(check) {
     Focus.act("addNetwork", dialled)
     check("and act opens it through the rail's own signal", dialled.sidebar.asked, 1)
 
-    // Finder's Cmd+1/2/3: the same property the chrome's three buttons write, so they follow.
+    // Finder's Cmd+1/2/3: the same chooseView the chrome's three buttons call, so the chord and
+    // the click persist the one stored view. The mock records what reaches it, because a chord
+    // that switched the view on screen without calling chooseView would otherwise pass this suite.
     var viewed = listPane(true)
+    viewed.persisted = []
+    viewed.chooseView = function (mode) { this.viewMode = mode; this.persisted.push(mode) }
     Focus.act("viewGrid", viewed)
     var grid = viewed.viewMode
     Focus.act("viewColumns", viewed)
     var cols = viewed.viewMode
     Focus.act("viewList", viewed)
-    check("ctrl 3, 2 and 1 pick the grid, the columns and the list", grid + "|" + cols + "|" + viewed.viewMode, "grid|columns|list")
+    check("ctrl 3, 2 and 1 pick the grid, the columns and the list, through chooseView each time",
+          grid + "|" + cols + "|" + viewed.viewMode + "|" + viewed.persisted.join("|"),
+          "grid|columns|list|grid|columns|list")
 
     // The seam itself. A case that only messaged was indistinguishable from a wired one on this
     // side of the suite, which is how the whole feature stayed unreachable through a green run, so

--- a/tests/js/tabs.js
+++ b/tests/js/tabs.js
@@ -8,6 +8,7 @@ function pane(path) {
         history: ["/home/gm"],
         cursorIndex: 4,
         viewMode: "list",
+        holdView: false,
         showHidden: false,
         searchMode: "",
         searchFrom: "",
@@ -184,6 +185,7 @@ function run(check) {
     check("previous wraps from the first tab to the last", Tabs.currentIndex(cycling), 1)
     check("previous restores the second tab's directory, view and hidden preference",
           cycling.path + "|" + cycling.viewMode + "|" + cycling.showHidden, "/tmp/second|grid|true")
+    check("and holds that view against the stored default until chooseView", cycling.holdView, true)
     Tabs.applyPending(cycling)
     Tabs.applyPending(cycling)
     check("previous restores the second tab's cursor and sorting",

--- a/tests/ui.sh
+++ b/tests/ui.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Drives the real Quickshell window with omarchy-drive and asserts through the read-only IPC seam.
-# Usage: ./tests/ui.sh [cursor|terminal|open|rows|click|menu|hidden|selection|select|colour|lifted|icons|thumbs|hashcache|stale|nosweep|oem|header|overflow|focus|preview|network|netmark|networktimeout|networklive|gvfs|sharebrowser|unmount|eject|rename|renamelife|taildrop|grid|columns|operations|tabs|openterminal|renderer|settings ...]; networklive is opt-in.
+# Usage: ./tests/ui.sh [cursor|terminal|open|rows|click|menu|hidden|selection|select|colour|lifted|icons|thumbs|hashcache|stale|nosweep|oem|header|overflow|focus|preview|network|netmark|networktimeout|networklive|gvfs|sharebrowser|unmount|eject|rename|renamelife|taildrop|grid|columns|operations|tabs|openterminal|renderer|settings|viewpersist ...]; networklive is opt-in.
 set -u
 set -o pipefail
 # Hard rule 9's guard, which owns FIXTURE_ROOT and every create and delete this suite makes.
@@ -7751,6 +7751,69 @@ case_views() {
     kill_flea
 }
 
+# The view the window is left on is the view the next launch opens on. The ctrl-1/2/3 chords and
+# the chrome's three buttons both reach ViewState.setView, so both must reach ui.json, a
+# restart must read it back without a click, and a hand-edited view word this build cannot draw
+# must come up as the list view rather than a pane nothing shows. XDG_STATE_HOME points inside the
+# fixture root for the whole case, so nothing here can write the operator's own ui.json; hard
+# rule 9 covers writes and not only deletes.
+case_viewpersist() {
+    local dir="$fixture_root/viewpersist"
+    local state="$fixture_root/viewpersist-state"
+    sandbox_scratch "$dir"
+    sandbox_scratch "$state"
+    : > "$dir/a.txt"
+    : > "$dir/b.txt"
+    local real_state="${XDG_STATE_HOME-}"
+    export XDG_STATE_HOME="$state"
+    local stored="$state/flea/ui.json"
+
+    launch "$dir"
+    wait_listing 2
+    [[ "$(ipc viewMode)" == "list" ]] || fail "viewpersist: a first launch opened on $(ipc viewMode), not list"
+
+    # The chord. switch_view proves the screen; the file line proves the write behind it.
+    switch_view columns
+    [[ -f "$stored" ]] || fail "viewpersist: the ctrl-2 chord wrote no state file at $stored"
+    grep -q '"view": "columns"' "$stored" \
+        || fail "viewpersist: the chord left the file holding $(cat "$stored" 2>/dev/null || printf nothing)"
+
+    kill_flea
+    launch "$dir"
+    wait_listing 2
+    [[ "$(ipc viewMode)" == "columns" ]] \
+        || fail "viewpersist: a restart opened on $(ipc viewMode), not the stored columns"
+
+    # The chrome button, the other entrance, from the view the restart came up on.
+    click_chrome grid
+    settle
+    [[ "$(ipc viewMode)" == "grid" ]] || fail "viewpersist: the grid button left $(ipc viewMode)"
+    grep -q '"view": "grid"' "$stored" \
+        || fail "viewpersist: the button left the file holding $(cat "$stored" 2>/dev/null || printf nothing)"
+
+    kill_flea
+    launch "$dir"
+    wait_listing 2
+    [[ "$(ipc viewMode)" == "grid" ]] \
+        || fail "viewpersist: the second restart opened on $(ipc viewMode), not the stored grid"
+
+    # A word the schema does not know reaches the window only past the settle, which rewrites it
+    # back to the default; the window draws the list view either way, because anything else is a
+    # pane nothing shows. The written-back file is the settle's own proof.
+    printf '{"view":"banana"}\n' > "$stored"
+    kill_flea
+    launch "$dir"
+    wait_listing 2
+    [[ "$(ipc viewMode)" == "list" ]] \
+        || fail "viewpersist: an unknown view word opened as $(ipc viewMode), not list"
+    grep -q '"view": "list"' "$stored" \
+        || fail "viewpersist: the settle did not rename the unknown view back to list"
+
+    printf 'VIEWPERSIST chord=ok restart=ok button=ok fallback=ok\n'
+    if [[ -n "$real_state" ]]; then export XDG_STATE_HOME="$real_state"; else unset XDG_STATE_HOME; fi
+    kill_flea
+}
+
 # One row per format family the preview classifies, all in the columns view's own frame, judged on
 # what the frame draws: decoded pixels, lines, member names, pages, an advancing position, the sentence.
 formats_fixture() {
@@ -8092,7 +8155,7 @@ case_previewviews() {
 . "$repo/tests/ui-convert-design.sh"
 
 declare -a wanted=("$@")
-[[ ${#wanted[@]} -eq 0 ]] && wanted=(cursor scroll terminal open rows click menu background hidden selection watch select colour lifted icons thumbs hashcache stale nosweep oem header overflow focus preview pdffocus network netmark networkauth networktimeout gvfs sharebrowser unmount eject rename renamelife taildrop providers grid columns operations tabs openterminal renderer settings clickthrough wheelunder overlays views formats previewviews hangshare openwithdesign)
+[[ ${#wanted[@]} -eq 0 ]] && wanted=(cursor scroll terminal open rows click menu background hidden selection watch select colour lifted icons thumbs hashcache stale nosweep oem header overflow focus preview pdffocus network netmark networkauth networktimeout gvfs sharebrowser unmount eject rename renamelife taildrop providers grid columns operations tabs openterminal renderer settings clickthrough wheelunder overlays views formats previewviews hangshare openwithdesign viewpersist)
 
 : > "$run_log"
 : > "$flea_log"

--- a/ui/Pane.qml
+++ b/ui/Pane.qml
@@ -150,11 +150,13 @@ FocusScope {
     // Read once for the window: the chrome's path and the search strip's scope both shorten with it.
     readonly property string home: Quickshell.env("HOME") || ""
 
-    // "list", "columns" or "grid"; the chrome's own buttons write it and the views read it.
+    // "list", "columns" or "grid"; the views read it. The first frame draws the stored view, and
+    // chooseView (the chrome's buttons and ctrl-1/2/3) writes the same key, so a restart opens on
+    // it. Dual and a word this build cannot draw both land on the list, via ViewState.view.
     property string viewMode: "list"
     property bool preferencesReady: false
     Component.onCompleted: {
-        root.viewMode = root.listOnly || ViewState.state.view === "dual" ? "list" : ViewState.state.view || "list"
+        root.viewMode = root.listOnly ? "list" : ViewState.view
         root.preferencesReady = true
     }
     // Only the list view draws a filter, so leaving it takes the filter with it.
@@ -182,7 +184,7 @@ FocusScope {
         id: preferences
         interval: 0
         onTriggered: {
-            var desired = root.listOnly || ViewState.state.view === "dual" ? "list" : ViewState.state.view || "list"
+            var desired = root.listOnly ? "list" : ViewState.view
             if (root.viewMode !== desired) root.viewMode = desired
             if (!root.visible || !root.path || root.listInFlight || root.searchMode.length > 0
                     || root.appliedListingPreferences === root.listingPreferences) return
@@ -518,7 +520,7 @@ FocusScope {
         if (root.viewMode === "columns" && columnsLoader.item) columnsLoader.item.loadSelection()
     }
     function togglePreviewColumn() { ViewState.changeLeaf("preview", { column: !ViewState.previewColumn }) }
-    function chooseView(mode) { ViewState.changeKey("view", mode) }
+    function chooseView(mode) { ViewState.setView(mode) }
     function focusPreviewColumn() {
         if (!ViewState.previewColumn || root.dualMode) return
         if (root.viewMode === "columns" && columnsLoader.item) columnsLoader.item.focusPreview()

--- a/ui/Pane.qml
+++ b/ui/Pane.qml
@@ -154,17 +154,18 @@ FocusScope {
     // chooseView (the chrome's buttons and ctrl-1/2/3) writes the same key, so a restart opens on
     // it. Dual and a word this build cannot draw both land on the list, via ViewState.view.
     property string viewMode: "list"
+    // A tab restore holds this so the preferences timer cannot assign ViewState.view over the
+    // snapshot; chooseView clears it, because that is an explicit view change.
+    property bool holdView: false
     property bool preferencesReady: false
     Component.onCompleted: {
         root.viewMode = root.listOnly ? "list" : ViewState.view
         root.preferencesReady = true
     }
-    // Only the list view draws a filter, so leaving it takes the filter with it.
-    onViewModeChanged: {
-        Filter.close(root)
-        if (root.preferencesReady && !root.listOnly && (!root.dualMode || root.viewMode !== "list") && ViewState.state.view !== root.viewMode)
-            ViewState.changeKey("view", root.viewMode)
-    }
+    // Only the list view draws a filter, so leaving it takes the filter with it. Persistence is
+    // chooseView's, not this handler's: Tabs.apply assigns viewMode, and writing that would replace
+    // the stored restart view with a tab snapshot.
+    onViewModeChanged: Filter.close(root)
     readonly property string listingPreferences: JSON.stringify([ViewState.state.hidden, ViewState.state.sort,
         ViewState.state.foldersFirst, ViewState.state.groupByKind])
     property string appliedListingPreferences: ""
@@ -184,8 +185,10 @@ FocusScope {
         id: preferences
         interval: 0
         onTriggered: {
-            var desired = root.listOnly ? "list" : ViewState.view
-            if (root.viewMode !== desired) root.viewMode = desired
+            if (!root.holdView) {
+                var desired = root.listOnly ? "list" : ViewState.view
+                if (root.viewMode !== desired) root.viewMode = desired
+            }
             if (!root.visible || !root.path || root.listInFlight || root.searchMode.length > 0
                     || root.appliedListingPreferences === root.listingPreferences) return
             root.openWithoutHistory(root.path)
@@ -520,7 +523,7 @@ FocusScope {
         if (root.viewMode === "columns" && columnsLoader.item) columnsLoader.item.loadSelection()
     }
     function togglePreviewColumn() { ViewState.changeLeaf("preview", { column: !ViewState.previewColumn }) }
-    function chooseView(mode) { ViewState.setView(mode) }
+    function chooseView(mode) { root.holdView = false; ViewState.setView(mode) }
     function focusPreviewColumn() {
         if (!ViewState.previewColumn || root.dualMode) return
         if (root.viewMode === "columns" && columnsLoader.item) columnsLoader.item.focusPreview()

--- a/ui/ViewState.qml
+++ b/ui/ViewState.qml
@@ -47,6 +47,14 @@ QtObject {
         return out
     }
 
+    // The listing's view, "view" in src/uischema.rs, which ui/Pane.qml draws for the first frame so
+    // the view left on screen is the view the next launch opens on. A word a hand edit left that
+    // this Flea cannot draw falls back to the list the way an unparsable columns set falls back
+    // above; the settle has usually already renamed it, but a file this window could not read is
+    // drawn as it was read.
+    readonly property string view: Settings.contains(["list", "columns", "grid"], root.state.view)
+                                   ? root.state.view : "list"
+
     // The Display section's text size, `display.textSize` in src/uischema.rs: {"mode":"system"}
     // follows Omarchy and is the default, and an override pins one of TextSize.js's seven stops as
     // {"mode":N}. ui/Theme.qml is the only consumer, and the monitor scale beside it in the panel is
@@ -171,6 +179,13 @@ QtObject {
 
     function setKeysPreset(name) {
         root.changeKey("keys", name)
+    }
+
+    // The view's one writer: chooseView (ctrl-1/2/3) and the chrome's buttons both land here, so
+    // the two entrances cannot persist two different answers. owe() sends nothing for a value the
+    // window already holds, so a repeated chord is not a patch.
+    function setView(mode) {
+        root.changeKey("view", mode)
     }
 
     // Flipped by ui/Pane.qml's onChosen, when a header-menu row answers "col:<key>".

--- a/ui/js/Focus.js
+++ b/ui/js/Focus.js
@@ -146,7 +146,7 @@ function act(action, root, menuId, paths) {
     case "sortReverse": Sort.reverse(root); return
     case "addNetwork": root.sidebar.addRequested(); return
     case "eject": Eject.release(root, root.sidebar, false); return
-    // Finder's Cmd+1/2/3; the chrome's three buttons write the same property, so they follow.
+    // Finder's Cmd+1/2/3; the chrome's three buttons write the same key, so they persist together.
     case "viewList": root.chooseView("list"); return
     case "viewColumns": root.chooseView("columns"); return
     case "viewGrid": root.chooseView("grid"); return

--- a/ui/js/Tabs.js
+++ b/ui/js/Tabs.js
@@ -139,6 +139,7 @@ function apply(pane, item) {
     var same = pane.path === item.path && pane.showHidden === item.showHidden
     pane.history = item.history.slice()
     pane.forwardHistory = (item.forwardHistory || []).slice()
+    pane.holdView = true
     pane.viewMode = item.viewMode
     pane.showHidden = item.showHidden
     if (same) {

--- a/ui/shell.qml
+++ b/ui/shell.qml
@@ -156,7 +156,7 @@ ShellRoot {
                 onSearchRequested: view.currentPane.act("search")
                 onFilterRequested: view.currentPane.act("filter")
                 onSortRequested: view.currentPane.act("sortNext")
-                onViewChosen: function (mode) { ViewState.setView(mode) }
+                onViewChosen: function (mode) { view.currentPane.chooseView(mode) }
                 // The path bar's four. The primaryPane navigates and answers for the keyboard exactly as it
                 // does for every other route in, so a path typed and a row opened end the same way.
                 onPathEntered: function (path) { view.currentPane.open(path) }

--- a/ui/shell.qml
+++ b/ui/shell.qml
@@ -156,7 +156,7 @@ ShellRoot {
                 onSearchRequested: view.currentPane.act("search")
                 onFilterRequested: view.currentPane.act("filter")
                 onSortRequested: view.currentPane.act("sortNext")
-                onViewChosen: function (mode) { ViewState.changeKey("view", mode) }
+                onViewChosen: function (mode) { ViewState.setView(mode) }
                 // The path bar's four. The primaryPane navigates and answers for the keyboard exactly as it
                 // does for every other route in, so a path typed and a row opened end the same way.
                 onPathEntered: function (path) { view.currentPane.open(path) }


### PR DESCRIPTION
## Problem

Switching the view (columns, grid) is session-only: a restart opens on the list view whatever was on screen. Every other file manager on Linux persists the view mode — Nautilus, Dolphin, Thunar, pcmanfm and nemo all do.

This tree has carried the schema for it since the 0.1.4 handoff: `src/uischema.rs` validates `view` as `list`/`columns`/`grid`, `flea --ui-state '{"view":"columns"}'` accepts and merges it, and `src/uistore.rs`'s tests drive exactly that patch. The window just never read the key at startup and never wrote it on a change — `ui/Pane.qml`'s `viewMode` was hardcoded to `"list"` and the chrome's buttons and the ctrl-1/2/3 chords assigned it in memory. This PR wires the two ends together. No schema change, no wire change.

## The change

- `ui/ViewState.qml` — `view` reads the stored word and falls back to `"list"` for anything this build cannot draw, the way an unparsable `columns` set does; `setView` is the writer, through the same `changeKey` → patch machinery the settings already ride.
- `ui/Pane.qml` — `viewMode` starts on the stored view, and `setView(mode)` is the one user view change: it rebinds `viewMode` and persists.
- `ui/shell.qml` — the chrome's three buttons route through `pane.setView`.
- `ui/js/Focus.js` — the ctrl-1/2/3 chords route through the same seam, so a chord and a button cannot persist two different answers. `owe()` sends nothing for a value the window already holds, so a repeated chord is not a second write.

Two deliberate edges:

- **A tab switch does not rewrite the stored view.** `ui/js/Tabs.js`'s per-tab snapshot restores a tab's own view straight onto the property without a patch, because switching tabs is not choosing a view. Only an explicit user view change persists.
- **An unknown stored word draws the list view** (and the launch settle normally renames it back to the default, per the state file's per-key fallback). A file this window could not read is drawn as it was read, same as `columns`.

## Tests

- `tests/js/focus.js` — the view chords now assert `setView` was called. The old assertion read only the `viewMode` property, so a chord that switched the screen without persisting would have passed it; the mock records what reaches the seam.
- `tests/ui.sh case_viewpersist` — the real window: the ctrl-2 chord writes the file, a restart opens on the stored columns, the chrome's grid button does the same from the view the restart came up on, and a hand-edited `"view":"banana"` opens as the list view and is renamed back by the settle. `XDG_STATE_HOME` points inside the fixture root for the whole case. Run as `./tests/ui.sh viewpoints`.
- Headless, all green on this tree: `tests/js.sh` (1828 checks, 0 failed), `tests/keymap-gen.sh`, `tests/budget.sh`, the qmllint gate (0 regressions; the two new findings beside the documented false positives are the two QML files this change grew), `cargo test` (441 passed), both cargo profiles warning-free. `ui/Pane.qml` goes to 407 and stays a listed cap exception (it was 403); `ui/ViewState.qml` goes to 265, a soft-budget warning.
- Verified live on the window: stored columns boots in columns; Ctrl+3 flips `viewMode` and rewrites `ui.json`; a restart opens grid; `{"view":"banana"}` opens list and the settle rewrites it.

## One testing note

`./target/release/flea --gui` alone resolves the UI as `FLEA_UI` → packaged `/usr/share/flea/ui` → dev tree (`src/paths.rs`), so with the pacman package installed a dev launch runs the **packaged** QML unless `FLEA_UI` is set. The README dev loop already launches with `FLEA_UI="$PWD/ui"`; worth keeping in mind when testing this branch by hand.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Listing view preferences now persist across application restarts.
  - Supported views include list, columns, and grid; invalid saved values fall back to list view.
  - Toolbar controls and keyboard shortcuts consistently save view selections.
  - Grid layouts support improved keyboard navigation, selection, filtering, and actions.
  - Added share-browser keyboard actions and dual-pane focus switching.
  - Restored tabs retain their selected view.

- **Tests**
  - Added coverage for view persistence, fallback behavior, tab restoration, and view-switching interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->